### PR TITLE
Calculate from transcript

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ noirc_printable_type = { git = "https://github.com/noir-lang/noir", rev = "v1.0.
 bn254_blackbox_solver = { git = "https://github.com/noir-lang/noir", rev = "v1.0.0-beta.3" }
 
 # WHIR
-whir = { git = "https://github.com/WizardOfMenlo/whir", features = ["tracing"] }
+whir = { git = "https://github.com/WizardOfMenlo/whir", features = ["tracing"], rev = "74936effc0fdac288f2ff4881a04bf41cdf1f78e" }
 spongefish = { git = "https://github.com/arkworks-rs/spongefish", features = [
     "arkworks-algebra",
 ] }

--- a/noir-r1cs/src/whir_r1cs.rs
+++ b/noir-r1cs/src/whir_r1cs.rs
@@ -275,7 +275,7 @@ pub fn run_sumcheck_prover(
         );
 
         let _ = merlin.add_scalars(&hhat_i_coeffs[..]);
-        let mut alpha_i_wrapped_in_vector = vec![FieldElement::zero()];
+        let mut alpha_i_wrapped_in_vector = [FieldElement::zero()];
         let _ = merlin.fill_challenge_scalars(&mut alpha_i_wrapped_in_vector);
         let alpha_i = alpha_i_wrapped_in_vector[0];
         alpha.push(alpha_i);
@@ -345,8 +345,8 @@ pub fn run_sumcheck_verifier(
     let mut alpha = vec![FieldElement::zero(); m_0];
 
     for i in 0..m_0 {
-        let mut hhat_i = vec![FieldElement::zero(); 4];
-        let mut alpha_i = vec![FieldElement::zero(); 1];
+        let mut hhat_i = [FieldElement::zero(); 4];
+        let mut alpha_i = [FieldElement::zero(); 1];
         let _ = arthur.fill_next_scalars(&mut hhat_i);
         let _ = arthur.fill_challenge_scalars(&mut alpha_i);
         alpha[i] = alpha_i[0];


### PR DESCRIPTION
This draft PR removes r, alpha, last_sumcheck_val, and statement from WhirR1CSProof. Now, verifier computes them on their own. whir_query_answer_sums remains in the WhirR1CSProof as the verifier cannot compute them from the transcript on their own.