### PR TITLE
Fixes file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,3 @@ Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-prover/params
-prover/proof

--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ First make sure you have the exact correct version of Noir installed [so the art
 noirup -C 03b58fa2
 ```
 
-Compile and execute the Noir circuit:
+Compile the Noir circuit:
 
 ```sh
 cd noir-examples/poseidon-rounds
 nargo compile
-nargo execute witness
 ```
 
 Generate the Noir Proof Scheme:
@@ -27,7 +26,7 @@ cargo run --release --bin noir-r1cs prepare ./target/basic.json -o ./noir-proof-
 Generate the Noir Proof using the input Toml:
 
 ```sh
-cargo run --release --bin noir-r1cs prove ./noir-proof-scheme.nps ./target/witness.gz -o ./noir-proof.np
+cargo run --release --bin noir-r1cs prove ./noir-proof-scheme.nps ./Prover.toml -o ./noir-proof.np
 ```
 
 Verify the Noir Proof:

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ First make sure you have the exact correct version of Noir installed [so the art
 noirup -C 03b58fa2
 ```
 
-Compile the Noir circuit:
+Compile and execute the Noir circuit:
 
 ```sh
 cd noir-examples/poseidon-rounds
 nargo compile
+nargo execute witness
 ```
 
 Generate the Noir Proof Scheme:
@@ -26,7 +27,7 @@ cargo run --release --bin noir-r1cs prepare ./target/basic.json -o ./noir-proof-
 Generate the Noir Proof using the input Toml:
 
 ```sh
-cargo run --release --bin noir-r1cs prove ./noir-proof-scheme.nps ./Prover.toml -o ./noir-proof.np
+cargo run --release --bin noir-r1cs prove ./noir-proof-scheme.nps ./target/witness.gz -o ./noir-proof.np
 ```
 
 Verify the Noir Proof:

--- a/noir-r1cs/src/cli/cmd/generate_gnark_inputs.rs
+++ b/noir-r1cs/src/cli/cmd/generate_gnark_inputs.rs
@@ -44,7 +44,7 @@ impl Command for Args {
             scheme.whir.m,
         );
 
-        let mut file = File::create("./prover/proof").unwrap();
+        let mut file = File::create("./proof_for_recursive_verifier").unwrap();
         let mut proof_bytes = vec![];
         proof
             .whir_r1cs_proof

--- a/noir-r1cs/src/cli/cmd/generate_gnark_inputs.rs
+++ b/noir-r1cs/src/cli/cmd/generate_gnark_inputs.rs
@@ -21,6 +21,22 @@ pub struct Args {
     /// path to the proof file
     #[argh(positional)]
     proof_path: PathBuf,
+
+    /// path to the proof file for gnark recursive verifier
+    #[argh(
+        option,
+        long = "proof",
+        default = "String::from(\"./proof_for_recursive_verifier\")"
+    )]
+    proof_for_recursive_verifier: String,
+
+    /// path to the parameters file for gnark recursive verifier
+    #[argh(
+        option,
+        long = "params",
+        default = "String::from(\"./params_for_recursive_verifier\")"
+    )]
+    params_for_recursive_verifier: String,
 }
 
 impl Command for Args {
@@ -42,9 +58,10 @@ impl Command for Args {
             proof.whir_r1cs_proof.whir_query_answer_sums,
             scheme.whir.m_0,
             scheme.whir.m,
+            &self.params_for_recursive_verifier,
         );
 
-        let mut file = File::create("./proof_for_recursive_verifier").unwrap();
+        let mut file = File::create(&self.proof_for_recursive_verifier).unwrap();
         let mut proof_bytes = vec![];
         proof
             .whir_r1cs_proof

--- a/noir-r1cs/src/cli/cmd/prove.rs
+++ b/noir-r1cs/src/cli/cmd/prove.rs
@@ -49,7 +49,7 @@ impl Command for Args {
 
         // Read the input toml
         let witness_file_path =
-            &PathBuf::from("../noir-examples/noir-r1cs-test-programs/acir_assert_zero/basic.gz");
+            &PathBuf::from(&self.witness_path);
         let mut witness_stack = deserialize_witness_stack(witness_file_path).unwrap();
         let witness_map: WitnessMap<NoirFieldElement> = witness_stack.pop().unwrap().witness;
 

--- a/noir-r1cs/src/cli/cmd/prove.rs
+++ b/noir-r1cs/src/cli/cmd/prove.rs
@@ -48,8 +48,7 @@ impl Command for Args {
         info!(constraints, witnesses, "Read Noir proof scheme");
 
         // Read the input toml
-        let witness_file_path =
-            &PathBuf::from(&self.witness_path);
+        let witness_file_path = &PathBuf::from(&self.witness_path);
         let mut witness_stack = deserialize_witness_stack(witness_file_path).unwrap();
         let witness_map: WitnessMap<NoirFieldElement> = witness_stack.pop().unwrap().witness;
 

--- a/noir-r1cs/src/gnark_config.rs
+++ b/noir-r1cs/src/gnark_config.rs
@@ -109,7 +109,7 @@ pub fn write_gnark_parameters_to_file(
 ) {
     let gnark_config = gnark_parameters(whir_params, transcript, io, sums, m_0, m);
     println!("round config {:?}", whir_params.round_parameters);
-    let mut file_params = File::create("./prover/params").unwrap();
+    let mut file_params = File::create("./params_for_recursive_verifier").unwrap();
     file_params
         .write_all(serde_json::to_string(&gnark_config).unwrap().as_bytes())
         .expect("Writing gnark parameters to a file failed");

--- a/noir-r1cs/src/gnark_config.rs
+++ b/noir-r1cs/src/gnark_config.rs
@@ -106,10 +106,11 @@ pub fn write_gnark_parameters_to_file(
     sums: [FieldElement; 3],
     m_0: usize,
     m: usize,
+    file_path: &str,
 ) {
     let gnark_config = gnark_parameters(whir_params, transcript, io, sums, m_0, m);
     println!("round config {:?}", whir_params.round_parameters);
-    let mut file_params = File::create("./params_for_recursive_verifier").unwrap();
+    let mut file_params = File::create(file_path).unwrap();
     file_params
         .write_all(serde_json::to_string(&gnark_config).unwrap().as_bytes())
         .expect("Writing gnark parameters to a file failed");

--- a/noir-r1cs/src/memory.rs
+++ b/noir-r1cs/src/memory.rs
@@ -4,21 +4,21 @@ pub struct MemoryBlock {
     /// The R1CS witnesses corresponding to the memory block values
     pub initial_value_witnesses: Vec<usize>,
     /// The memory operations, in the order that they occur
-    pub operations: Vec<MemoryOperation>,
+    pub operations:              Vec<MemoryOperation>,
 }
 
 impl MemoryBlock {
     pub fn new() -> Self {
         Self {
             initial_value_witnesses: vec![],
-            operations: vec![],
+            operations:              vec![],
         }
     }
 
     pub fn is_read_only(&self) -> bool {
         self.operations.iter().all(|op| match op {
-            MemoryOperation::Load(_, _) => true,
-            MemoryOperation::Store(_, _) => false,
+            MemoryOperation::Load(..) => true,
+            MemoryOperation::Store(..) => false,
         })
     }
 }


### PR DESCRIPTION
Summary of Changes:
- Replaced hardcoded noir-r1cs prover witness file path with a CLI variable (was likely a forgotten placeholder).
- Fixed broken input file paths for the recursive-verifier.
- Updated the README to reflect these changes.
- Added nargo execute command to the README .