### PR TITLE
Optimised Montgomery squaring

### DIFF
--- a/block-multiplier-codegen/src/main.rs
+++ b/block-multiplier-codegen/src/main.rs
@@ -1,8 +1,5 @@
 use {
-    block_multiplier_codegen::{
-        scalar::{setup_montgomery_single_step, setup_montgomery_squaring_single_step},
-        simd::{setup_single_step_simd, setup_single_step_squaring_simd},
-    },
+    block_multiplier_codegen::{scalar, simd},
     hla::builder::{Interleaving, build_includable},
 };
 
@@ -10,43 +7,40 @@ fn main() {
     build_includable(
         "./asm/montgomery_interleaved_3.s",
         Interleaving::par(
-            Interleaving::single(setup_montgomery_single_step),
-            Interleaving::single(setup_single_step_simd),
+            Interleaving::single(scalar::setup_single_step),
+            Interleaving::single(simd::setup_single_step),
         ),
     );
     build_includable(
         "./asm/montgomery_square_interleaved_3.s",
         Interleaving::par(
-            Interleaving::single(setup_montgomery_squaring_single_step),
-            Interleaving::single(setup_single_step_squaring_simd),
+            Interleaving::single(scalar::setup_square_single_step),
+            Interleaving::single(simd::setup_square_single_step),
         ),
     );
     build_includable(
         "./asm/montgomery_interleaved_4.s",
         Interleaving::par(
-            Interleaving::seq(vec![
-                setup_montgomery_single_step,
-                setup_montgomery_single_step,
-            ]),
-            Interleaving::single(setup_single_step_simd),
+            Interleaving::seq(vec![scalar::setup_single_step, scalar::setup_single_step]),
+            Interleaving::single(simd::setup_single_step),
         ),
     );
     build_includable(
         "./asm/montgomery_square_interleaved_4.s",
         Interleaving::par(
             Interleaving::seq(vec![
-                setup_montgomery_squaring_single_step,
-                setup_montgomery_squaring_single_step,
+                scalar::setup_square_single_step,
+                scalar::setup_square_single_step,
             ]),
-            Interleaving::single(setup_single_step_squaring_simd),
+            Interleaving::single(simd::setup_square_single_step),
         ),
     );
     build_includable(
         "./asm/montgomery.s",
-        Interleaving::single(setup_montgomery_single_step),
+        Interleaving::single(scalar::setup_single_step),
     );
     build_includable(
         "./asm/montgomery_square.s",
-        Interleaving::single(setup_montgomery_squaring_single_step),
+        Interleaving::single(scalar::setup_square_single_step),
     );
 }

--- a/block-multiplier-codegen/src/main.rs
+++ b/block-multiplier-codegen/src/main.rs
@@ -1,5 +1,7 @@
 use {
-    block_multiplier_codegen::{scalar::setup_montgomery, simd::setup_single_step_simd},
+    block_multiplier_codegen::{
+        scalar::setup_montgomery_single_step, simd::setup_single_step_simd,
+    },
     hla::builder::{Interleaving, build_inline},
 };
 
@@ -7,15 +9,22 @@ fn main() {
     build_inline(
         "./asm/montgomery_interleaved_3.s",
         Interleaving::par(
-            Interleaving::single(setup_montgomery),
+            Interleaving::single(setup_montgomery_single_step),
             Interleaving::single(setup_single_step_simd),
         ),
     );
     build_inline(
         "./asm/montgomery_interleaved_4.s",
         Interleaving::par(
-            Interleaving::seq(vec![setup_montgomery, setup_montgomery]),
+            Interleaving::seq(vec![
+                setup_montgomery_single_step,
+                setup_montgomery_single_step,
+            ]),
             Interleaving::single(setup_single_step_simd),
         ),
+    );
+    build_inline(
+        "./asm/montgomery.s",
+        Interleaving::single(setup_montgomery_single_step),
     );
 }

--- a/block-multiplier-codegen/src/main.rs
+++ b/block-multiplier-codegen/src/main.rs
@@ -1,20 +1,27 @@
 use {
     block_multiplier_codegen::{
         scalar::{setup_montgomery_single_step, setup_montgomery_squaring_single_step},
-        simd::setup_single_step_simd,
+        simd::{setup_single_step_simd, setup_single_step_squaring_simd},
     },
-    hla::builder::{Interleaving, build_inline},
+    hla::builder::{Interleaving, build_includable},
 };
 
 fn main() {
-    build_inline(
+    build_includable(
         "./asm/montgomery_interleaved_3.s",
         Interleaving::par(
             Interleaving::single(setup_montgomery_single_step),
             Interleaving::single(setup_single_step_simd),
         ),
     );
-    build_inline(
+    build_includable(
+        "./asm/montgomery_square_interleaved_3.s",
+        Interleaving::par(
+            Interleaving::single(setup_montgomery_squaring_single_step),
+            Interleaving::single(setup_single_step_squaring_simd),
+        ),
+    );
+    build_includable(
         "./asm/montgomery_interleaved_4.s",
         Interleaving::par(
             Interleaving::seq(vec![
@@ -24,11 +31,21 @@ fn main() {
             Interleaving::single(setup_single_step_simd),
         ),
     );
-    build_inline(
+    build_includable(
+        "./asm/montgomery_square_interleaved_4.s",
+        Interleaving::par(
+            Interleaving::seq(vec![
+                setup_montgomery_squaring_single_step,
+                setup_montgomery_squaring_single_step,
+            ]),
+            Interleaving::single(setup_single_step_squaring_simd),
+        ),
+    );
+    build_includable(
         "./asm/montgomery.s",
         Interleaving::single(setup_montgomery_single_step),
     );
-    build_inline(
+    build_includable(
         "./asm/montgomery_square.s",
         Interleaving::single(setup_montgomery_squaring_single_step),
     );

--- a/block-multiplier-codegen/src/main.rs
+++ b/block-multiplier-codegen/src/main.rs
@@ -1,6 +1,7 @@
 use {
     block_multiplier_codegen::{
-        scalar::setup_montgomery_single_step, simd::setup_single_step_simd,
+        scalar::{setup_montgomery_single_step, setup_montgomery_squaring_single_step},
+        simd::setup_single_step_simd,
     },
     hla::builder::{Interleaving, build_inline},
 };
@@ -26,5 +27,9 @@ fn main() {
     build_inline(
         "./asm/montgomery.s",
         Interleaving::single(setup_montgomery_single_step),
+    );
+    build_inline(
+        "./asm/montgomery_square.s",
+        Interleaving::single(setup_montgomery_squaring_single_step),
     );
 }

--- a/block-multiplier-codegen/src/scalar.rs
+++ b/block-multiplier-codegen/src/scalar.rs
@@ -344,7 +344,7 @@ where
     for i in 1..rows {
         let tmp = &mut mult[(i, 0)];
         let tmp = tmp.as_(alloc, asm);
-        [t[i], carry] = carry_add(alloc, asm, &tmp, &carry);
+        [t[i], carry] = carry_add(alloc, asm, tmp, &carry);
     }
     t[rows] = carry;
 
@@ -353,11 +353,11 @@ where
         let mut carry;
         let tmp = &mut mult[(0, j)];
         let tmp = tmp.as_(alloc, asm);
-        [t[j], carry] = carry_add(alloc, asm, &tmp, &t[j]);
+        [t[j], carry] = carry_add(alloc, asm, tmp, &t[j]);
         for i in 1..rows {
             let tmp = &mut mult[(i, j)];
             let tmp = tmp.as_(alloc, asm);
-            let tmp = carry_add(alloc, asm, &tmp, &carry);
+            let tmp = carry_add(alloc, asm, tmp, &carry);
             [t[i + j], carry] = carry_add(alloc, asm, &tmp, &t[i + j]);
         }
         t[j + rows] = carry;

--- a/block-multiplier-codegen/src/scalar.rs
+++ b/block-multiplier-codegen/src/scalar.rs
@@ -311,7 +311,7 @@ pub fn widening_mul_u256(
 }
 
 pub fn lazy_widening_mul<'a>(a: &'a Reg<u64>, b: &'a Reg<u64>) -> Lazy<'a, [Reg<u64>; 2]> {
-    Lazy::Thunk(Box::new(|alloc, asm| widening_mul(alloc, asm, a, b)))
+    Lazy::thunk(Box::new(|alloc, asm| widening_mul(alloc, asm, a, b)))
 }
 
 fn lazy_outer_product<'a>(
@@ -337,7 +337,7 @@ where
     // replace such that we can use the registers of mult[0][0] in the output.
     let tmp = mem::replace(
         &mut mult[(0, 0)],
-        Lazy::Forced([alloc.fresh(), alloc.fresh()]),
+        Lazy::forced([alloc.fresh(), alloc.fresh()]),
     );
 
     [t[0], carry] = tmp.into_(alloc, asm);

--- a/block-multiplier-codegen/src/simd.rs
+++ b/block-multiplier-codegen/src/simd.rs
@@ -296,7 +296,7 @@ fn montgomery(
     a: [Reg<Simd<u64, 2>>; 4],
     b: [Reg<Simd<u64, 2>>; 4],
 ) -> [Reg<Simd<u64, 2>>; 4] {
-    montgomeryF(alloc, asm, |alloc, asm, mask52, c1, c2| {
+    montgomery_f(alloc, asm, |alloc, asm, mask52, c1, c2| {
         montgomery_mul(alloc, asm, mask52, c1, c2, a, b)
     })
 }
@@ -306,7 +306,7 @@ fn montgomery_squaring(
     asm: &mut Assembler,
     a: [Reg<Simd<u64, 2>>; 4],
 ) -> [Reg<Simd<u64, 2>>; 4] {
-    montgomeryF(alloc, asm, |alloc, asm, mask52, c1, c2| {
+    montgomery_f(alloc, asm, |alloc, asm, mask52, c1, c2| {
         montgomery_square(alloc, asm, mask52, c1, c2, a)
     })
 }
@@ -347,7 +347,7 @@ fn montgomery_square(
 
 /// Performs a full Montgomery multiplication of two pairs of two u256 numbers
 /// `a` and `b` using SIMD instructions.
-fn montgomeryF(
+fn montgomery_f(
     alloc: &mut FreshAllocator,
     asm: &mut Assembler,
     f: impl FnOnce(

--- a/block-multiplier-codegen/src/simd.rs
+++ b/block-multiplier-codegen/src/simd.rs
@@ -326,7 +326,7 @@ fn montgomery_mul(
     let a = u256_to_u260_shl2(alloc, asm, mask52, a);
     let b = u256_to_u260_shl2(alloc, asm, mask52, b);
     let t = make_initials(alloc, asm);
-    widening_mul_u256(alloc, asm, &c1, &c2, t, a, b)
+    widening_mul_u256(alloc, asm, c1, c2, t, a, b)
 }
 
 fn montgomery_square(
@@ -342,7 +342,7 @@ fn montgomery_square(
     // shifting both inputs by 2.
     let a = u256_to_u260_shl2(alloc, asm, mask52, a);
     let t = make_initials(alloc, asm);
-    square_mul_u256(alloc, asm, &c1, &c2, t, a)
+    square_mul_u256(alloc, asm, c1, c2, t, a)
 }
 
 /// Performs a full Montgomery multiplication of two pairs of two u256 numbers

--- a/block-multiplier-codegen/src/simd.rs
+++ b/block-multiplier-codegen/src/simd.rs
@@ -74,7 +74,7 @@ pub fn setup_widening_mul_u256_simd(
 /// step using SIMD instructions.
 ///
 /// Returns the input and output variables for the generated assembly function.
-pub fn setup_single_step_simd(
+pub fn setup_single_step(
     alloc: &mut FreshAllocator,
     asm: &mut Assembler,
 ) -> (Vec<FreshVariable>, FreshVariable) {
@@ -83,19 +83,19 @@ pub fn setup_single_step_simd(
 
     let var_a = FreshVariable::new("av", &a);
     let var_b = FreshVariable::new("bv", &b);
-    let res = montgomery(alloc, asm, a, b);
+    let res = single_step(alloc, asm, a, b);
 
     (vec![var_a, var_b], FreshVariable::new("outv", &res))
 }
 
-pub fn setup_single_step_squaring_simd(
+pub fn setup_square_single_step(
     alloc: &mut FreshAllocator,
     asm: &mut Assembler,
 ) -> (Vec<FreshVariable>, FreshVariable) {
     let a = alloc.fresh_array();
 
     let var_a = FreshVariable::new("av", &a);
-    let res = montgomery_squaring(alloc, asm, a);
+    let res = square_single_step(alloc, asm, a);
 
     (vec![var_a], FreshVariable::new("outv", &res))
 }
@@ -260,12 +260,11 @@ fn square_mul_u256(
 ///
 /// Requires the callee to remove the bias that has been used to shift the
 /// multiplication operation into the mantissa
-pub fn madd_u256_limb(
+fn madd_u256_limb(
     alloc: &mut FreshAllocator,
     asm: &mut Assembler,
     mut t: [Reg<Simd<u64, 2>>; 6],
-    c1: &Reg<Simd<u64, 2>>,
-    c2: &Reg<Simd<u64, 2>>,
+    constants: &RegisterConstants,
     s: Reg<Simd<u64, 2>>,
     v: [u64; 5],
 ) -> [Reg<Simd<u64, 2>>; 6] {
@@ -278,10 +277,10 @@ pub fn madd_u256_limb(
         // No measurable difference in loading the vector v completely outside or per
         // element inside the load
         let vs = load_floating_simd(alloc, asm, v[i] as f64);
-        let lc1 = mov16b(alloc, asm, c1);
+        let lc1 = mov16b(alloc, asm, &constants.c1);
 
         let hi = fmla2d(alloc, asm, lc1.into_(), &s, &vs);
-        let tmp = fsub2d(alloc, asm, c2.as_(), &hi);
+        let tmp = fsub2d(alloc, asm, constants.c2.as_(), &hi);
         let lo = fmla2d(alloc, asm, tmp, &s, &vs);
 
         t[i + 1] = add2d(alloc, asm, &t[i + 1], hi.as_());
@@ -290,73 +289,55 @@ pub fn madd_u256_limb(
     t
 }
 
-fn montgomery(
+fn single_step(
     alloc: &mut FreshAllocator,
     asm: &mut Assembler,
     a: [Reg<Simd<u64, 2>>; 4],
     b: [Reg<Simd<u64, 2>>; 4],
 ) -> [Reg<Simd<u64, 2>>; 4] {
-    montgomery_f(alloc, asm, |alloc, asm, mask52, c1, c2| {
-        montgomery_mul(alloc, asm, mask52, c1, c2, a, b)
+    single_step_base(alloc, asm, |alloc, asm, constants| {
+        {
+            // The be interoperable with the scalar montgomery multiplication we have to
+            // compensate for SIMD's mod 260 instead of 256. This is achieved by
+            // shifting both inputs by 2.
+            let a = u256_to_u260_shl2(alloc, asm, &constants.mask52, a);
+            let b = u256_to_u260_shl2(alloc, asm, &constants.mask52, b);
+            let t = make_initials(alloc, asm);
+            widening_mul_u256(alloc, asm, &constants.c1, &constants.c2, t, a, b)
+        }
     })
 }
 
-fn montgomery_squaring(
+fn square_single_step(
     alloc: &mut FreshAllocator,
     asm: &mut Assembler,
     a: [Reg<Simd<u64, 2>>; 4],
 ) -> [Reg<Simd<u64, 2>>; 4] {
-    montgomery_f(alloc, asm, |alloc, asm, mask52, c1, c2| {
-        montgomery_square(alloc, asm, mask52, c1, c2, a)
+    single_step_base(alloc, asm, |alloc, asm, constants| {
+        {
+            // The be interoperable with the scalar montgomery multiplication we have to
+            // compensate for SIMD's mod 260 instead of 256. This is achieved by
+            // shifting both inputs by 2.
+            let a = u256_to_u260_shl2(alloc, asm, &constants.mask52, a);
+            let t = make_initials(alloc, asm);
+            square_mul_u256(alloc, asm, &constants.c1, &constants.c2, t, a)
+        }
     })
 }
 
-fn montgomery_mul(
-    alloc: &mut FreshAllocator,
-    asm: &mut Assembler,
-    mask52: &Reg<Simd<u64, 2>>,
-    c1: &Reg<Simd<u64, 2>>,
-    c2: &Reg<Simd<u64, 2>>,
-    a: [Reg<Simd<u64, 2>>; 4],
-    b: [Reg<Simd<u64, 2>>; 4],
-) -> [Reg<Simd<u64, 2>>; 10] {
-    // The be interoperable with the scalar montgomery multiplication we have to
-    // compensate for SIMD's mod 260 instead of 256. This is achieved by
-    // shifting both inputs by 2.
-    let a = u256_to_u260_shl2(alloc, asm, mask52, a);
-    let b = u256_to_u260_shl2(alloc, asm, mask52, b);
-    let t = make_initials(alloc, asm);
-    widening_mul_u256(alloc, asm, c1, c2, t, a, b)
-}
-
-fn montgomery_square(
-    alloc: &mut FreshAllocator,
-    asm: &mut Assembler,
-    mask52: &Reg<Simd<u64, 2>>,
-    c1: &Reg<Simd<u64, 2>>,
-    c2: &Reg<Simd<u64, 2>>,
-    a: [Reg<Simd<u64, 2>>; 4],
-) -> [Reg<Simd<u64, 2>>; 10] {
-    // The be interoperable with the scalar montgomery multiplication we have to
-    // compensate for SIMD's mod 260 instead of 256. This is achieved by
-    // shifting both inputs by 2.
-    let a = u256_to_u260_shl2(alloc, asm, mask52, a);
-    let t = make_initials(alloc, asm);
-    square_mul_u256(alloc, asm, c1, c2, t, a)
+struct RegisterConstants {
+    mask:   Reg<u64>,
+    mask52: Reg<Simd<u64, 2>>,
+    c1:     Reg<Simd<u64, 2>>,
+    c2:     Reg<Simd<u64, 2>>,
 }
 
 /// Performs a full Montgomery multiplication of two pairs of two u256 numbers
 /// `a` and `b` using SIMD instructions.
-fn montgomery_f(
+fn single_step_base(
     alloc: &mut FreshAllocator,
     asm: &mut Assembler,
-    f: impl FnOnce(
-        &mut FreshAllocator,
-        &mut Assembler,
-        &Reg<Simd<u64, 2>>,
-        &Reg<Simd<u64, 2>>,
-        &Reg<Simd<u64, 2>>,
-    ) -> [Reg<Simd<u64, 2>>; 10],
+    f: impl FnOnce(&mut FreshAllocator, &mut Assembler, &RegisterConstants) -> [Reg<Simd<u64, 2>>; 10],
 ) -> [Reg<Simd<u64, 2>>; 4] {
     let mask = mov(alloc, asm, MASK52);
     let mask52 = dup2d(alloc, asm, &mask);
@@ -371,7 +352,14 @@ fn montgomery_f(
     let c2 = load_const(alloc, asm, C2.to_bits());
     let c2 = dup2d(alloc, asm, &c2);
 
-    let [t0, t1, t2, t3, t4, t5, t6, t7, t8, t9] = f(alloc, asm, &mask52, &c1, &c2);
+    let constants = RegisterConstants {
+        mask,
+        mask52,
+        c1,
+        c2,
+    };
+
+    let [t0, t1, t2, t3, t4, t5, t6, t7, t8, t9] = f(alloc, asm, &constants);
     let t1 = usra2d(alloc, asm, t1, &t0, 52);
     let t2 = usra2d(alloc, asm, t2, &t1, 52);
     let t3 = usra2d(alloc, asm, t3, &t2, 52);
@@ -379,17 +367,17 @@ fn montgomery_f(
 
     let t4_10 = [t4, t5, t6, t7, t8, t9];
 
-    let t0 = and16(alloc, asm, &t0, &mask52);
-    let t1 = and16(alloc, asm, &t1, &mask52);
-    let t2 = and16(alloc, asm, &t2, &mask52);
-    let t3 = and16(alloc, asm, &t3, &mask52);
+    let t0 = and16(alloc, asm, &t0, &constants.mask52);
+    let t1 = and16(alloc, asm, &t1, &constants.mask52);
+    let t2 = and16(alloc, asm, &t2, &constants.mask52);
+    let t3 = and16(alloc, asm, &t3, &constants.mask52);
 
     // loading rho interleaved with multiplication to prevent to prevent allocation
     // a lot of X-registers
-    let r0 = madd_u256_limb(alloc, asm, t4_10, &c1, &c2, t0, RHO_4);
-    let r1 = madd_u256_limb(alloc, asm, r0, &c1, &c2, t1, RHO_3);
-    let r2 = madd_u256_limb(alloc, asm, r1, &c1, &c2, t2, RHO_2);
-    let s = madd_u256_limb(alloc, asm, r2, &c1, &c2, t3, RHO_1);
+    let r0 = madd_u256_limb(alloc, asm, t4_10, &constants, t0, RHO_4);
+    let r1 = madd_u256_limb(alloc, asm, r0, &constants, t1, RHO_3);
+    let r2 = madd_u256_limb(alloc, asm, r1, &constants, t2, RHO_2);
+    let s = madd_u256_limb(alloc, asm, r2, &constants, t3, RHO_1);
 
     // Could be replaced with fmul, but the rust compiler generates something close
     // to this
@@ -399,11 +387,11 @@ fn montgomery_f(
     let m0 = mul(alloc, asm, &s00, &u52_np0);
     let m1 = mul(alloc, asm, &s01, &u52_np0);
 
-    let m0 = and(alloc, asm, &m0, &mask);
-    let m1 = and(alloc, asm, &m1, &mask);
+    let m0 = and(alloc, asm, &m0, &constants.mask);
+    let m1 = and(alloc, asm, &m1, &constants.mask);
     let m = load_tuple(alloc, asm, m0, m1);
 
-    let s = madd_u256_limb(alloc, asm, s, &c1, &c2, m, U52_P);
+    let s = madd_u256_limb(alloc, asm, s, &constants, m, U52_P);
 
     let rs = reduce(alloc, asm, s);
 

--- a/block-multiplier/build.rs
+++ b/block-multiplier/build.rs
@@ -1,5 +1,7 @@
 use {
-    block_multiplier_codegen::{scalar::setup_montgomery, simd::setup_single_step_simd},
+    block_multiplier_codegen::{
+        scalar::setup_montgomery_single_step, simd::setup_single_step_simd,
+    },
     hla::builder::{Interleaving, build_includable},
     std::path::Path,
 };
@@ -10,7 +12,7 @@ fn main() {
         build_includable(
             path,
             Interleaving::par(
-                Interleaving::single(setup_montgomery),
+                Interleaving::single(setup_montgomery_single_step),
                 Interleaving::single(setup_single_step_simd),
             ),
         );
@@ -20,7 +22,10 @@ fn main() {
         build_includable(
             path,
             Interleaving::par(
-                Interleaving::seq(vec![setup_montgomery, setup_montgomery]),
+                Interleaving::seq(vec![
+                    setup_montgomery_single_step,
+                    setup_montgomery_single_step,
+                ]),
                 Interleaving::single(setup_single_step_simd),
             ),
         );

--- a/block-multiplier/build.rs
+++ b/block-multiplier/build.rs
@@ -1,6 +1,7 @@
 use {
     block_multiplier_codegen::{
-        scalar::setup_montgomery_single_step, simd::setup_single_step_simd,
+        scalar::{setup_montgomery_single_step, setup_montgomery_squaring_single_step},
+        simd::{setup_single_step_simd, setup_single_step_squaring_simd},
     },
     hla::builder::{Interleaving, build_includable},
     std::path::Path,
@@ -27,6 +28,29 @@ fn main() {
                     setup_montgomery_single_step,
                 ]),
                 Interleaving::single(setup_single_step_simd),
+            ),
+        );
+    }
+    let path = Path::new("./src/aarch64/montgomery_square_interleaved_3.s");
+    if !path.exists() {
+        build_includable(
+            path,
+            Interleaving::par(
+                Interleaving::single(setup_montgomery_squaring_single_step),
+                Interleaving::single(setup_single_step_squaring_simd),
+            ),
+        );
+    }
+    let path = Path::new("./src/aarch64/montgomery_square_interleaved_4.s");
+    if !path.exists() {
+        build_includable(
+            path,
+            Interleaving::par(
+                Interleaving::seq(vec![
+                    setup_montgomery_squaring_single_step,
+                    setup_montgomery_squaring_single_step,
+                ]),
+                Interleaving::single(setup_single_step_squaring_simd),
             ),
         );
     }

--- a/block-multiplier/build.rs
+++ b/block-multiplier/build.rs
@@ -1,8 +1,5 @@
 use {
-    block_multiplier_codegen::{
-        scalar::{setup_montgomery_single_step, setup_montgomery_squaring_single_step},
-        simd::{setup_single_step_simd, setup_single_step_squaring_simd},
-    },
+    block_multiplier_codegen::{scalar, simd},
     hla::builder::{Interleaving, build_includable},
     std::path::Path,
 };
@@ -13,8 +10,8 @@ fn main() {
         build_includable(
             path,
             Interleaving::par(
-                Interleaving::single(setup_montgomery_single_step),
-                Interleaving::single(setup_single_step_simd),
+                Interleaving::single(scalar::setup_single_step),
+                Interleaving::single(simd::setup_single_step),
             ),
         );
     }
@@ -23,11 +20,8 @@ fn main() {
         build_includable(
             path,
             Interleaving::par(
-                Interleaving::seq(vec![
-                    setup_montgomery_single_step,
-                    setup_montgomery_single_step,
-                ]),
-                Interleaving::single(setup_single_step_simd),
+                Interleaving::seq(vec![scalar::setup_single_step, scalar::setup_single_step]),
+                Interleaving::single(simd::setup_single_step),
             ),
         );
     }
@@ -36,8 +30,8 @@ fn main() {
         build_includable(
             path,
             Interleaving::par(
-                Interleaving::single(setup_montgomery_squaring_single_step),
-                Interleaving::single(setup_single_step_squaring_simd),
+                Interleaving::single(scalar::setup_square_single_step),
+                Interleaving::single(simd::setup_square_single_step),
             ),
         );
     }
@@ -47,10 +41,10 @@ fn main() {
             path,
             Interleaving::par(
                 Interleaving::seq(vec![
-                    setup_montgomery_squaring_single_step,
-                    setup_montgomery_squaring_single_step,
+                    scalar::setup_square_single_step,
+                    scalar::setup_square_single_step,
                 ]),
-                Interleaving::single(setup_single_step_squaring_simd),
+                Interleaving::single(simd::setup_square_single_step),
             ),
         );
     }

--- a/block-multiplier/src/aarch64/mod.rs
+++ b/block-multiplier/src/aarch64/mod.rs
@@ -7,6 +7,7 @@ use {
 ///
 /// Raspberry Pi 5:  2.2 times the throughput compared to a single multiplier.
 /// Apple Silicon (M3): same throughput as a single multiplier
+#[inline]
 pub fn montgomery_interleaved_3(
     _rtz: &RoundingGuard<Zero>,
     a: [u64; 4],
@@ -25,6 +26,28 @@ pub fn montgomery_interleaved_3(
         lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3") out[3],
         lateout("v0") outv[0], lateout("v1") outv[1], lateout("v2") outv[2], lateout("v3") outv[3],
         lateout("x4") _, lateout("x5") _, lateout("x6") _, lateout("x7") _, lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _, lateout("v4") _, lateout("v5") _, lateout("v6") _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _, lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _, lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _, lateout("v19") _, lateout("v20") _, lateout("v21") _, lateout("v22") _, lateout("v23") _, lateout("v24") _,
+        lateout("lr") _,
+        options(nomem, nostack)
+        )
+    };
+    (out, outv)
+}
+
+#[inline]
+pub fn montgomery_square_interleaved_3(
+    _rtz: &RoundingGuard<Zero>,
+    a: [u64; 4],
+    av: [Simd<u64, 2>; 4],
+) -> ([u64; 4], [Simd<u64, 2>; 4]) {
+    let mut out = [0; 4];
+    let mut outv = [Simd::splat(0); 4];
+    unsafe {
+        asm!(include_str!("montgomery_square_interleaved_3.s"),
+        in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+        in("v0") av[0], in("v1") av[1], in("v2") av[2], in("v3") av[3],
+        lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3") out[3],
+        lateout("v0") outv[0], lateout("v1") outv[1], lateout("v2") outv[2], lateout("v3") outv[3],
+        lateout("x4") _, lateout("x5") _, lateout("x6") _, lateout("x7") _, lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _, lateout("x17") _, lateout("v4") _, lateout("v5") _, lateout("v6") _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _, lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _, lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _, lateout("v19") _,
         lateout("lr") _,
         options(nomem, nostack)
         )
@@ -62,6 +85,40 @@ pub fn montgomery_interleaved_4(
             lateout("v0") outv[0], lateout("v1") outv[1], lateout("v2") outv[2], lateout("v3") outv[3],
             lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _, lateout("x17") _, lateout("x20") _, lateout("x21") _, lateout("x22") _, lateout("x23") _, lateout("x24") _, lateout("x25") _, lateout("x26") _, lateout("v4") _, lateout("v5") _, lateout("v6") _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _, lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _, lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _, lateout("v19") _, lateout("v20") _, lateout("v21") _, lateout("v22") _, lateout("v23") _, lateout("v24") _,
             lateout("lr") _,
+            options(nomem, nostack)
+        )
+    };
+    (out, out1, outv)
+}
+
+#[inline]
+pub fn montgomery_square_interleaved_4(
+    _rtz: &RoundingGuard<Zero>,
+    a: [u64; 4],
+    a1: [u64; 4],
+    av: [Simd<u64, 2>; 4],
+) -> ([u64; 4], [u64; 4], [Simd<u64, 2>; 4]) {
+    let mut out = [0; 4];
+    let mut out1 = [0; 4];
+    let mut outv = [Simd::splat(0); 4];
+    unsafe {
+        asm!(
+            include_str!("montgomery_square_interleaved_4.s"),
+            in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+            in("x4") a1[0], in("x5") a1[1], in("x6") a1[2], in("x7") a1[3],
+            in("v0") av[0], in("v1") av[1], in("v2") av[2], in("v3") av[3],
+            lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3")
+            out[3], lateout("x4") out1[0], lateout("x5") out1[1], lateout("x6")
+            out1[2], lateout("x7") out1[3], lateout("v0") outv[0], lateout("v1")
+            outv[1], lateout("v2") outv[2], lateout("v3") outv[3], lateout("x8") _,
+            lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _,
+            lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _,
+            lateout("x17") _, lateout("x20") _, lateout("x21") _, lateout("x22") _,
+            lateout("x23") _, lateout("x24") _, lateout("v4") _, lateout("v5") _, lateout("v6")
+            _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _,
+            lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _,
+            lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _,
+            lateout("v19") _, lateout("lr") _,
             options(nomem, nostack)
         )
     };

--- a/block-multiplier/src/aarch64/mod.rs
+++ b/block-multiplier/src/aarch64/mod.rs
@@ -137,14 +137,7 @@ mod tests {
         std::array,
     };
 
-    /// Property test that verifies `montgomery_interleaved_3` and
-    /// `montgomery_square_interleaved_3` produce identical results when
-    /// multiplying a value by itself.
-    ///
-    /// This test ensures that the optimized squaring function
-    /// `montgomery_square_interleaved_3` is mathematically equivalent to
-    /// using the general multiplication function `montgomery_interleaved_3`
-    /// with identical inputs (i.e., a * a == square(a)).
+    /// test that compares square interleaved with ark_ff
     #[test]
     fn test_montgomery_square() {
         proptest!(|(

--- a/block-multiplier/src/aarch64/montgomery_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_interleaved_3.s
@@ -10,84 +10,84 @@
   mov x8, #4503599627370495
   dup.2d v8, x8
   mul x9, x0, x4
-  shl.2d v9, v1, #14
-  shl.2d v10, v2, #26
-  shl.2d v11, v3, #38
-  umulh x10, x0, x4
-  ushr.2d v3, v3, #14
-  shl.2d v12, v0, #2
-  usra.2d v9, v0, #50
-  mul x11, x1, x4
-  usra.2d v10, v1, #38
-  usra.2d v11, v2, #26
+  mov x10, #5075556780046548992
+  dup.2d v9, x10
+  mov x10, #1
+  umulh x11, x0, x4
+  movk x10, #18032, lsl 48
+  dup.2d v10, x10
+  shl.2d v11, v1, #14
+  mul x10, x1, x4
+  shl.2d v12, v2, #26
+  shl.2d v13, v3, #38
   umulh x12, x1, x4
-  and.16b v0, v12, v8
-  and.16b v1, v9, v8
-  and.16b v2, v10, v8
-  adds x10, x11, x10
+  ushr.2d v3, v3, #14
+  shl.2d v14, v0, #2
+  usra.2d v11, v0, #50
+  adds x10, x10, x11
   cinc x11, x12, hs
-  and.16b v9, v11, v8
-  shl.2d v10, v5, #14
-  shl.2d v11, v6, #26
+  usra.2d v12, v1, #38
+  usra.2d v13, v2, #26
+  and.16b v0, v14, v8
   mul x12, x2, x4
-  shl.2d v12, v7, #38
-  ushr.2d v7, v7, #14
+  and.16b v1, v11, v8
+  and.16b v2, v12, v8
   umulh x13, x2, x4
-  shl.2d v13, v4, #2
-  usra.2d v10, v4, #50
-  usra.2d v11, v5, #38
+  and.16b v11, v13, v8
+  shl.2d v12, v5, #14
+  shl.2d v13, v6, #26
   adds x11, x12, x11
   cinc x12, x13, hs
-  usra.2d v12, v6, #26
-  and.16b v4, v13, v8
-  and.16b v5, v10, v8
+  shl.2d v14, v7, #38
+  ushr.2d v7, v7, #14
+  shl.2d v15, v4, #2
   mul x13, x3, x4
-  and.16b v6, v11, v8
-  and.16b v10, v12, v8
-  mov x14, #13605374474286268416
+  usra.2d v12, v4, #50
+  usra.2d v13, v5, #38
+  usra.2d v14, v6, #26
   umulh x4, x3, x4
-  dup.2d v11, x14
-  mov x14, #6440147467139809280
+  and.16b v4, v15, v8
+  and.16b v5, v12, v8
   adds x12, x13, x12
   cinc x4, x4, hs
-  dup.2d v12, x14
-  mov x13, #3688448094816436224
+  and.16b v6, v13, v8
+  and.16b v12, v14, v8
+  mov x13, #13605374474286268416
+  mul x14, x0, x5
   dup.2d v13, x13
-  mul x13, x0, x5
+  mov x13, #6440147467139809280
+  dup.2d v14, x13
+  umulh x13, x0, x5
+  mov x15, #3688448094816436224
+  dup.2d v15, x15
+  adds x10, x14, x10
+  cinc x13, x13, hs
   mov x14, #9209861237972664320
-  dup.2d v14, x14
-  mov x14, #12218265789056155648
-  umulh x15, x0, x5
-  dup.2d v15, x14
-  mov x14, #17739678932212383744
-  adds x10, x13, x10
-  cinc x13, x15, hs
   dup.2d v16, x14
-  mov x14, #2301339409586323456
+  mov x14, #12218265789056155648
+  mul x15, x1, x5
   dup.2d v17, x14
-  mul x14, x1, x5
+  mov x14, #17739678932212383744
+  dup.2d v18, x14
+  umulh x14, x1, x5
+  mov x16, #2301339409586323456
+  dup.2d v19, x16
+  adds x13, x15, x13
+  cinc x14, x14, hs
   mov x15, #7822752552742551552
-  dup.2d v18, x15
-  mov x15, #5071053180419178496
-  umulh x16, x1, x5
-  dup.2d v19, x15
-  mov x15, #16352570246982270976
-  adds x13, x14, x13
-  cinc x14, x16, hs
   dup.2d v20, x15
-  mov x15, #5075556780046548992
-  dup.2d v21, x15
+  mov x15, #5071053180419178496
   adds x11, x13, x11
   cinc x13, x14, hs
-  mov x14, #1
-  movk x14, #18032, lsl 48
+  dup.2d v21, x15
+  mov x14, #16352570246982270976
   dup.2d v22, x14
   mul x14, x2, x5
   ucvtf.2d v0, v0
   ucvtf.2d v1, v1
   ucvtf.2d v2, v2
   umulh x15, x2, x5
-  ucvtf.2d v9, v9
+  ucvtf.2d v11, v11
   ucvtf.2d v3, v3
   adds x13, x14, x13
   cinc x14, x15, hs
@@ -96,244 +96,244 @@
   ucvtf.2d v6, v6
   adds x12, x13, x12
   cinc x13, x14, hs
-  ucvtf.2d v10, v10
+  ucvtf.2d v12, v12
   ucvtf.2d v7, v7
-  mov.16b v23, v21
+  mov.16b v23, v9
   mul x14, x3, x5
   fmla.2d v23, v0, v4
-  fsub.2d v24, v22, v23
+  fsub.2d v24, v10, v23
   umulh x5, x3, x5
   fmla.2d v24, v0, v4
-  add.2d v13, v13, v23
-  add.2d v11, v11, v24
+  add.2d v15, v15, v23
+  add.2d v13, v13, v24
   adds x13, x14, x13
   cinc x5, x5, hs
-  mov.16b v23, v21
+  mov.16b v23, v9
   fmla.2d v23, v0, v5
-  fsub.2d v24, v22, v23
+  fsub.2d v24, v10, v23
   adds x4, x13, x4
   cinc x5, x5, hs
   fmla.2d v24, v0, v5
-  add.2d v15, v15, v23
+  add.2d v17, v17, v23
   mul x13, x0, x6
-  add.2d v13, v13, v24
-  mov.16b v23, v21
+  add.2d v15, v15, v24
+  mov.16b v23, v9
   fmla.2d v23, v0, v6
   umulh x14, x0, x6
-  fsub.2d v24, v22, v23
+  fsub.2d v24, v10, v23
   fmla.2d v24, v0, v6
-  add.2d v17, v17, v23
+  add.2d v19, v19, v23
   adds x11, x13, x11
   cinc x13, x14, hs
-  add.2d v15, v15, v24
-  mov.16b v23, v21
-  fmla.2d v23, v0, v10
-  mul x14, x1, x6
-  fsub.2d v24, v22, v23
-  fmla.2d v24, v0, v10
-  umulh x15, x1, x6
-  add.2d v19, v19, v23
   add.2d v17, v17, v24
-  mov.16b v23, v21
+  mov.16b v23, v9
+  fmla.2d v23, v0, v12
+  mul x14, x1, x6
+  fsub.2d v24, v10, v23
+  fmla.2d v24, v0, v12
+  umulh x15, x1, x6
+  add.2d v21, v21, v23
+  add.2d v19, v19, v24
+  mov.16b v23, v9
   adds x13, x14, x13
   cinc x14, x15, hs
   fmla.2d v23, v0, v7
-  fsub.2d v24, v22, v23
+  fsub.2d v24, v10, v23
   fmla.2d v24, v0, v7
   adds x12, x13, x12
   cinc x13, x14, hs
-  add.2d v0, v20, v23
-  add.2d v19, v19, v24
+  add.2d v0, v22, v23
+  add.2d v21, v21, v24
   mul x14, x2, x6
-  mov.16b v20, v21
-  fmla.2d v20, v1, v4
-  fsub.2d v23, v22, v20
+  mov.16b v22, v9
+  fmla.2d v22, v1, v4
+  fsub.2d v23, v10, v22
   umulh x15, x2, x6
   fmla.2d v23, v1, v4
-  add.2d v15, v15, v20
-  add.2d v13, v13, v23
+  add.2d v17, v17, v22
+  add.2d v15, v15, v23
   adds x13, x14, x13
   cinc x14, x15, hs
-  mov.16b v20, v21
-  fmla.2d v20, v1, v5
+  mov.16b v22, v9
+  fmla.2d v22, v1, v5
   adds x4, x13, x4
   cinc x13, x14, hs
-  fsub.2d v23, v22, v20
+  fsub.2d v23, v10, v22
   fmla.2d v23, v1, v5
-  add.2d v17, v17, v20
+  add.2d v19, v19, v22
   mul x14, x3, x6
-  add.2d v15, v15, v23
-  mov.16b v20, v21
-  fmla.2d v20, v1, v6
+  add.2d v17, v17, v23
+  mov.16b v22, v9
+  fmla.2d v22, v1, v6
   umulh x6, x3, x6
-  fsub.2d v23, v22, v20
+  fsub.2d v23, v10, v22
   fmla.2d v23, v1, v6
-  add.2d v19, v19, v20
+  add.2d v21, v21, v22
   adds x13, x14, x13
   cinc x6, x6, hs
-  add.2d v17, v17, v23
-  mov.16b v20, v21
+  add.2d v19, v19, v23
+  mov.16b v22, v9
   adds x5, x13, x5
   cinc x6, x6, hs
-  fmla.2d v20, v1, v10
-  fsub.2d v23, v22, v20
-  fmla.2d v23, v1, v10
+  fmla.2d v22, v1, v12
+  fsub.2d v23, v10, v22
+  fmla.2d v23, v1, v12
   mul x13, x0, x7
-  add.2d v0, v0, v20
-  add.2d v19, v19, v23
-  mov.16b v20, v21
+  add.2d v0, v0, v22
+  add.2d v21, v21, v23
+  mov.16b v22, v9
   umulh x0, x0, x7
-  fmla.2d v20, v1, v7
-  fsub.2d v23, v22, v20
+  fmla.2d v22, v1, v7
+  fsub.2d v23, v10, v22
   adds x12, x13, x12
   cinc x0, x0, hs
   fmla.2d v23, v1, v7
-  add.2d v1, v18, v20
+  add.2d v1, v20, v22
   add.2d v0, v0, v23
   mul x13, x1, x7
-  mov.16b v18, v21
-  fmla.2d v18, v2, v4
-  fsub.2d v20, v22, v18
-  umulh x1, x1, x7
+  mov.16b v20, v9
   fmla.2d v20, v2, v4
-  add.2d v17, v17, v18
+  fsub.2d v22, v10, v20
+  umulh x1, x1, x7
+  fmla.2d v22, v2, v4
+  add.2d v19, v19, v20
   adds x0, x13, x0
   cinc x1, x1, hs
-  add.2d v15, v15, v20
-  mov.16b v18, v21
-  fmla.2d v18, v2, v5
+  add.2d v17, v17, v22
+  mov.16b v20, v9
+  fmla.2d v20, v2, v5
   adds x0, x0, x4
   cinc x1, x1, hs
-  fsub.2d v20, v22, v18
-  fmla.2d v20, v2, v5
-  add.2d v18, v19, v18
+  fsub.2d v22, v10, v20
+  fmla.2d v22, v2, v5
+  add.2d v20, v21, v20
   mul x4, x2, x7
-  add.2d v17, v17, v20
-  mov.16b v19, v21
-  fmla.2d v19, v2, v6
+  add.2d v19, v19, v22
+  mov.16b v21, v9
+  fmla.2d v21, v2, v6
   umulh x2, x2, x7
-  fsub.2d v20, v22, v19
-  fmla.2d v20, v2, v6
+  fsub.2d v22, v10, v21
+  fmla.2d v22, v2, v6
   adds x1, x4, x1
   cinc x2, x2, hs
-  add.2d v0, v0, v19
-  add.2d v18, v18, v20
-  mov.16b v19, v21
+  add.2d v0, v0, v21
+  add.2d v20, v20, v22
+  mov.16b v21, v9
   adds x1, x1, x5
   cinc x2, x2, hs
-  fmla.2d v19, v2, v10
-  fsub.2d v20, v22, v19
-  fmla.2d v20, v2, v10
+  fmla.2d v21, v2, v12
+  fsub.2d v22, v10, v21
+  fmla.2d v22, v2, v12
   mul x4, x3, x7
-  add.2d v1, v1, v19
-  add.2d v0, v0, v20
+  add.2d v1, v1, v21
+  add.2d v0, v0, v22
   umulh x3, x3, x7
-  mov.16b v19, v21
-  fmla.2d v19, v2, v7
-  fsub.2d v20, v22, v19
+  mov.16b v21, v9
+  fmla.2d v21, v2, v7
+  fsub.2d v22, v10, v21
   adds x2, x4, x2
   cinc x3, x3, hs
-  fmla.2d v20, v2, v7
-  add.2d v2, v16, v19
-  add.2d v1, v1, v20
+  fmla.2d v22, v2, v7
+  add.2d v2, v18, v21
+  add.2d v1, v1, v22
   adds x2, x2, x6
   cinc x3, x3, hs
-  mov.16b v16, v21
-  fmla.2d v16, v9, v4
+  mov.16b v18, v9
+  fmla.2d v18, v11, v4
   mov x4, #48718
-  fsub.2d v19, v22, v16
-  fmla.2d v19, v9, v4
-  add.2d v16, v18, v16
+  fsub.2d v21, v10, v18
+  fmla.2d v21, v11, v4
+  add.2d v18, v20, v18
   movk x4, #4732, lsl 16
-  add.2d v17, v17, v19
-  mov.16b v18, v21
-  fmla.2d v18, v9, v5
+  add.2d v19, v19, v21
+  mov.16b v20, v9
+  fmla.2d v20, v11, v5
   movk x4, #45078, lsl 32
-  fsub.2d v19, v22, v18
-  fmla.2d v19, v9, v5
-  add.2d v0, v0, v18
+  fsub.2d v21, v10, v20
+  fmla.2d v21, v11, v5
+  add.2d v0, v0, v20
   movk x4, #39852, lsl 48
-  add.2d v16, v16, v19
-  mov.16b v18, v21
+  add.2d v18, v18, v21
+  mov.16b v20, v9
   mov x5, #16676
-  fmla.2d v18, v9, v6
-  fsub.2d v19, v22, v18
-  fmla.2d v19, v9, v6
+  fmla.2d v20, v11, v6
+  fsub.2d v21, v10, v20
+  fmla.2d v21, v11, v6
   movk x5, #12692, lsl 16
-  add.2d v1, v1, v18
-  add.2d v0, v0, v19
-  mov.16b v18, v21
+  add.2d v1, v1, v20
+  add.2d v0, v0, v21
+  mov.16b v20, v9
   movk x5, #20986, lsl 32
-  fmla.2d v18, v9, v10
-  fsub.2d v19, v22, v18
+  fmla.2d v20, v11, v12
+  fsub.2d v21, v10, v20
   movk x5, #2848, lsl 48
-  fmla.2d v19, v9, v10
-  add.2d v2, v2, v18
-  add.2d v1, v1, v19
+  fmla.2d v21, v11, v12
+  add.2d v2, v2, v20
+  add.2d v1, v1, v21
   mov x6, #51052
-  mov.16b v18, v21
-  fmla.2d v18, v9, v7
-  fsub.2d v19, v22, v18
+  mov.16b v20, v9
+  fmla.2d v20, v11, v7
+  fsub.2d v21, v10, v20
   movk x6, #24721, lsl 16
-  fmla.2d v19, v9, v7
-  add.2d v9, v14, v18
+  fmla.2d v21, v11, v7
+  add.2d v11, v16, v20
   movk x6, #61092, lsl 32
-  add.2d v2, v2, v19
-  mov.16b v14, v21
-  fmla.2d v14, v3, v4
+  add.2d v2, v2, v21
+  mov.16b v16, v9
+  fmla.2d v16, v3, v4
   movk x6, #45156, lsl 48
-  fsub.2d v18, v22, v14
-  fmla.2d v18, v3, v4
-  add.2d v0, v0, v14
-  mov x7, #3197
-  add.2d v4, v16, v18
-  mov.16b v14, v21
-  fmla.2d v14, v3, v5
-  movk x7, #18936, lsl 16
-  fsub.2d v16, v22, v14
-  fmla.2d v16, v3, v5
-  movk x7, #10922, lsl 32
-  add.2d v1, v1, v14
+  fsub.2d v20, v10, v16
+  fmla.2d v20, v3, v4
   add.2d v0, v0, v16
-  mov.16b v5, v21
+  mov x7, #3197
+  add.2d v4, v18, v20
+  mov.16b v16, v9
+  fmla.2d v16, v3, v5
+  movk x7, #18936, lsl 16
+  fsub.2d v18, v10, v16
+  fmla.2d v18, v3, v5
+  movk x7, #10922, lsl 32
+  add.2d v1, v1, v16
+  add.2d v0, v0, v18
+  mov.16b v5, v9
   movk x7, #11014, lsl 48
   fmla.2d v5, v3, v6
-  fsub.2d v14, v22, v5
-  fmla.2d v14, v3, v6
+  fsub.2d v16, v10, v5
+  fmla.2d v16, v3, v6
   mul x13, x4, x9
   add.2d v2, v2, v5
-  add.2d v1, v1, v14
+  add.2d v1, v1, v16
   umulh x4, x4, x9
-  mov.16b v5, v21
-  fmla.2d v5, v3, v10
-  fsub.2d v6, v22, v5
+  mov.16b v5, v9
+  fmla.2d v5, v3, v12
+  fsub.2d v6, v10, v5
   adds x12, x13, x12
   cinc x4, x4, hs
-  fmla.2d v6, v3, v10
-  add.2d v5, v9, v5
+  fmla.2d v6, v3, v12
+  add.2d v5, v11, v5
   add.2d v2, v2, v6
   mul x13, x5, x9
-  mov.16b v6, v21
+  mov.16b v6, v9
   fmla.2d v6, v3, v7
   umulh x5, x5, x9
-  fsub.2d v9, v22, v6
-  fmla.2d v9, v3, v7
-  add.2d v3, v12, v6
+  fsub.2d v11, v10, v6
+  fmla.2d v11, v3, v7
+  add.2d v3, v14, v6
   adds x4, x13, x4
   cinc x5, x5, hs
-  add.2d v5, v5, v9
-  usra.2d v13, v11, #52
+  add.2d v5, v5, v11
   usra.2d v15, v13, #52
+  usra.2d v17, v15, #52
   adds x0, x4, x0
   cinc x4, x5, hs
-  usra.2d v17, v15, #52
-  usra.2d v4, v17, #52
-  and.16b v6, v11, v8
+  usra.2d v19, v17, #52
+  usra.2d v4, v19, #52
+  and.16b v6, v13, v8
   mul x5, x6, x9
-  and.16b v7, v13, v8
-  and.16b v9, v15, v8
+  and.16b v7, v15, v8
+  and.16b v11, v17, v8
   umulh x6, x6, x9
-  and.16b v8, v17, v8
+  and.16b v8, v19, v8
   ucvtf.2d v6, v6
   mov x13, #37864
   adds x4, x5, x4
@@ -343,15 +343,15 @@
   movk x13, #17153, lsl 48
   adds x1, x4, x1
   cinc x4, x5, hs
-  dup.2d v10, x13
-  mov.16b v11, v21
+  dup.2d v12, x13
+  mov.16b v13, v9
   mul x5, x7, x9
-  fmla.2d v11, v6, v10
-  fsub.2d v12, v22, v11
-  fmla.2d v12, v6, v10
+  fmla.2d v13, v6, v12
+  fsub.2d v14, v10, v13
+  fmla.2d v14, v6, v12
   umulh x6, x7, x9
-  add.2d v0, v0, v11
-  add.2d v4, v4, v12
+  add.2d v0, v0, v13
+  add.2d v4, v4, v14
   mov x7, #46128
   adds x4, x5, x4
   cinc x5, x6, hs
@@ -360,60 +360,60 @@
   adds x2, x4, x2
   cinc x4, x5, hs
   movk x7, #17161, lsl 48
-  dup.2d v10, x7
-  mov.16b v11, v21
+  dup.2d v12, x7
+  mov.16b v13, v9
   add x3, x3, x4
-  fmla.2d v11, v6, v10
-  fsub.2d v12, v22, v11
-  fmla.2d v12, v6, v10
+  fmla.2d v13, v6, v12
+  fsub.2d v14, v10, v13
+  fmla.2d v14, v6, v12
   mov x4, #56431
-  add.2d v1, v1, v11
-  add.2d v0, v0, v12
+  add.2d v1, v1, v13
+  add.2d v0, v0, v14
   mov x5, #52826
   movk x4, #30457, lsl 16
   movk x5, #57790, lsl 16
   movk x5, #55431, lsl 32
   movk x4, #30012, lsl 32
   movk x5, #17196, lsl 48
-  dup.2d v10, x5
-  mov.16b v11, v21
+  dup.2d v12, x5
+  mov.16b v13, v9
   movk x4, #6382, lsl 48
-  fmla.2d v11, v6, v10
-  fsub.2d v12, v22, v11
-  fmla.2d v12, v6, v10
+  fmla.2d v13, v6, v12
+  fsub.2d v14, v10, v13
+  fmla.2d v14, v6, v12
   mov x5, #59151
-  add.2d v2, v2, v11
-  add.2d v1, v1, v12
+  add.2d v2, v2, v13
+  add.2d v1, v1, v14
   movk x5, #41769, lsl 16
   mov x6, #31276
   movk x6, #21262, lsl 16
   movk x6, #2304, lsl 32
   movk x5, #32276, lsl 32
   movk x6, #17182, lsl 48
-  dup.2d v10, x6
-  mov.16b v11, v21
+  dup.2d v12, x6
+  mov.16b v13, v9
   movk x5, #21677, lsl 48
-  fmla.2d v11, v6, v10
-  fsub.2d v12, v22, v11
+  fmla.2d v13, v6, v12
+  fsub.2d v14, v10, v13
   mov x6, #34015
-  fmla.2d v12, v6, v10
-  add.2d v5, v5, v11
-  add.2d v2, v2, v12
+  fmla.2d v14, v6, v12
+  add.2d v5, v5, v13
+  add.2d v2, v2, v14
   movk x6, #20342, lsl 16
   mov x7, #28672
   movk x7, #24515, lsl 16
   movk x7, #54929, lsl 32
   movk x6, #13935, lsl 32
   movk x7, #17064, lsl 48
-  dup.2d v10, x7
-  mov.16b v11, v21
+  dup.2d v12, x7
+  mov.16b v13, v9
   movk x6, #11030, lsl 48
-  fmla.2d v11, v6, v10
-  fsub.2d v12, v22, v11
+  fmla.2d v13, v6, v12
+  fsub.2d v14, v10, v13
   mov x7, #13689
-  fmla.2d v12, v6, v10
-  add.2d v3, v3, v11
-  add.2d v5, v5, v12
+  fmla.2d v14, v6, v12
+  add.2d v3, v3, v13
+  add.2d v5, v5, v14
   movk x7, #8159, lsl 16
   ucvtf.2d v6, v7
   mov x9, #44768
@@ -423,14 +423,14 @@
   movk x9, #17133, lsl 48
   movk x7, #4913, lsl 48
   dup.2d v7, x9
-  mov.16b v10, v21
-  fmla.2d v10, v6, v7
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
   mul x9, x4, x10
-  fsub.2d v11, v22, v10
-  fmla.2d v11, v6, v7
-  add.2d v0, v0, v10
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
+  add.2d v0, v0, v12
   umulh x4, x4, x10
-  add.2d v4, v4, v11
+  add.2d v4, v4, v13
   mov x13, #47492
   adds x9, x9, x12
   cinc x4, x4, hs
@@ -439,15 +439,15 @@
   movk x13, #17168, lsl 48
   mul x12, x5, x10
   dup.2d v7, x13
-  mov.16b v10, v21
-  fmla.2d v10, v6, v7
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
   umulh x5, x5, x10
-  fsub.2d v11, v22, v10
-  fmla.2d v11, v6, v7
-  add.2d v1, v1, v10
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
+  add.2d v1, v1, v12
   adds x4, x12, x4
   cinc x5, x5, hs
-  add.2d v0, v0, v11
+  add.2d v0, v0, v13
   mov x12, #57936
   adds x0, x4, x0
   cinc x4, x5, hs
@@ -456,15 +456,15 @@
   movk x12, #17197, lsl 48
   mul x5, x6, x10
   dup.2d v7, x12
-  mov.16b v10, v21
-  fmla.2d v10, v6, v7
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
   umulh x6, x6, x10
-  fsub.2d v11, v22, v10
-  fmla.2d v11, v6, v7
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
   adds x4, x5, x4
   cinc x5, x6, hs
-  add.2d v2, v2, v10
-  add.2d v1, v1, v11
+  add.2d v2, v2, v12
+  add.2d v1, v1, v13
   mov x6, #17708
   adds x1, x4, x1
   cinc x4, x5, hs
@@ -473,15 +473,15 @@
   movk x6, #17188, lsl 48
   mul x5, x7, x10
   dup.2d v7, x6
-  mov.16b v10, v21
+  mov.16b v12, v9
   umulh x6, x7, x10
-  fmla.2d v10, v6, v7
-  fsub.2d v11, v22, v10
-  fmla.2d v11, v6, v7
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
   adds x4, x5, x4
   cinc x5, x6, hs
-  add.2d v5, v5, v10
-  add.2d v2, v2, v11
+  add.2d v5, v5, v12
+  add.2d v2, v2, v13
   mov x6, #29184
   adds x2, x4, x2
   cinc x4, x5, hs
@@ -490,15 +490,15 @@
   movk x6, #17083, lsl 48
   add x3, x3, x4
   dup.2d v7, x6
-  mov.16b v10, v21
+  mov.16b v12, v9
   mov x4, #61005
-  fmla.2d v10, v6, v7
-  fsub.2d v11, v22, v10
-  fmla.2d v11, v6, v7
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
   movk x4, #58262, lsl 16
-  add.2d v3, v3, v10
-  add.2d v5, v5, v11
-  ucvtf.2d v6, v9
+  add.2d v3, v3, v12
+  add.2d v5, v5, v13
+  ucvtf.2d v6, v11
   movk x4, #32851, lsl 32
   mov x5, #58856
   movk x5, #14953, lsl 16
@@ -507,14 +507,14 @@
   movk x5, #17181, lsl 48
   dup.2d v7, x5
   mov x5, #37581
-  mov.16b v9, v21
-  fmla.2d v9, v6, v7
-  fsub.2d v10, v22, v9
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
+  fsub.2d v12, v10, v11
   movk x5, #43836, lsl 16
-  fmla.2d v10, v6, v7
-  add.2d v0, v0, v9
+  fmla.2d v12, v6, v7
+  add.2d v0, v0, v11
   movk x5, #36286, lsl 32
-  add.2d v4, v4, v10
+  add.2d v4, v4, v12
   mov x6, #35392
   movk x6, #12477, lsl 16
   movk x5, #51783, lsl 48
@@ -522,14 +522,14 @@
   movk x6, #17142, lsl 48
   dup.2d v7, x6
   mov x6, #10899
-  mov.16b v9, v21
-  fmla.2d v9, v6, v7
-  fsub.2d v10, v22, v9
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
+  fsub.2d v12, v10, v11
   movk x6, #30709, lsl 16
-  fmla.2d v10, v6, v7
-  add.2d v1, v1, v9
+  fmla.2d v12, v6, v7
+  add.2d v1, v1, v11
   movk x6, #61551, lsl 32
-  add.2d v0, v0, v10
+  add.2d v0, v0, v12
   mov x7, #9848
   movk x7, #54501, lsl 16
   movk x6, #45784, lsl 48
@@ -537,14 +537,14 @@
   movk x7, #17170, lsl 48
   dup.2d v7, x7
   mov x7, #36612
-  mov.16b v9, v21
-  fmla.2d v9, v6, v7
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
   movk x7, #63402, lsl 16
-  fsub.2d v10, v22, v9
-  fmla.2d v10, v6, v7
-  add.2d v2, v2, v9
+  fsub.2d v12, v10, v11
+  fmla.2d v12, v6, v7
+  add.2d v2, v2, v11
   movk x7, #47623, lsl 32
-  add.2d v1, v1, v10
+  add.2d v1, v1, v12
   mov x10, #9584
   movk x10, #63883, lsl 16
   movk x7, #9430, lsl 48
@@ -552,15 +552,15 @@
   movk x10, #17190, lsl 48
   mul x12, x4, x11
   dup.2d v7, x10
-  mov.16b v9, v21
-  fmla.2d v9, v6, v7
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
   umulh x4, x4, x11
-  fsub.2d v10, v22, v9
-  fmla.2d v10, v6, v7
-  add.2d v5, v5, v9
+  fsub.2d v12, v10, v11
+  fmla.2d v12, v6, v7
+  add.2d v5, v5, v11
   adds x9, x12, x9
   cinc x4, x4, hs
-  add.2d v2, v2, v10
+  add.2d v2, v2, v12
   mov x10, #51712
   movk x10, #16093, lsl 16
   mul x12, x5, x11
@@ -568,16 +568,16 @@
   movk x10, #17068, lsl 48
   umulh x5, x5, x11
   dup.2d v7, x10
-  mov.16b v9, v21
-  fmla.2d v9, v6, v7
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
   adds x4, x12, x4
   cinc x5, x5, hs
-  fsub.2d v10, v22, v9
-  fmla.2d v10, v6, v7
-  add.2d v3, v3, v9
+  fsub.2d v12, v10, v11
+  fmla.2d v12, v6, v7
+  add.2d v3, v3, v11
   adds x0, x4, x0
   cinc x4, x5, hs
-  add.2d v5, v5, v10
+  add.2d v5, v5, v12
   ucvtf.2d v6, v8
   mul x5, x6, x11
   mov x10, #34724
@@ -586,16 +586,16 @@
   umulh x6, x6, x11
   movk x10, #17184, lsl 48
   dup.2d v7, x10
-  mov.16b v8, v21
+  mov.16b v8, v9
   adds x4, x5, x4
   cinc x5, x6, hs
   fmla.2d v8, v6, v7
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   adds x1, x4, x1
   cinc x4, x5, hs
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v0, v0, v8
-  add.2d v4, v4, v9
+  add.2d v4, v4, v11
   mul x5, x7, x11
   mov x6, #25532
   movk x6, #31025, lsl 16
@@ -603,16 +603,16 @@
   umulh x7, x7, x11
   movk x6, #17199, lsl 48
   dup.2d v7, x6
-  mov.16b v8, v21
+  mov.16b v8, v9
   adds x4, x5, x4
   cinc x5, x7, hs
   fmla.2d v8, v6, v7
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   adds x2, x4, x2
   cinc x4, x5, hs
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v1, v1, v8
-  add.2d v0, v0, v9
+  add.2d v0, v0, v11
   add x3, x3, x4
   mov x4, #18830
   movk x4, #2465, lsl 16
@@ -621,13 +621,13 @@
   movk x4, #17194, lsl 48
   dup.2d v7, x4
   movk x5, #61439, lsl 16
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   movk x5, #62867, lsl 32
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v2, v2, v8
-  add.2d v1, v1, v9
+  add.2d v1, v1, v11
   movk x5, #49889, lsl 48
   mov x4, #21566
   movk x4, #43708, lsl 16
@@ -636,13 +636,13 @@
   movk x4, #17185, lsl 48
   dup.2d v7, x4
   mov x4, #1
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   movk x4, #61440, lsl 16
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v5, v5, v8
-  add.2d v2, v2, v9
+  add.2d v2, v2, v11
   movk x4, #62867, lsl 32
   mov x6, #3072
   movk x6, #8058, lsl 16
@@ -651,14 +651,14 @@
   movk x6, #17047, lsl 48
   dup.2d v7, x6
   mov x6, #28817
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   movk x6, #31161, lsl 16
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v3, v3, v8
   movk x6, #59464, lsl 32
-  add.2d v5, v5, v9
+  add.2d v5, v5, v11
   mov x7, #65535
   movk x7, #61439, lsl 16
   movk x6, #10291, lsl 48
@@ -682,14 +682,14 @@
   movk x7, #17151, lsl 48
   dup.2d v7, x7
   mov x7, #41001
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
   movk x7, #57649, lsl 16
-  fsub.2d v9, v22, v8
-  fmla.2d v9, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
   add.2d v0, v0, v8
   movk x7, #20082, lsl 32
-  add.2d v4, v4, v9
+  add.2d v4, v4, v11
   mov x8, #20728
   movk x8, #23588, lsl 16
   movk x7, #12388, lsl 48
@@ -697,15 +697,15 @@
   movk x8, #17170, lsl 48
   mul x10, x4, x5
   dup.2d v7, x8
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
   umulh x4, x4, x5
-  fsub.2d v9, v22, v8
-  fmla.2d v9, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
   add.2d v1, v1, v8
   cmn x10, x9
   cinc x4, x4, hs
-  add.2d v0, v0, v9
+  add.2d v0, v0, v11
   mov x8, #16000
   mul x9, x6, x5
   movk x8, #53891, lsl 16
@@ -713,16 +713,16 @@
   movk x8, #17144, lsl 48
   umulh x6, x6, x5
   dup.2d v7, x8
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
   adds x4, x9, x4
   cinc x6, x6, hs
-  fsub.2d v9, v22, v8
-  fmla.2d v9, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
   add.2d v2, v2, v8
   adds x0, x4, x0
   cinc x4, x6, hs
-  add.2d v1, v1, v9
+  add.2d v1, v1, v11
   mov x6, #46800
   mul x8, x11, x5
   movk x6, #2568, lsl 16
@@ -730,16 +730,16 @@
   movk x6, #17188, lsl 48
   umulh x9, x11, x5
   dup.2d v7, x6
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
   adds x4, x8, x4
   cinc x6, x9, hs
-  fsub.2d v9, v22, v8
-  fmla.2d v9, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
   adds x1, x4, x1
   cinc x4, x6, hs
   add.2d v5, v5, v8
-  add.2d v2, v2, v9
+  add.2d v2, v2, v11
   mov x6, #39040
   mul x8, x7, x5
   movk x6, #14704, lsl 16
@@ -747,11 +747,11 @@
   movk x6, #17096, lsl 48
   umulh x5, x7, x5
   dup.2d v7, x6
-  mov.16b v8, v21
+  mov.16b v8, v9
   adds x4, x8, x4
   cinc x5, x5, hs
   fmla.2d v8, v6, v7
-  fsub.2d v9, v22, v8
+  fsub.2d v9, v10, v8
   fmla.2d v9, v6, v7
   adds x2, x4, x2
   cinc x4, x5, hs

--- a/block-multiplier/src/aarch64/montgomery_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_interleaved_4.s
@@ -14,105 +14,105 @@
   mul x17, x0, x4
   dup.2d v8, x16
   umulh x20, x0, x4
-  shl.2d v9, v1, #14
-  shl.2d v10, v2, #26
+  mov x21, #5075556780046548992
+  dup.2d v9, x21
   mul x21, x1, x4
-  shl.2d v11, v3, #38
-  umulh x22, x1, x4
-  ushr.2d v3, v3, #14
+  mov x22, #1
+  umulh x23, x1, x4
+  movk x22, #18032, lsl 48
   adds x20, x21, x20
-  cinc x21, x22, hs
-  shl.2d v12, v0, #2
-  usra.2d v9, v0, #50
+  cinc x21, x23, hs
+  dup.2d v10, x22
+  shl.2d v11, v1, #14
   mul x22, x2, x4
-  usra.2d v10, v1, #38
+  shl.2d v12, v2, #26
   umulh x23, x2, x4
-  usra.2d v11, v2, #26
+  shl.2d v13, v3, #38
   adds x21, x22, x21
   cinc x22, x23, hs
-  and.16b v0, v12, v8
-  and.16b v1, v9, v8
+  ushr.2d v3, v3, #14
+  shl.2d v14, v0, #2
   mul x23, x3, x4
-  and.16b v2, v10, v8
+  usra.2d v11, v0, #50
   umulh x4, x3, x4
-  and.16b v9, v11, v8
+  usra.2d v12, v1, #38
   adds x22, x23, x22
   cinc x4, x4, hs
-  shl.2d v10, v5, #14
-  shl.2d v11, v6, #26
+  usra.2d v13, v2, #26
+  and.16b v0, v14, v8
   mul x23, x0, x5
-  shl.2d v12, v7, #38
+  and.16b v1, v11, v8
   umulh x24, x0, x5
-  ushr.2d v7, v7, #14
+  and.16b v2, v12, v8
   adds x20, x23, x20
   cinc x23, x24, hs
-  shl.2d v13, v4, #2
-  usra.2d v10, v4, #50
+  and.16b v11, v13, v8
+  shl.2d v12, v5, #14
   mul x24, x1, x5
-  usra.2d v11, v5, #38
+  shl.2d v13, v6, #26
   umulh x25, x1, x5
-  usra.2d v12, v6, #26
+  shl.2d v14, v7, #38
   adds x23, x24, x23
   cinc x24, x25, hs
-  and.16b v4, v13, v8
-  and.16b v5, v10, v8
+  ushr.2d v7, v7, #14
+  shl.2d v15, v4, #2
   adds x21, x23, x21
   cinc x23, x24, hs
-  and.16b v6, v11, v8
+  usra.2d v12, v4, #50
   mul x24, x2, x5
-  and.16b v10, v12, v8
-  mov x25, #13605374474286268416
-  umulh x26, x2, x5
-  dup.2d v11, x25
+  usra.2d v13, v5, #38
+  usra.2d v14, v6, #26
+  umulh x25, x2, x5
+  and.16b v4, v15, v8
   adds x23, x24, x23
-  cinc x24, x26, hs
-  mov x25, #6440147467139809280
+  cinc x24, x25, hs
+  and.16b v5, v12, v8
   adds x22, x23, x22
   cinc x23, x24, hs
-  dup.2d v12, x25
-  mov x24, #3688448094816436224
-  mul x25, x3, x5
-  dup.2d v13, x24
+  and.16b v6, v13, v8
+  and.16b v12, v14, v8
+  mul x24, x3, x5
+  mov x25, #13605374474286268416
   umulh x5, x3, x5
-  mov x24, #9209861237972664320
-  adds x23, x25, x23
+  dup.2d v13, x25
+  adds x23, x24, x23
   cinc x5, x5, hs
+  mov x24, #6440147467139809280
   dup.2d v14, x24
-  mov x24, #12218265789056155648
   adds x4, x23, x4
   cinc x5, x5, hs
-  dup.2d v15, x24
-  mul x23, x0, x6
-  mov x24, #17739678932212383744
-  umulh x25, x0, x6
-  dup.2d v16, x24
-  mov x24, #2301339409586323456
-  adds x21, x23, x21
-  cinc x23, x25, hs
+  mov x23, #3688448094816436224
+  mul x24, x0, x6
+  dup.2d v15, x23
+  umulh x23, x0, x6
+  mov x25, #9209861237972664320
+  dup.2d v16, x25
+  adds x21, x24, x21
+  cinc x23, x23, hs
+  mov x24, #12218265789056155648
+  mul x25, x1, x6
   dup.2d v17, x24
-  mul x24, x1, x6
-  mov x25, #7822752552742551552
-  umulh x26, x1, x6
-  dup.2d v18, x25
-  mov x25, #5071053180419178496
-  adds x23, x24, x23
-  cinc x24, x26, hs
-  dup.2d v19, x25
+  umulh x24, x1, x6
+  mov x26, #17739678932212383744
+  dup.2d v18, x26
+  adds x23, x25, x23
+  cinc x24, x24, hs
+  mov x25, #2301339409586323456
   adds x22, x23, x22
+  cinc x23, x24, hs
+  dup.2d v19, x25
+  mul x24, x2, x6
+  mov x25, #7822752552742551552
+  dup.2d v20, x25
+  umulh x25, x2, x6
+  mov x26, #5071053180419178496
+  adds x23, x24, x23
+  cinc x24, x25, hs
+  dup.2d v21, x26
+  adds x4, x23, x4
   cinc x23, x24, hs
   mov x24, #16352570246982270976
-  mul x25, x2, x6
-  dup.2d v20, x24
-  mov x24, #5075556780046548992
-  umulh x26, x2, x6
-  dup.2d v21, x24
-  adds x23, x25, x23
-  cinc x24, x26, hs
-  mov x25, #1
-  adds x4, x23, x4
-  cinc x23, x24, hs
-  movk x25, #18032, lsl 48
-  dup.2d v22, x25
+  dup.2d v22, x24
   mul x24, x3, x6
   ucvtf.2d v0, v0
   umulh x6, x3, x6
@@ -120,7 +120,7 @@
   ucvtf.2d v2, v2
   adds x23, x24, x23
   cinc x6, x6, hs
-  ucvtf.2d v9, v9
+  ucvtf.2d v11, v11
   adds x5, x23, x5
   cinc x6, x6, hs
   ucvtf.2d v3, v3
@@ -131,311 +131,311 @@
   ucvtf.2d v6, v6
   adds x22, x23, x22
   cinc x0, x0, hs
-  ucvtf.2d v10, v10
+  ucvtf.2d v12, v12
   mul x23, x1, x7
   ucvtf.2d v7, v7
-  mov.16b v23, v21
+  mov.16b v23, v9
   umulh x1, x1, x7
   fmla.2d v23, v0, v4
   adds x0, x23, x0
   cinc x1, x1, hs
-  fsub.2d v24, v22, v23
+  fsub.2d v24, v10, v23
   adds x0, x0, x4
   cinc x1, x1, hs
   fmla.2d v24, v0, v4
-  add.2d v13, v13, v23
+  add.2d v15, v15, v23
   mul x4, x2, x7
-  add.2d v11, v11, v24
+  add.2d v13, v13, v24
   umulh x2, x2, x7
-  mov.16b v23, v21
+  mov.16b v23, v9
   adds x1, x4, x1
   cinc x2, x2, hs
   fmla.2d v23, v0, v5
-  fsub.2d v24, v22, v23
+  fsub.2d v24, v10, v23
   adds x1, x1, x5
   cinc x2, x2, hs
   fmla.2d v24, v0, v5
   mul x4, x3, x7
-  add.2d v15, v15, v23
+  add.2d v17, v17, v23
   umulh x3, x3, x7
-  add.2d v13, v13, v24
-  mov.16b v23, v21
+  add.2d v15, v15, v24
+  mov.16b v23, v9
   adds x2, x4, x2
   cinc x3, x3, hs
   fmla.2d v23, v0, v6
   adds x2, x2, x6
   cinc x3, x3, hs
-  fsub.2d v24, v22, v23
+  fsub.2d v24, v10, v23
   mov x4, #48718
   fmla.2d v24, v0, v6
-  add.2d v17, v17, v23
-  movk x4, #4732, lsl 16
-  add.2d v15, v15, v24
-  movk x4, #45078, lsl 32
-  mov.16b v23, v21
-  fmla.2d v23, v0, v10
-  movk x4, #39852, lsl 48
-  fsub.2d v24, v22, v23
-  mov x5, #16676
-  fmla.2d v24, v0, v10
-  movk x5, #12692, lsl 16
   add.2d v19, v19, v23
+  movk x4, #4732, lsl 16
   add.2d v17, v17, v24
+  movk x4, #45078, lsl 32
+  mov.16b v23, v9
+  fmla.2d v23, v0, v12
+  movk x4, #39852, lsl 48
+  fsub.2d v24, v10, v23
+  mov x5, #16676
+  fmla.2d v24, v0, v12
+  movk x5, #12692, lsl 16
+  add.2d v21, v21, v23
+  add.2d v19, v19, v24
   movk x5, #20986, lsl 32
-  mov.16b v23, v21
+  mov.16b v23, v9
   movk x5, #2848, lsl 48
   fmla.2d v23, v0, v7
   mov x6, #51052
-  fsub.2d v24, v22, v23
+  fsub.2d v24, v10, v23
   fmla.2d v24, v0, v7
   movk x6, #24721, lsl 16
-  add.2d v0, v20, v23
+  add.2d v0, v22, v23
   movk x6, #61092, lsl 32
-  add.2d v19, v19, v24
+  add.2d v21, v21, v24
   movk x6, #45156, lsl 48
-  mov.16b v20, v21
-  fmla.2d v20, v1, v4
+  mov.16b v22, v9
+  fmla.2d v22, v1, v4
   mov x7, #3197
-  fsub.2d v23, v22, v20
+  fsub.2d v23, v10, v22
   movk x7, #18936, lsl 16
   fmla.2d v23, v1, v4
   movk x7, #10922, lsl 32
-  add.2d v15, v15, v20
-  add.2d v13, v13, v23
+  add.2d v17, v17, v22
+  add.2d v15, v15, v23
   movk x7, #11014, lsl 48
-  mov.16b v20, v21
+  mov.16b v22, v9
   mul x23, x4, x17
-  fmla.2d v20, v1, v5
+  fmla.2d v22, v1, v5
   umulh x4, x4, x17
-  fsub.2d v23, v22, v20
+  fsub.2d v23, v10, v22
   fmla.2d v23, v1, v5
   adds x22, x23, x22
   cinc x4, x4, hs
-  add.2d v17, v17, v20
+  add.2d v19, v19, v22
   mul x23, x5, x17
-  add.2d v15, v15, v23
+  add.2d v17, v17, v23
   umulh x5, x5, x17
-  mov.16b v20, v21
-  fmla.2d v20, v1, v6
+  mov.16b v22, v9
+  fmla.2d v22, v1, v6
   adds x4, x23, x4
   cinc x5, x5, hs
-  fsub.2d v23, v22, v20
+  fsub.2d v23, v10, v22
   adds x0, x4, x0
   cinc x4, x5, hs
   fmla.2d v23, v1, v6
-  add.2d v19, v19, v20
+  add.2d v21, v21, v22
   mul x5, x6, x17
-  add.2d v17, v17, v23
+  add.2d v19, v19, v23
   umulh x6, x6, x17
-  mov.16b v20, v21
+  mov.16b v22, v9
   adds x4, x5, x4
   cinc x5, x6, hs
-  fmla.2d v20, v1, v10
-  fsub.2d v23, v22, v20
+  fmla.2d v22, v1, v12
+  fsub.2d v23, v10, v22
   adds x1, x4, x1
   cinc x4, x5, hs
-  fmla.2d v23, v1, v10
+  fmla.2d v23, v1, v12
   mul x5, x7, x17
-  add.2d v0, v0, v20
+  add.2d v0, v0, v22
   umulh x6, x7, x17
-  add.2d v19, v19, v23
-  mov.16b v20, v21
+  add.2d v21, v21, v23
+  mov.16b v22, v9
   adds x4, x5, x4
   cinc x5, x6, hs
-  fmla.2d v20, v1, v7
+  fmla.2d v22, v1, v7
   adds x2, x4, x2
   cinc x4, x5, hs
-  fsub.2d v23, v22, v20
+  fsub.2d v23, v10, v22
   add x3, x3, x4
   fmla.2d v23, v1, v7
-  add.2d v1, v18, v20
+  add.2d v1, v20, v22
   mov x4, #56431
   add.2d v0, v0, v23
   movk x4, #30457, lsl 16
-  mov.16b v18, v21
+  mov.16b v20, v9
   movk x4, #30012, lsl 32
-  fmla.2d v18, v2, v4
-  fsub.2d v20, v22, v18
-  movk x4, #6382, lsl 48
   fmla.2d v20, v2, v4
+  fsub.2d v22, v10, v20
+  movk x4, #6382, lsl 48
+  fmla.2d v22, v2, v4
   mov x5, #59151
-  add.2d v17, v17, v18
+  add.2d v19, v19, v20
   movk x5, #41769, lsl 16
-  add.2d v15, v15, v20
-  mov.16b v18, v21
+  add.2d v17, v17, v22
+  mov.16b v20, v9
   movk x5, #32276, lsl 32
-  fmla.2d v18, v2, v5
-  movk x5, #21677, lsl 48
-  fsub.2d v20, v22, v18
-  mov x6, #34015
   fmla.2d v20, v2, v5
-  add.2d v18, v19, v18
+  movk x5, #21677, lsl 48
+  fsub.2d v22, v10, v20
+  mov x6, #34015
+  fmla.2d v22, v2, v5
+  add.2d v20, v21, v20
   movk x6, #20342, lsl 16
-  add.2d v17, v17, v20
+  add.2d v19, v19, v22
   movk x6, #13935, lsl 32
-  mov.16b v19, v21
-  fmla.2d v19, v2, v6
+  mov.16b v21, v9
+  fmla.2d v21, v2, v6
   movk x6, #11030, lsl 48
-  fsub.2d v20, v22, v19
+  fsub.2d v22, v10, v21
   mov x7, #13689
-  fmla.2d v20, v2, v6
+  fmla.2d v22, v2, v6
   movk x7, #8159, lsl 16
-  add.2d v0, v0, v19
-  add.2d v18, v18, v20
+  add.2d v0, v0, v21
+  add.2d v20, v20, v22
   movk x7, #215, lsl 32
-  mov.16b v19, v21
+  mov.16b v21, v9
   movk x7, #4913, lsl 48
-  fmla.2d v19, v2, v10
+  fmla.2d v21, v2, v12
   mul x17, x4, x20
-  fsub.2d v20, v22, v19
-  fmla.2d v20, v2, v10
+  fsub.2d v22, v10, v21
+  fmla.2d v22, v2, v12
   umulh x4, x4, x20
-  add.2d v1, v1, v19
+  add.2d v1, v1, v21
   adds x17, x17, x22
   cinc x4, x4, hs
-  add.2d v0, v0, v20
+  add.2d v0, v0, v22
   mul x22, x5, x20
-  mov.16b v19, v21
-  fmla.2d v19, v2, v7
+  mov.16b v21, v9
+  fmla.2d v21, v2, v7
   umulh x5, x5, x20
-  fsub.2d v20, v22, v19
+  fsub.2d v22, v10, v21
   adds x4, x22, x4
   cinc x5, x5, hs
-  fmla.2d v20, v2, v7
+  fmla.2d v22, v2, v7
   adds x0, x4, x0
   cinc x4, x5, hs
-  add.2d v2, v16, v19
-  add.2d v1, v1, v20
+  add.2d v2, v18, v21
+  add.2d v1, v1, v22
   mul x5, x6, x20
-  mov.16b v16, v21
+  mov.16b v18, v9
   umulh x6, x6, x20
-  fmla.2d v16, v9, v4
+  fmla.2d v18, v11, v4
   adds x4, x5, x4
   cinc x5, x6, hs
-  fsub.2d v19, v22, v16
-  fmla.2d v19, v9, v4
+  fsub.2d v21, v10, v18
+  fmla.2d v21, v11, v4
   adds x1, x4, x1
   cinc x4, x5, hs
-  add.2d v16, v18, v16
+  add.2d v18, v20, v18
   mul x5, x7, x20
-  add.2d v17, v17, v19
+  add.2d v19, v19, v21
   umulh x6, x7, x20
-  mov.16b v18, v21
-  fmla.2d v18, v9, v5
+  mov.16b v20, v9
+  fmla.2d v20, v11, v5
   adds x4, x5, x4
   cinc x5, x6, hs
-  fsub.2d v19, v22, v18
+  fsub.2d v21, v10, v20
   adds x2, x4, x2
   cinc x4, x5, hs
-  fmla.2d v19, v9, v5
-  add.2d v0, v0, v18
+  fmla.2d v21, v11, v5
+  add.2d v0, v0, v20
   add x3, x3, x4
-  add.2d v16, v16, v19
+  add.2d v18, v18, v21
   mov x4, #61005
-  mov.16b v18, v21
+  mov.16b v20, v9
   movk x4, #58262, lsl 16
-  fmla.2d v18, v9, v6
-  fsub.2d v19, v22, v18
+  fmla.2d v20, v11, v6
+  fsub.2d v21, v10, v20
   movk x4, #32851, lsl 32
-  fmla.2d v19, v9, v6
+  fmla.2d v21, v11, v6
   movk x4, #11582, lsl 48
-  add.2d v1, v1, v18
+  add.2d v1, v1, v20
   mov x5, #37581
-  add.2d v0, v0, v19
-  mov.16b v18, v21
+  add.2d v0, v0, v21
+  mov.16b v20, v9
   movk x5, #43836, lsl 16
-  fmla.2d v18, v9, v10
+  fmla.2d v20, v11, v12
   movk x5, #36286, lsl 32
-  fsub.2d v19, v22, v18
+  fsub.2d v21, v10, v20
   movk x5, #51783, lsl 48
-  fmla.2d v19, v9, v10
-  add.2d v2, v2, v18
+  fmla.2d v21, v11, v12
+  add.2d v2, v2, v20
   mov x6, #10899
-  add.2d v1, v1, v19
+  add.2d v1, v1, v21
   movk x6, #30709, lsl 16
-  mov.16b v18, v21
+  mov.16b v20, v9
   movk x6, #61551, lsl 32
-  fmla.2d v18, v9, v7
-  fsub.2d v19, v22, v18
+  fmla.2d v20, v11, v7
+  fsub.2d v21, v10, v20
   movk x6, #45784, lsl 48
-  fmla.2d v19, v9, v7
+  fmla.2d v21, v11, v7
   mov x7, #36612
-  add.2d v9, v14, v18
+  add.2d v11, v16, v20
   movk x7, #63402, lsl 16
-  add.2d v2, v2, v19
-  mov.16b v14, v21
+  add.2d v2, v2, v21
+  mov.16b v16, v9
   movk x7, #47623, lsl 32
-  fmla.2d v14, v3, v4
+  fmla.2d v16, v3, v4
   movk x7, #9430, lsl 48
-  fsub.2d v18, v22, v14
+  fsub.2d v20, v10, v16
   mul x20, x4, x21
-  fmla.2d v18, v3, v4
-  add.2d v0, v0, v14
+  fmla.2d v20, v3, v4
+  add.2d v0, v0, v16
   umulh x4, x4, x21
-  add.2d v4, v16, v18
+  add.2d v4, v18, v20
   adds x17, x20, x17
   cinc x4, x4, hs
-  mov.16b v14, v21
-  fmla.2d v14, v3, v5
-  mul x20, x5, x21
-  fsub.2d v16, v22, v14
-  umulh x5, x5, x21
+  mov.16b v16, v9
   fmla.2d v16, v3, v5
+  mul x20, x5, x21
+  fsub.2d v18, v10, v16
+  umulh x5, x5, x21
+  fmla.2d v18, v3, v5
   adds x4, x20, x4
   cinc x5, x5, hs
-  add.2d v1, v1, v14
-  add.2d v0, v0, v16
+  add.2d v1, v1, v16
+  add.2d v0, v0, v18
   adds x0, x4, x0
   cinc x4, x5, hs
-  mov.16b v5, v21
+  mov.16b v5, v9
   mul x5, x6, x21
   fmla.2d v5, v3, v6
   umulh x6, x6, x21
-  fsub.2d v14, v22, v5
-  fmla.2d v14, v3, v6
+  fsub.2d v16, v10, v5
+  fmla.2d v16, v3, v6
   adds x4, x5, x4
   cinc x5, x6, hs
   add.2d v2, v2, v5
   adds x1, x4, x1
   cinc x4, x5, hs
-  add.2d v1, v1, v14
+  add.2d v1, v1, v16
   mul x5, x7, x21
-  mov.16b v5, v21
-  fmla.2d v5, v3, v10
+  mov.16b v5, v9
+  fmla.2d v5, v3, v12
   umulh x6, x7, x21
-  fsub.2d v6, v22, v5
+  fsub.2d v6, v10, v5
   adds x4, x5, x4
   cinc x5, x6, hs
-  fmla.2d v6, v3, v10
+  fmla.2d v6, v3, v12
   adds x2, x4, x2
   cinc x4, x5, hs
-  add.2d v5, v9, v5
+  add.2d v5, v11, v5
   add.2d v2, v2, v6
   add x3, x3, x4
-  mov.16b v6, v21
+  mov.16b v6, v9
   mov x4, #65535
   fmla.2d v6, v3, v7
   movk x4, #61439, lsl 16
-  fsub.2d v9, v22, v6
-  fmla.2d v9, v3, v7
+  fsub.2d v11, v10, v6
+  fmla.2d v11, v3, v7
   movk x4, #62867, lsl 32
-  add.2d v3, v12, v6
+  add.2d v3, v14, v6
   movk x4, #49889, lsl 48
-  add.2d v5, v5, v9
+  add.2d v5, v5, v11
   mul x4, x4, x17
-  usra.2d v13, v11, #52
   usra.2d v15, v13, #52
-  mov x5, #1
   usra.2d v17, v15, #52
+  mov x5, #1
+  usra.2d v19, v17, #52
   movk x5, #61440, lsl 16
-  usra.2d v4, v17, #52
-  and.16b v6, v11, v8
+  usra.2d v4, v19, #52
+  and.16b v6, v13, v8
   movk x5, #62867, lsl 32
-  and.16b v7, v13, v8
+  and.16b v7, v15, v8
   movk x5, #17377, lsl 48
-  and.16b v9, v15, v8
+  and.16b v11, v17, v8
   mov x6, #28817
-  and.16b v8, v17, v8
+  and.16b v8, v19, v8
   ucvtf.2d v6, v6
   movk x6, #31161, lsl 16
   mov x7, #37864
@@ -445,18 +445,18 @@
   movk x7, #28960, lsl 32
   movk x7, #17153, lsl 48
   mov x20, #22621
-  dup.2d v10, x7
+  dup.2d v12, x7
   movk x20, #33153, lsl 16
-  mov.16b v11, v21
+  mov.16b v13, v9
   movk x20, #17846, lsl 32
-  fmla.2d v11, v6, v10
-  fsub.2d v12, v22, v11
+  fmla.2d v13, v6, v12
+  fsub.2d v14, v10, v13
   movk x20, #47184, lsl 48
-  fmla.2d v12, v6, v10
+  fmla.2d v14, v6, v12
   mov x7, #41001
-  add.2d v0, v0, v11
+  add.2d v0, v0, v13
   movk x7, #57649, lsl 16
-  add.2d v4, v4, v12
+  add.2d v4, v4, v14
   mov x21, #46128
   movk x7, #20082, lsl 32
   movk x21, #29964, lsl 16
@@ -464,20 +464,20 @@
   movk x21, #7587, lsl 32
   mul x22, x5, x4
   movk x21, #17161, lsl 48
-  dup.2d v10, x21
+  dup.2d v12, x21
   umulh x5, x5, x4
-  mov.16b v11, v21
+  mov.16b v13, v9
   cmn x22, x17
   cinc x5, x5, hs
-  fmla.2d v11, v6, v10
+  fmla.2d v13, v6, v12
   mul x17, x6, x4
-  fsub.2d v12, v22, v11
-  fmla.2d v12, v6, v10
+  fsub.2d v14, v10, v13
+  fmla.2d v14, v6, v12
   umulh x6, x6, x4
-  add.2d v1, v1, v11
+  add.2d v1, v1, v13
   adds x5, x17, x5
   cinc x6, x6, hs
-  add.2d v0, v0, v12
+  add.2d v0, v0, v14
   mov x17, #52826
   adds x0, x5, x0
   cinc x5, x6, hs
@@ -486,21 +486,21 @@
   movk x17, #55431, lsl 32
   umulh x20, x20, x4
   movk x17, #17196, lsl 48
-  dup.2d v10, x17
+  dup.2d v12, x17
   adds x5, x6, x5
   cinc x6, x20, hs
-  mov.16b v11, v21
+  mov.16b v13, v9
   adds x1, x5, x1
   cinc x5, x6, hs
-  fmla.2d v11, v6, v10
+  fmla.2d v13, v6, v12
   mul x6, x7, x4
-  fsub.2d v12, v22, v11
-  fmla.2d v12, v6, v10
+  fsub.2d v14, v10, v13
+  fmla.2d v14, v6, v12
   umulh x4, x7, x4
-  add.2d v2, v2, v11
+  add.2d v2, v2, v13
   adds x5, x6, x5
   cinc x4, x4, hs
-  add.2d v1, v1, v12
+  add.2d v1, v1, v14
   adds x2, x5, x2
   cinc x4, x4, hs
   mov x5, #31276
@@ -510,17 +510,17 @@
   mov x4, #2
   movk x5, #17182, lsl 48
   movk x4, #57344, lsl 16
-  dup.2d v10, x5
-  mov.16b v11, v21
+  dup.2d v12, x5
+  mov.16b v13, v9
   movk x4, #60199, lsl 32
-  fmla.2d v11, v6, v10
+  fmla.2d v13, v6, v12
   movk x4, #34755, lsl 48
-  fsub.2d v12, v22, v11
+  fsub.2d v14, v10, v13
   mov x5, #57634
-  fmla.2d v12, v6, v10
-  add.2d v5, v5, v11
+  fmla.2d v14, v6, v12
+  add.2d v5, v5, v13
   movk x5, #62322, lsl 16
-  add.2d v2, v2, v12
+  add.2d v2, v2, v14
   movk x5, #53392, lsl 32
   mov x6, #28672
   movk x5, #20583, lsl 48
@@ -529,17 +529,17 @@
   mov x7, #45242
   movk x6, #17064, lsl 48
   movk x7, #770, lsl 16
-  dup.2d v10, x6
-  mov.16b v11, v21
+  dup.2d v12, x6
+  mov.16b v13, v9
   movk x7, #35693, lsl 32
-  fmla.2d v11, v6, v10
+  fmla.2d v13, v6, v12
   movk x7, #28832, lsl 48
-  fsub.2d v12, v22, v11
+  fsub.2d v14, v10, v13
   mov x6, #16467
-  fmla.2d v12, v6, v10
-  add.2d v3, v3, v11
+  fmla.2d v14, v6, v12
+  add.2d v3, v3, v13
   movk x6, #49763, lsl 16
-  add.2d v5, v5, v12
+  add.2d v5, v5, v14
   movk x6, #40165, lsl 32
   ucvtf.2d v6, v7
   movk x6, #24776, lsl 48
@@ -558,17 +558,17 @@
   movk x17, #17133, lsl 48
   mul x4, x8, x12
   dup.2d v7, x17
-  mov.16b v10, v21
+  mov.16b v12, v9
   umulh x5, x8, x12
-  fmla.2d v10, v6, v7
+  fmla.2d v12, v6, v7
   mul x6, x9, x12
-  fsub.2d v11, v22, v10
+  fsub.2d v13, v10, v12
   umulh x7, x9, x12
-  fmla.2d v11, v6, v7
-  add.2d v0, v0, v10
+  fmla.2d v13, v6, v7
+  add.2d v0, v0, v12
   adds x5, x6, x5
   cinc x6, x7, hs
-  add.2d v4, v4, v11
+  add.2d v4, v4, v13
   mul x7, x10, x12
   mov x17, #47492
   umulh x20, x10, x12
@@ -579,17 +579,17 @@
   movk x17, #17168, lsl 48
   mul x20, x11, x12
   dup.2d v7, x17
-  mov.16b v10, v21
+  mov.16b v12, v9
   umulh x12, x11, x12
-  fmla.2d v10, v6, v7
+  fmla.2d v12, v6, v7
   adds x7, x20, x7
   cinc x12, x12, hs
-  fsub.2d v11, v22, v10
+  fsub.2d v13, v10, v12
   mul x17, x8, x13
-  fmla.2d v11, v6, v7
-  add.2d v1, v1, v10
+  fmla.2d v13, v6, v7
+  add.2d v1, v1, v12
   umulh x20, x8, x13
-  add.2d v0, v0, v11
+  add.2d v0, v0, v13
   adds x5, x17, x5
   cinc x17, x20, hs
   mov x20, #57936
@@ -603,16 +603,16 @@
   dup.2d v7, x20
   adds x6, x17, x6
   cinc x17, x21, hs
-  mov.16b v10, v21
-  fmla.2d v10, v6, v7
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
   mul x20, x10, x13
-  fsub.2d v11, v22, v10
+  fsub.2d v13, v10, v12
   umulh x21, x10, x13
-  fmla.2d v11, v6, v7
+  fmla.2d v13, v6, v7
   adds x17, x20, x17
   cinc x20, x21, hs
-  add.2d v2, v2, v10
-  add.2d v1, v1, v11
+  add.2d v2, v2, v12
+  add.2d v1, v1, v13
   adds x7, x17, x7
   cinc x17, x20, hs
   mov x20, #17708
@@ -626,16 +626,16 @@
   dup.2d v7, x20
   adds x12, x17, x12
   cinc x13, x13, hs
-  mov.16b v10, v21
+  mov.16b v12, v9
   mul x17, x8, x14
-  fmla.2d v10, v6, v7
-  fsub.2d v11, v22, v10
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
   umulh x20, x8, x14
-  fmla.2d v11, v6, v7
+  fmla.2d v13, v6, v7
   adds x6, x17, x6
   cinc x17, x20, hs
-  add.2d v5, v5, v10
-  add.2d v2, v2, v11
+  add.2d v5, v5, v12
+  add.2d v2, v2, v13
   mul x20, x9, x14
   mov x21, #29184
   umulh x22, x9, x14
@@ -648,19 +648,19 @@
   cinc x17, x20, hs
   dup.2d v7, x21
   mul x20, x10, x14
-  mov.16b v10, v21
+  mov.16b v12, v9
   umulh x21, x10, x14
-  fmla.2d v10, v6, v7
-  fsub.2d v11, v22, v10
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
   adds x17, x20, x17
   cinc x20, x21, hs
-  fmla.2d v11, v6, v7
+  fmla.2d v13, v6, v7
   adds x12, x17, x12
   cinc x17, x20, hs
-  add.2d v3, v3, v10
+  add.2d v3, v3, v12
   mul x20, x11, x14
-  add.2d v5, v5, v11
-  ucvtf.2d v6, v9
+  add.2d v5, v5, v13
+  ucvtf.2d v6, v11
   umulh x14, x11, x14
   mov x21, #58856
   adds x17, x20, x17
@@ -673,18 +673,18 @@
   mul x17, x8, x15
   dup.2d v7, x21
   umulh x8, x8, x15
-  mov.16b v9, v21
+  mov.16b v11, v9
   adds x7, x17, x7
   cinc x8, x8, hs
-  fmla.2d v9, v6, v7
-  fsub.2d v10, v22, v9
+  fmla.2d v11, v6, v7
+  fsub.2d v12, v10, v11
   mul x17, x9, x15
-  fmla.2d v10, v6, v7
+  fmla.2d v12, v6, v7
   umulh x9, x9, x15
-  add.2d v0, v0, v9
+  add.2d v0, v0, v11
   adds x8, x17, x8
   cinc x9, x9, hs
-  add.2d v4, v4, v10
+  add.2d v4, v4, v12
   mov x17, #35392
   adds x8, x8, x12
   cinc x9, x9, hs
@@ -696,18 +696,18 @@
   dup.2d v7, x17
   adds x9, x12, x9
   cinc x10, x10, hs
-  mov.16b v9, v21
+  mov.16b v11, v9
   adds x9, x9, x13
   cinc x10, x10, hs
-  fmla.2d v9, v6, v7
-  fsub.2d v10, v22, v9
+  fmla.2d v11, v6, v7
+  fsub.2d v12, v10, v11
   mul x12, x11, x15
-  fmla.2d v10, v6, v7
+  fmla.2d v12, v6, v7
   umulh x11, x11, x15
-  add.2d v1, v1, v9
+  add.2d v1, v1, v11
   adds x10, x12, x10
   cinc x11, x11, hs
-  add.2d v0, v0, v10
+  add.2d v0, v0, v12
   mov x12, #9848
   adds x10, x10, x14
   cinc x11, x11, hs
@@ -718,16 +718,16 @@
   movk x12, #17170, lsl 48
   dup.2d v7, x12
   movk x13, #45078, lsl 32
-  mov.16b v9, v21
+  mov.16b v11, v9
   movk x13, #39852, lsl 48
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   mov x12, #16676
-  fsub.2d v10, v22, v9
-  fmla.2d v10, v6, v7
+  fsub.2d v12, v10, v11
+  fmla.2d v12, v6, v7
   movk x12, #12692, lsl 16
-  add.2d v2, v2, v9
+  add.2d v2, v2, v11
   movk x12, #20986, lsl 32
-  add.2d v1, v1, v10
+  add.2d v1, v1, v12
   movk x12, #2848, lsl 48
   mov x14, #9584
   movk x14, #63883, lsl 16
@@ -737,16 +737,16 @@
   movk x14, #17190, lsl 48
   movk x15, #61092, lsl 32
   dup.2d v7, x14
-  mov.16b v9, v21
+  mov.16b v11, v9
   movk x15, #45156, lsl 48
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   mov x14, #3197
-  fsub.2d v10, v22, v9
-  fmla.2d v10, v6, v7
+  fsub.2d v12, v10, v11
+  fmla.2d v12, v6, v7
   movk x14, #18936, lsl 16
-  add.2d v5, v5, v9
+  add.2d v5, v5, v11
   movk x14, #10922, lsl 32
-  add.2d v2, v2, v10
+  add.2d v2, v2, v12
   movk x14, #11014, lsl 48
   mov x17, #51712
   movk x17, #16093, lsl 16
@@ -757,18 +757,18 @@
   adds x7, x20, x7
   cinc x13, x13, hs
   dup.2d v7, x17
-  mov.16b v9, v21
+  mov.16b v11, v9
   mul x17, x12, x4
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   umulh x12, x12, x4
-  fsub.2d v10, v22, v9
+  fsub.2d v12, v10, v11
   adds x13, x17, x13
   cinc x12, x12, hs
-  fmla.2d v10, v6, v7
-  add.2d v3, v3, v9
+  fmla.2d v12, v6, v7
+  add.2d v3, v3, v11
   adds x8, x13, x8
   cinc x12, x12, hs
-  add.2d v5, v5, v10
+  add.2d v5, v5, v12
   mul x13, x15, x4
   ucvtf.2d v6, v8
   umulh x15, x15, x4
@@ -782,18 +782,18 @@
   movk x17, #17184, lsl 48
   mul x13, x14, x4
   dup.2d v7, x17
-  mov.16b v8, v21
+  mov.16b v8, v9
   umulh x4, x14, x4
   fmla.2d v8, v6, v7
   adds x12, x13, x12
   cinc x4, x4, hs
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   adds x10, x12, x10
   cinc x4, x4, hs
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v0, v0, v8
   add x4, x11, x4
-  add.2d v4, v4, v9
+  add.2d v4, v4, v11
   mov x11, #56431
   mov x12, #25532
   movk x12, #31025, lsl 16
@@ -803,16 +803,16 @@
   movk x12, #17199, lsl 48
   movk x11, #6382, lsl 48
   dup.2d v7, x12
-  mov.16b v8, v21
+  mov.16b v8, v9
   mov x12, #59151
   fmla.2d v8, v6, v7
   movk x12, #41769, lsl 16
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   movk x12, #32276, lsl 32
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v1, v1, v8
   movk x12, #21677, lsl 48
-  add.2d v0, v0, v9
+  add.2d v0, v0, v11
   mov x13, #34015
   mov x14, #18830
   movk x13, #20342, lsl 16
@@ -823,15 +823,15 @@
   movk x13, #11030, lsl 48
   dup.2d v7, x14
   mov x14, #13689
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
   movk x14, #8159, lsl 16
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   movk x14, #215, lsl 32
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   movk x14, #4913, lsl 48
   add.2d v2, v2, v8
-  add.2d v1, v1, v9
+  add.2d v1, v1, v11
   mul x15, x11, x5
   mov x17, #21566
   umulh x11, x11, x5
@@ -843,17 +843,17 @@
   mul x15, x12, x5
   dup.2d v7, x17
   umulh x12, x12, x5
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
   adds x11, x15, x11
   cinc x12, x12, hs
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   adds x8, x11, x8
   cinc x11, x12, hs
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   mul x12, x13, x5
   add.2d v5, v5, v8
-  add.2d v2, v2, v9
+  add.2d v2, v2, v11
   umulh x13, x13, x5
   mov x15, #3072
   adds x11, x12, x11
@@ -866,18 +866,18 @@
   mul x12, x14, x5
   dup.2d v7, x15
   umulh x5, x14, x5
-  mov.16b v8, v21
+  mov.16b v8, v9
   adds x11, x12, x11
   cinc x5, x5, hs
   fmla.2d v8, v6, v7
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   adds x10, x11, x10
   cinc x5, x5, hs
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add x4, x4, x5
   add.2d v3, v3, v8
   mov x5, #61005
-  add.2d v5, v5, v9
+  add.2d v5, v5, v11
   mov x11, #65535
   movk x5, #58262, lsl 16
   movk x11, #61439, lsl 16
@@ -907,16 +907,16 @@
   movk x11, #17151, lsl 48
   dup.2d v7, x11
   mov x11, #36612
-  mov.16b v8, v21
+  mov.16b v8, v9
   movk x11, #63402, lsl 16
   fmla.2d v8, v6, v7
   movk x11, #47623, lsl 32
-  fsub.2d v9, v22, v8
-  fmla.2d v9, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
   movk x11, #9430, lsl 48
   add.2d v0, v0, v8
   mul x12, x5, x6
-  add.2d v4, v4, v9
+  add.2d v4, v4, v11
   umulh x5, x5, x6
   mov x15, #20728
   movk x15, #23588, lsl 16
@@ -927,18 +927,18 @@
   movk x15, #17170, lsl 48
   umulh x13, x13, x6
   dup.2d v7, x15
-  mov.16b v8, v21
+  mov.16b v8, v9
   adds x5, x12, x5
   cinc x12, x13, hs
   fmla.2d v8, v6, v7
   adds x5, x5, x8
   cinc x8, x12, hs
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   mul x12, x14, x6
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v1, v1, v8
   umulh x13, x14, x6
-  add.2d v0, v0, v9
+  add.2d v0, v0, v11
   adds x8, x12, x8
   cinc x12, x13, hs
   mov x13, #16000
@@ -950,18 +950,18 @@
   movk x13, #17144, lsl 48
   umulh x6, x11, x6
   dup.2d v7, x13
-  mov.16b v8, v21
+  mov.16b v8, v9
   adds x9, x12, x9
   cinc x6, x6, hs
   fmla.2d v8, v6, v7
   adds x9, x9, x10
   cinc x6, x6, hs
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   add x4, x4, x6
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   add.2d v2, v2, v8
   mov x6, #65535
-  add.2d v1, v1, v9
+  add.2d v1, v1, v11
   movk x6, #61439, lsl 16
   mov x10, #46800
   movk x6, #62867, lsl 32
@@ -972,15 +972,15 @@
   mul x6, x6, x7
   dup.2d v7, x10
   mov x10, #1
-  mov.16b v8, v21
+  mov.16b v8, v9
   fmla.2d v8, v6, v7
   movk x10, #61440, lsl 16
-  fsub.2d v9, v22, v8
+  fsub.2d v11, v10, v8
   movk x10, #62867, lsl 32
-  fmla.2d v9, v6, v7
+  fmla.2d v11, v6, v7
   movk x10, #17377, lsl 48
   add.2d v5, v5, v8
-  add.2d v2, v2, v9
+  add.2d v2, v2, v11
   mov x11, #28817
   mov x12, #39040
   movk x11, #31161, lsl 16
@@ -991,10 +991,10 @@
   movk x11, #10291, lsl 48
   dup.2d v7, x12
   mov x12, #22621
-  mov.16b v8, v21
+  mov.16b v8, v9
   movk x12, #33153, lsl 16
   fmla.2d v8, v6, v7
-  fsub.2d v9, v22, v8
+  fsub.2d v9, v10, v8
   movk x12, #17846, lsl 32
   fmla.2d v9, v6, v7
   movk x12, #47184, lsl 48

--- a/block-multiplier/src/aarch64/montgomery_square_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_square_interleaved_3.s
@@ -1,0 +1,764 @@
+// GENERATED FILE, DO NOT EDIT!
+// in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+// in("v0") av[0], in("v1") av[1], in("v2") av[2], in("v3") av[3],
+// lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3") out[3],
+// lateout("v0") outv[0], lateout("v1") outv[1], lateout("v2") outv[2], lateout("v3") outv[3],
+// lateout("x4") _, lateout("x5") _, lateout("x6") _, lateout("x7") _, lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _, lateout("x17") _, lateout("v4") _, lateout("v5") _, lateout("v6") _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _, lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _, lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _, lateout("v19") _,
+// lateout("lr") _
+  mov x4, #4503599627370495
+  dup.2d v4, x4
+  mul x5, x0, x0
+  mov x6, #5075556780046548992
+  dup.2d v5, x6
+  mov x6, #1
+  umulh x7, x0, x0
+  movk x6, #18032, lsl 48
+  dup.2d v6, x6
+  mul x6, x0, x1
+  shl.2d v7, v1, #14
+  shl.2d v8, v2, #26
+  shl.2d v9, v3, #38
+  umulh x8, x0, x1
+  ushr.2d v3, v3, #14
+  shl.2d v10, v0, #2
+  adds x7, x6, x7
+  cinc x9, x8, hs
+  usra.2d v7, v0, #50
+  usra.2d v8, v1, #38
+  usra.2d v9, v2, #26
+  mul x10, x0, x2
+  and.16b v0, v10, v4
+  and.16b v1, v7, v4
+  and.16b v2, v8, v4
+  umulh x11, x0, x2
+  and.16b v7, v9, v4
+  mov x12, #13605374474286268416
+  adds x9, x10, x9
+  cinc x13, x11, hs
+  dup.2d v8, x12
+  mov x12, #6440147467139809280
+  dup.2d v9, x12
+  mul x12, x0, x3
+  mov x14, #3688448094816436224
+  dup.2d v10, x14
+  umulh x0, x0, x3
+  mov x14, #9209861237972664320
+  dup.2d v11, x14
+  mov x14, #12218265789056155648
+  adds x13, x12, x13
+  cinc x15, x0, hs
+  dup.2d v12, x14
+  mov x14, #17739678932212383744
+  adds x6, x6, x7
+  cinc x7, x8, hs
+  dup.2d v13, x14
+  mov x8, #2301339409586323456
+  dup.2d v14, x8
+  mul x8, x1, x1
+  mov x14, #7822752552742551552
+  dup.2d v15, x14
+  mov x14, #5071053180419178496
+  umulh x16, x1, x1
+  dup.2d v16, x14
+  mov x14, #16352570246982270976
+  adds x7, x8, x7
+  cinc x8, x16, hs
+  dup.2d v17, x14
+  ucvtf.2d v0, v0
+  ucvtf.2d v1, v1
+  adds x7, x7, x9
+  cinc x8, x8, hs
+  ucvtf.2d v2, v2
+  ucvtf.2d v7, v7
+  mul x9, x1, x2
+  ucvtf.2d v3, v3
+  mov.16b v18, v5
+  fmla.2d v18, v0, v0
+  umulh x14, x1, x2
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v0
+  adds x8, x9, x8
+  cinc x16, x14, hs
+  add.2d v10, v10, v18
+  add.2d v8, v8, v19
+  mov.16b v18, v5
+  adds x8, x8, x13
+  cinc x13, x16, hs
+  fmla.2d v18, v0, v1
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v1
+  mul x16, x1, x3
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  umulh x1, x1, x3
+  add.2d v12, v12, v18
+  add.2d v10, v10, v19
+  mov.16b v18, v5
+  adds x13, x16, x13
+  cinc x17, x1, hs
+  fmla.2d v18, v0, v2
+  fsub.2d v19, v6, v18
+  adds x13, x13, x15
+  cinc x15, x17, hs
+  fmla.2d v19, v0, v2
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  adds x7, x10, x7
+  cinc x10, x11, hs
+  add.2d v14, v14, v18
+  add.2d v12, v12, v19
+  adds x9, x9, x10
+  cinc x10, x14, hs
+  mov.16b v18, v5
+  fmla.2d v18, v0, v7
+  fsub.2d v19, v6, v18
+  adds x8, x9, x8
+  cinc x9, x10, hs
+  fmla.2d v19, v0, v7
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  mul x10, x2, x2
+  add.2d v16, v16, v18
+  add.2d v14, v14, v19
+  umulh x11, x2, x2
+  mov.16b v18, v5
+  fmla.2d v18, v0, v3
+  fsub.2d v19, v6, v18
+  adds x9, x10, x9
+  cinc x10, x11, hs
+  fmla.2d v19, v0, v3
+  add.2d v0, v18, v18
+  adds x9, x9, x13
+  cinc x10, x10, hs
+  add.2d v18, v19, v19
+  add.2d v0, v17, v0
+  add.2d v16, v16, v18
+  mul x11, x2, x3
+  mov.16b v17, v5
+  fmla.2d v17, v1, v1
+  umulh x2, x2, x3
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v1
+  add.2d v14, v14, v17
+  adds x10, x11, x10
+  cinc x13, x2, hs
+  add.2d v12, v12, v18
+  mov.16b v17, v5
+  fmla.2d v17, v1, v2
+  adds x10, x10, x15
+  cinc x13, x13, hs
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v2
+  adds x8, x12, x8
+  cinc x0, x0, hs
+  add.2d v17, v17, v17
+  add.2d v18, v18, v18
+  add.2d v16, v16, v17
+  adds x0, x16, x0
+  cinc x1, x1, hs
+  add.2d v14, v14, v18
+  mov.16b v17, v5
+  adds x0, x0, x9
+  cinc x1, x1, hs
+  fmla.2d v17, v1, v7
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v7
+  adds x1, x11, x1
+  cinc x2, x2, hs
+  add.2d v17, v17, v17
+  add.2d v18, v18, v18
+  adds x1, x1, x10
+  cinc x2, x2, hs
+  add.2d v0, v0, v17
+  add.2d v16, v16, v18
+  mov.16b v17, v5
+  mul x9, x3, x3
+  fmla.2d v17, v1, v3
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v3
+  umulh x3, x3, x3
+  add.2d v1, v17, v17
+  add.2d v17, v18, v18
+  adds x2, x9, x2
+  cinc x3, x3, hs
+  add.2d v1, v15, v1
+  add.2d v0, v0, v17
+  mov.16b v15, v5
+  adds x2, x2, x13
+  cinc x3, x3, hs
+  fmla.2d v15, v2, v2
+  fsub.2d v17, v6, v15
+  mov x9, #48718
+  fmla.2d v17, v2, v2
+  add.2d v0, v0, v15
+  add.2d v15, v16, v17
+  movk x9, #4732, lsl 16
+  mov.16b v16, v5
+  fmla.2d v16, v2, v7
+  movk x9, #45078, lsl 32
+  fsub.2d v17, v6, v16
+  fmla.2d v17, v2, v7
+  add.2d v16, v16, v16
+  movk x9, #39852, lsl 48
+  add.2d v17, v17, v17
+  add.2d v1, v1, v16
+  add.2d v0, v0, v17
+  mov x10, #16676
+  mov.16b v16, v5
+  fmla.2d v16, v2, v3
+  movk x10, #12692, lsl 16
+  fsub.2d v17, v6, v16
+  fmla.2d v17, v2, v3
+  add.2d v2, v16, v16
+  movk x10, #20986, lsl 32
+  add.2d v16, v17, v17
+  add.2d v2, v13, v2
+  movk x10, #2848, lsl 48
+  add.2d v1, v1, v16
+  mov.16b v13, v5
+  fmla.2d v13, v7, v7
+  mov x11, #51052
+  fsub.2d v16, v6, v13
+  fmla.2d v16, v7, v7
+  add.2d v2, v2, v13
+  movk x11, #24721, lsl 16
+  add.2d v1, v1, v16
+  mov.16b v13, v5
+  movk x11, #61092, lsl 32
+  fmla.2d v13, v7, v3
+  fsub.2d v16, v6, v13
+  fmla.2d v16, v7, v3
+  movk x11, #45156, lsl 48
+  add.2d v7, v13, v13
+  add.2d v13, v16, v16
+  mov x12, #3197
+  add.2d v7, v11, v7
+  add.2d v2, v2, v13
+  mov.16b v11, v5
+  movk x12, #18936, lsl 16
+  fmla.2d v11, v3, v3
+  fsub.2d v13, v6, v11
+  movk x12, #10922, lsl 32
+  fmla.2d v13, v3, v3
+  add.2d v3, v9, v11
+  add.2d v7, v7, v13
+  movk x12, #11014, lsl 48
+  usra.2d v10, v8, #52
+  usra.2d v12, v10, #52
+  usra.2d v14, v12, #52
+  mul x13, x9, x5
+  usra.2d v15, v14, #52
+  and.16b v8, v8, v4
+  umulh x9, x9, x5
+  and.16b v9, v10, v4
+  and.16b v10, v12, v4
+  and.16b v4, v14, v4
+  adds x8, x13, x8
+  cinc x9, x9, hs
+  ucvtf.2d v8, v8
+  mov x13, #37864
+  mul x14, x10, x5
+  movk x13, #1815, lsl 16
+  movk x13, #28960, lsl 32
+  movk x13, #17153, lsl 48
+  umulh x10, x10, x5
+  dup.2d v11, x13
+  mov.16b v12, v5
+  adds x9, x14, x9
+  cinc x10, x10, hs
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v11
+  adds x0, x9, x0
+  cinc x9, x10, hs
+  add.2d v0, v0, v12
+  add.2d v11, v15, v13
+  mov x10, #46128
+  mul x13, x11, x5
+  movk x10, #29964, lsl 16
+  movk x10, #7587, lsl 32
+  umulh x11, x11, x5
+  movk x10, #17161, lsl 48
+  dup.2d v12, x10
+  mov.16b v13, v5
+  adds x9, x13, x9
+  cinc x10, x11, hs
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  adds x1, x9, x1
+  cinc x9, x10, hs
+  fmla.2d v14, v8, v12
+  add.2d v1, v1, v13
+  add.2d v0, v0, v14
+  mul x10, x12, x5
+  mov x11, #52826
+  movk x11, #57790, lsl 16
+  umulh x5, x12, x5
+  movk x11, #55431, lsl 32
+  movk x11, #17196, lsl 48
+  dup.2d v12, x11
+  adds x9, x10, x9
+  cinc x5, x5, hs
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  adds x2, x9, x2
+  cinc x5, x5, hs
+  fmla.2d v14, v8, v12
+  add.2d v2, v2, v13
+  add x3, x3, x5
+  add.2d v1, v1, v14
+  mov x5, #31276
+  movk x5, #21262, lsl 16
+  mov x9, #56431
+  movk x5, #2304, lsl 32
+  movk x5, #17182, lsl 48
+  movk x9, #30457, lsl 16
+  dup.2d v12, x5
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  movk x9, #30012, lsl 32
+  fsub.2d v14, v6, v13
+  fmla.2d v14, v8, v12
+  movk x9, #6382, lsl 48
+  add.2d v7, v7, v13
+  add.2d v2, v2, v14
+  mov x5, #28672
+  mov x10, #59151
+  movk x5, #24515, lsl 16
+  movk x5, #54929, lsl 32
+  movk x5, #17064, lsl 48
+  movk x10, #41769, lsl 16
+  dup.2d v12, x5
+  mov.16b v13, v5
+  movk x10, #32276, lsl 32
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  fmla.2d v14, v8, v12
+  movk x10, #21677, lsl 48
+  add.2d v3, v3, v13
+  add.2d v7, v7, v14
+  mov x5, #34015
+  ucvtf.2d v8, v9
+  mov x11, #44768
+  movk x11, #51919, lsl 16
+  movk x5, #20342, lsl 16
+  movk x11, #6346, lsl 32
+  movk x11, #17133, lsl 48
+  movk x5, #13935, lsl 32
+  dup.2d v9, x11
+  mov.16b v12, v5
+  fmla.2d v12, v8, v9
+  movk x5, #11030, lsl 48
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v9
+  add.2d v0, v0, v12
+  mov x11, #13689
+  add.2d v9, v11, v13
+  mov x12, #47492
+  movk x11, #8159, lsl 16
+  movk x12, #23630, lsl 16
+  movk x12, #49985, lsl 32
+  movk x12, #17168, lsl 48
+  movk x11, #215, lsl 32
+  dup.2d v11, x12
+  mov.16b v12, v5
+  movk x11, #4913, lsl 48
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v11
+  mul x12, x9, x6
+  add.2d v1, v1, v12
+  add.2d v0, v0, v13
+  umulh x9, x9, x6
+  mov x13, #57936
+  movk x13, #54828, lsl 16
+  movk x13, #18292, lsl 32
+  adds x8, x12, x8
+  cinc x9, x9, hs
+  movk x13, #17197, lsl 48
+  dup.2d v11, x13
+  mov.16b v12, v5
+  mul x12, x10, x6
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  umulh x10, x10, x6
+  fmla.2d v13, v8, v11
+  add.2d v2, v2, v12
+  add.2d v1, v1, v13
+  adds x9, x12, x9
+  cinc x10, x10, hs
+  mov x12, #17708
+  movk x12, #43915, lsl 16
+  adds x0, x9, x0
+  cinc x9, x10, hs
+  movk x12, #64348, lsl 32
+  movk x12, #17188, lsl 48
+  dup.2d v11, x12
+  mul x10, x5, x6
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  umulh x5, x5, x6
+  fmla.2d v13, v8, v11
+  add.2d v7, v7, v12
+  adds x9, x10, x9
+  cinc x5, x5, hs
+  add.2d v2, v2, v13
+  mov x10, #29184
+  movk x10, #20789, lsl 16
+  adds x1, x9, x1
+  cinc x5, x5, hs
+  movk x10, #19197, lsl 32
+  movk x10, #17083, lsl 48
+  mul x9, x11, x6
+  dup.2d v11, x10
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  umulh x6, x11, x6
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v11
+  adds x5, x9, x5
+  cinc x6, x6, hs
+  add.2d v3, v3, v12
+  add.2d v7, v7, v13
+  ucvtf.2d v8, v10
+  adds x2, x5, x2
+  cinc x5, x6, hs
+  mov x6, #58856
+  movk x6, #14953, lsl 16
+  movk x6, #15155, lsl 32
+  add x3, x3, x5
+  movk x6, #17181, lsl 48
+  dup.2d v10, x6
+  mov x5, #61005
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  movk x5, #58262, lsl 16
+  fmla.2d v12, v8, v10
+  add.2d v0, v0, v11
+  movk x5, #32851, lsl 32
+  add.2d v9, v9, v12
+  mov x6, #35392
+  movk x6, #12477, lsl 16
+  movk x5, #11582, lsl 48
+  movk x6, #56780, lsl 32
+  movk x6, #17142, lsl 48
+  mov x9, #37581
+  dup.2d v10, x6
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  movk x9, #43836, lsl 16
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  movk x9, #36286, lsl 32
+  add.2d v0, v0, v12
+  mov x6, #9848
+  movk x9, #51783, lsl 48
+  movk x6, #54501, lsl 16
+  movk x6, #31540, lsl 32
+  movk x6, #17170, lsl 48
+  mov x10, #10899
+  dup.2d v10, x6
+  mov.16b v11, v5
+  movk x10, #30709, lsl 16
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  movk x10, #61551, lsl 32
+  add.2d v2, v2, v11
+  add.2d v1, v1, v12
+  movk x10, #45784, lsl 48
+  mov x6, #9584
+  movk x6, #63883, lsl 16
+  movk x6, #18253, lsl 32
+  mov x11, #36612
+  movk x6, #17190, lsl 48
+  dup.2d v10, x6
+  mov.16b v11, v5
+  movk x11, #63402, lsl 16
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  movk x11, #47623, lsl 32
+  fmla.2d v12, v8, v10
+  add.2d v7, v7, v11
+  add.2d v2, v2, v12
+  movk x11, #9430, lsl 48
+  mov x6, #51712
+  movk x6, #16093, lsl 16
+  mul x12, x5, x7
+  movk x6, #30633, lsl 32
+  movk x6, #17068, lsl 48
+  dup.2d v10, x6
+  umulh x5, x5, x7
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  adds x6, x12, x8
+  cinc x5, x5, hs
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  add.2d v3, v3, v11
+  mul x8, x9, x7
+  add.2d v7, v7, v12
+  ucvtf.2d v4, v4
+  mov x12, #34724
+  umulh x9, x9, x7
+  movk x12, #40393, lsl 16
+  movk x12, #23752, lsl 32
+  adds x5, x8, x5
+  cinc x8, x9, hs
+  movk x12, #17184, lsl 48
+  dup.2d v8, x12
+  mov.16b v10, v5
+  adds x0, x5, x0
+  cinc x5, x8, hs
+  fmla.2d v10, v4, v8
+  fsub.2d v11, v6, v10
+  mul x8, x10, x7
+  fmla.2d v11, v4, v8
+  add.2d v0, v0, v10
+  add.2d v8, v9, v11
+  umulh x9, x10, x7
+  mov x10, #25532
+  movk x10, #31025, lsl 16
+  adds x5, x8, x5
+  cinc x8, x9, hs
+  movk x10, #10002, lsl 32
+  movk x10, #17199, lsl 48
+  dup.2d v9, x10
+  adds x1, x5, x1
+  cinc x5, x8, hs
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  mul x8, x11, x7
+  fmla.2d v11, v4, v9
+  add.2d v1, v1, v10
+  umulh x7, x11, x7
+  add.2d v0, v0, v11
+  mov x9, #18830
+  movk x9, #2465, lsl 16
+  adds x5, x8, x5
+  cinc x7, x7, hs
+  movk x9, #36348, lsl 32
+  movk x9, #17194, lsl 48
+  adds x2, x5, x2
+  cinc x5, x7, hs
+  dup.2d v9, x9
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  add x3, x3, x5
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  mov x5, #65535
+  add.2d v2, v2, v10
+  add.2d v1, v1, v11
+  mov x7, #21566
+  movk x5, #61439, lsl 16
+  movk x7, #43708, lsl 16
+  movk x7, #57685, lsl 32
+  movk x7, #17185, lsl 48
+  movk x5, #62867, lsl 32
+  dup.2d v9, x7
+  mov.16b v10, v5
+  movk x5, #49889, lsl 48
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  mul x5, x5, x6
+  add.2d v7, v7, v10
+  add.2d v2, v2, v11
+  mov x7, #1
+  mov x8, #3072
+  movk x8, #8058, lsl 16
+  movk x8, #46097, lsl 32
+  movk x7, #61440, lsl 16
+  movk x8, #17047, lsl 48
+  dup.2d v9, x8
+  mov.16b v10, v5
+  movk x7, #62867, lsl 32
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  movk x7, #17377, lsl 48
+  fmla.2d v11, v4, v9
+  add.2d v3, v3, v10
+  add.2d v4, v7, v11
+  mov x8, #28817
+  mov x9, #65535
+  movk x9, #61439, lsl 16
+  movk x8, #31161, lsl 16
+  movk x9, #62867, lsl 32
+  movk x9, #1, lsl 48
+  umov x10, v8.d[0]
+  movk x8, #59464, lsl 32
+  umov x11, v8.d[1]
+  mul x10, x10, x9
+  movk x8, #10291, lsl 48
+  mul x9, x11, x9
+  and x10, x10, x4
+  and x4, x9, x4
+  mov x9, #22621
+  ins v7.d[0], x10
+  ins v7.d[1], x4
+  ucvtf.2d v7, v7
+  mov x4, #16
+  movk x9, #33153, lsl 16
+  movk x4, #22847, lsl 32
+  movk x4, #17151, lsl 48
+  movk x9, #17846, lsl 32
+  dup.2d v9, x4
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  movk x9, #47184, lsl 48
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  mov x4, #41001
+  add.2d v0, v0, v10
+  add.2d v8, v8, v11
+  mov x10, #20728
+  movk x4, #57649, lsl 16
+  movk x10, #23588, lsl 16
+  movk x10, #7790, lsl 32
+  movk x4, #20082, lsl 32
+  movk x10, #17170, lsl 48
+  dup.2d v9, x10
+  mov.16b v10, v5
+  movk x4, #12388, lsl 48
+  fmla.2d v10, v7, v9
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  mul x10, x7, x5
+  add.2d v1, v1, v10
+  add.2d v0, v0, v11
+  umulh x7, x7, x5
+  mov x11, #16000
+  movk x11, #53891, lsl 16
+  movk x11, #5509, lsl 32
+  cmn x10, x6
+  cinc x7, x7, hs
+  movk x11, #17144, lsl 48
+  dup.2d v9, x11
+  mul x6, x8, x5
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  fsub.2d v11, v6, v10
+  umulh x8, x8, x5
+  fmla.2d v11, v7, v9
+  add.2d v2, v2, v10
+  adds x6, x6, x7
+  cinc x7, x8, hs
+  add.2d v1, v1, v11
+  mov x8, #46800
+  movk x8, #2568, lsl 16
+  adds x0, x6, x0
+  cinc x6, x7, hs
+  movk x8, #1335, lsl 32
+  movk x8, #17188, lsl 48
+  dup.2d v9, x8
+  mul x7, x9, x5
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  umulh x8, x9, x5
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  add.2d v4, v4, v10
+  adds x6, x7, x6
+  cinc x7, x8, hs
+  add.2d v2, v2, v11
+  mov x8, #39040
+  adds x1, x6, x1
+  cinc x6, x7, hs
+  movk x8, #14704, lsl 16
+  movk x8, #12839, lsl 32
+  movk x8, #17096, lsl 48
+  mul x7, x4, x5
+  dup.2d v9, x8
+  mov.16b v5, v5
+  umulh x4, x4, x5
+  fmla.2d v5, v7, v9
+  fsub.2d v6, v6, v5
+  fmla.2d v6, v7, v9
+  adds x5, x7, x6
+  cinc x4, x4, hs
+  add.2d v3, v3, v5
+  add.2d v4, v4, v6
+  mov x6, #140737488355328
+  adds x2, x5, x2
+  cinc x4, x4, hs
+  dup.2d v5, x6
+  and.16b v5, v3, v5
+  add x3, x3, x4
+  cmeq.2d v5, v5, #0
+  mov x4, #2
+  movk x4, #57344, lsl 16
+  mov x5, #2
+  movk x4, #60199, lsl 32
+  movk x4, #3, lsl 48
+  movk x5, #57344, lsl 16
+  dup.2d v6, x4
+  bic.16b v6, v6, v5
+  mov x4, #10364
+  movk x5, #60199, lsl 32
+  movk x4, #11794, lsl 16
+  movk x4, #3895, lsl 32
+  movk x5, #34755, lsl 48
+  movk x4, #9, lsl 48
+  dup.2d v7, x4
+  bic.16b v7, v7, v5
+  mov x4, #57634
+  mov x6, #26576
+  movk x6, #47696, lsl 16
+  movk x6, #688, lsl 32
+  movk x4, #62322, lsl 16
+  movk x6, #3, lsl 48
+  dup.2d v9, x6
+  movk x4, #53392, lsl 32
+  bic.16b v9, v9, v5
+  mov x6, #46800
+  movk x6, #2568, lsl 16
+  movk x4, #20583, lsl 48
+  movk x6, #1335, lsl 32
+  movk x6, #4, lsl 48
+  mov x7, #45242
+  dup.2d v10, x6
+  bic.16b v10, v10, v5
+  mov x6, #49763
+  movk x7, #770, lsl 16
+  movk x6, #40165, lsl 16
+  movk x6, #24776, lsl 32
+  movk x7, #35693, lsl 32
+  dup.2d v11, x6
+  bic.16b v5, v11, v5
+  sub.2d v0, v0, v6
+  movk x7, #28832, lsl 48
+  ssra.2d v0, v8, #52
+  sub.2d v6, v1, v7
+  ssra.2d v6, v0, #52
+  mov x6, #16467
+  sub.2d v7, v2, v9
+  ssra.2d v7, v6, #52
+  movk x6, #49763, lsl 16
+  sub.2d v4, v4, v10
+  ssra.2d v4, v7, #52
+  sub.2d v5, v3, v5
+  movk x6, #40165, lsl 32
+  ssra.2d v5, v4, #52
+  ushr.2d v1, v6, #12
+  movk x6, #24776, lsl 48
+  ushr.2d v2, v7, #24
+  ushr.2d v3, v4, #36
+  sli.2d v0, v6, #52
+  subs x5, x0, x5
+  sbcs x4, x1, x4
+  sbcs x7, x2, x7
+  sbcs x6, x3, x6
+  sli.2d v1, v7, #40
+  sli.2d v2, v4, #28
+  sli.2d v3, v5, #16
+  tst x3, #9223372036854775808
+  csel x0, x5, x0, mi
+  csel x1, x4, x1, mi
+  csel x2, x7, x2, mi
+  csel x3, x6, x3, mi

--- a/block-multiplier/src/aarch64/montgomery_square_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_square_interleaved_4.s
@@ -1,0 +1,1020 @@
+// GENERATED FILE, DO NOT EDIT!
+// in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+// in("x4") a1[0], in("x5") a1[1], in("x6") a1[2], in("x7") a1[3],
+// in("v0") av[0], in("v1") av[1], in("v2") av[2], in("v3") av[3],
+// lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3") out[3],
+// lateout("x4") out1[0], lateout("x5") out1[1], lateout("x6") out1[2], lateout("x7") out1[3],
+// lateout("v0") outv[0], lateout("v1") outv[1], lateout("v2") outv[2], lateout("v3") outv[3],
+// lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _, lateout("x17") _, lateout("x20") _, lateout("x21") _, lateout("x22") _, lateout("x23") _, lateout("x24") _, lateout("v4") _, lateout("v5") _, lateout("v6") _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _, lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _, lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _, lateout("v19") _,
+// lateout("lr") _
+  mov x8, #4503599627370495
+  mul x9, x0, x0
+  dup.2d v4, x8
+  umulh x10, x0, x0
+  mov x11, #5075556780046548992
+  mul x12, x0, x1
+  dup.2d v5, x11
+  mov x11, #1
+  umulh x13, x0, x1
+  movk x11, #18032, lsl 48
+  adds x10, x12, x10
+  cinc x14, x13, hs
+  dup.2d v6, x11
+  mul x11, x0, x2
+  shl.2d v7, v1, #14
+  shl.2d v8, v2, #26
+  umulh x15, x0, x2
+  shl.2d v9, v3, #38
+  adds x14, x11, x14
+  cinc x16, x15, hs
+  ushr.2d v3, v3, #14
+  mul x17, x0, x3
+  shl.2d v10, v0, #2
+  umulh x0, x0, x3
+  usra.2d v7, v0, #50
+  usra.2d v8, v1, #38
+  adds x16, x17, x16
+  cinc x20, x0, hs
+  usra.2d v9, v2, #26
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  and.16b v0, v10, v4
+  mul x13, x1, x1
+  and.16b v1, v7, v4
+  and.16b v2, v8, v4
+  umulh x21, x1, x1
+  and.16b v7, v9, v4
+  adds x12, x13, x12
+  cinc x13, x21, hs
+  mov x21, #13605374474286268416
+  adds x12, x12, x14
+  cinc x13, x13, hs
+  dup.2d v8, x21
+  mul x14, x1, x2
+  mov x21, #6440147467139809280
+  dup.2d v9, x21
+  umulh x21, x1, x2
+  mov x22, #3688448094816436224
+  adds x13, x14, x13
+  cinc x23, x21, hs
+  dup.2d v10, x22
+  adds x13, x13, x16
+  cinc x16, x23, hs
+  mov x22, #9209861237972664320
+  dup.2d v11, x22
+  mul x22, x1, x3
+  mov x23, #12218265789056155648
+  umulh x1, x1, x3
+  dup.2d v12, x23
+  adds x16, x22, x16
+  cinc x23, x1, hs
+  mov x24, #17739678932212383744
+  adds x16, x16, x20
+  cinc x20, x23, hs
+  dup.2d v13, x24
+  mov x23, #2301339409586323456
+  adds x11, x11, x12
+  cinc x12, x15, hs
+  dup.2d v14, x23
+  adds x12, x14, x12
+  cinc x14, x21, hs
+  mov x15, #7822752552742551552
+  adds x12, x12, x13
+  cinc x13, x14, hs
+  dup.2d v15, x15
+  mov x14, #5071053180419178496
+  mul x15, x2, x2
+  dup.2d v16, x14
+  umulh x14, x2, x2
+  mov x21, #16352570246982270976
+  adds x13, x15, x13
+  cinc x14, x14, hs
+  dup.2d v17, x21
+  adds x13, x13, x16
+  cinc x14, x14, hs
+  ucvtf.2d v0, v0
+  ucvtf.2d v1, v1
+  mul x15, x2, x3
+  ucvtf.2d v2, v2
+  umulh x2, x2, x3
+  ucvtf.2d v7, v7
+  adds x14, x15, x14
+  cinc x16, x2, hs
+  ucvtf.2d v3, v3
+  mov.16b v18, v5
+  adds x14, x14, x20
+  cinc x16, x16, hs
+  fmla.2d v18, v0, v0
+  adds x12, x17, x12
+  cinc x0, x0, hs
+  fsub.2d v19, v6, v18
+  adds x0, x22, x0
+  cinc x1, x1, hs
+  fmla.2d v19, v0, v0
+  adds x0, x0, x13
+  cinc x1, x1, hs
+  add.2d v10, v10, v18
+  add.2d v8, v8, v19
+  adds x1, x15, x1
+  cinc x2, x2, hs
+  mov.16b v18, v5
+  adds x1, x1, x14
+  cinc x2, x2, hs
+  fmla.2d v18, v0, v1
+  mul x13, x3, x3
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v1
+  umulh x3, x3, x3
+  add.2d v18, v18, v18
+  adds x2, x13, x2
+  cinc x3, x3, hs
+  add.2d v19, v19, v19
+  adds x2, x2, x16
+  cinc x3, x3, hs
+  add.2d v12, v12, v18
+  mov x13, #48718
+  add.2d v10, v10, v19
+  mov.16b v18, v5
+  movk x13, #4732, lsl 16
+  fmla.2d v18, v0, v2
+  movk x13, #45078, lsl 32
+  fsub.2d v19, v6, v18
+  movk x13, #39852, lsl 48
+  fmla.2d v19, v0, v2
+  add.2d v18, v18, v18
+  mov x14, #16676
+  add.2d v19, v19, v19
+  movk x14, #12692, lsl 16
+  add.2d v14, v14, v18
+  movk x14, #20986, lsl 32
+  add.2d v12, v12, v19
+  movk x14, #2848, lsl 48
+  mov.16b v18, v5
+  fmla.2d v18, v0, v7
+  mov x15, #51052
+  fsub.2d v19, v6, v18
+  movk x15, #24721, lsl 16
+  fmla.2d v19, v0, v7
+  movk x15, #61092, lsl 32
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  movk x15, #45156, lsl 48
+  add.2d v16, v16, v18
+  mov x16, #3197
+  add.2d v14, v14, v19
+  movk x16, #18936, lsl 16
+  mov.16b v18, v5
+  movk x16, #10922, lsl 32
+  fmla.2d v18, v0, v3
+  fsub.2d v19, v6, v18
+  movk x16, #11014, lsl 48
+  fmla.2d v19, v0, v3
+  mul x17, x13, x9
+  add.2d v0, v18, v18
+  umulh x13, x13, x9
+  add.2d v18, v19, v19
+  add.2d v0, v17, v0
+  adds x12, x17, x12
+  cinc x13, x13, hs
+  add.2d v16, v16, v18
+  mul x17, x14, x9
+  mov.16b v17, v5
+  umulh x14, x14, x9
+  fmla.2d v17, v1, v1
+  adds x13, x17, x13
+  cinc x14, x14, hs
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v1
+  adds x0, x13, x0
+  cinc x13, x14, hs
+  add.2d v14, v14, v17
+  mul x14, x15, x9
+  add.2d v12, v12, v18
+  umulh x15, x15, x9
+  mov.16b v17, v5
+  fmla.2d v17, v1, v2
+  adds x13, x14, x13
+  cinc x14, x15, hs
+  fsub.2d v18, v6, v17
+  adds x1, x13, x1
+  cinc x13, x14, hs
+  fmla.2d v18, v1, v2
+  mul x14, x16, x9
+  add.2d v17, v17, v17
+  umulh x9, x16, x9
+  add.2d v18, v18, v18
+  add.2d v16, v16, v17
+  adds x13, x14, x13
+  cinc x9, x9, hs
+  add.2d v14, v14, v18
+  adds x2, x13, x2
+  cinc x9, x9, hs
+  mov.16b v17, v5
+  add x3, x3, x9
+  fmla.2d v17, v1, v7
+  fsub.2d v18, v6, v17
+  mov x9, #56431
+  fmla.2d v18, v1, v7
+  movk x9, #30457, lsl 16
+  add.2d v17, v17, v17
+  movk x9, #30012, lsl 32
+  add.2d v18, v18, v18
+  movk x9, #6382, lsl 48
+  add.2d v0, v0, v17
+  add.2d v16, v16, v18
+  mov x13, #59151
+  mov.16b v17, v5
+  movk x13, #41769, lsl 16
+  fmla.2d v17, v1, v3
+  movk x13, #32276, lsl 32
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v3
+  movk x13, #21677, lsl 48
+  add.2d v1, v17, v17
+  mov x14, #34015
+  add.2d v17, v18, v18
+  movk x14, #20342, lsl 16
+  add.2d v1, v15, v1
+  movk x14, #13935, lsl 32
+  add.2d v0, v0, v17
+  mov.16b v15, v5
+  movk x14, #11030, lsl 48
+  fmla.2d v15, v2, v2
+  mov x15, #13689
+  fsub.2d v17, v6, v15
+  movk x15, #8159, lsl 16
+  fmla.2d v17, v2, v2
+  add.2d v0, v0, v15
+  movk x15, #215, lsl 32
+  add.2d v15, v16, v17
+  movk x15, #4913, lsl 48
+  mov.16b v16, v5
+  mul x16, x9, x10
+  fmla.2d v16, v2, v7
+  umulh x9, x9, x10
+  fsub.2d v17, v6, v16
+  fmla.2d v17, v2, v7
+  adds x12, x16, x12
+  cinc x9, x9, hs
+  add.2d v16, v16, v16
+  mul x16, x13, x10
+  add.2d v17, v17, v17
+  umulh x13, x13, x10
+  add.2d v1, v1, v16
+  add.2d v0, v0, v17
+  adds x9, x16, x9
+  cinc x13, x13, hs
+  mov.16b v16, v5
+  adds x0, x9, x0
+  cinc x9, x13, hs
+  fmla.2d v16, v2, v3
+  mul x13, x14, x10
+  fsub.2d v17, v6, v16
+  fmla.2d v17, v2, v3
+  umulh x14, x14, x10
+  add.2d v2, v16, v16
+  adds x9, x13, x9
+  cinc x13, x14, hs
+  add.2d v16, v17, v17
+  adds x1, x9, x1
+  cinc x9, x13, hs
+  add.2d v2, v13, v2
+  mul x13, x15, x10
+  add.2d v1, v1, v16
+  mov.16b v13, v5
+  umulh x10, x15, x10
+  fmla.2d v13, v7, v7
+  adds x9, x13, x9
+  cinc x10, x10, hs
+  fsub.2d v16, v6, v13
+  adds x2, x9, x2
+  cinc x9, x10, hs
+  fmla.2d v16, v7, v7
+  add.2d v2, v2, v13
+  add x3, x3, x9
+  add.2d v1, v1, v16
+  mov x9, #61005
+  mov.16b v13, v5
+  movk x9, #58262, lsl 16
+  fmla.2d v13, v7, v3
+  movk x9, #32851, lsl 32
+  fsub.2d v16, v6, v13
+  fmla.2d v16, v7, v3
+  movk x9, #11582, lsl 48
+  add.2d v7, v13, v13
+  mov x10, #37581
+  add.2d v13, v16, v16
+  movk x10, #43836, lsl 16
+  add.2d v7, v11, v7
+  add.2d v2, v2, v13
+  movk x10, #36286, lsl 32
+  mov.16b v11, v5
+  movk x10, #51783, lsl 48
+  fmla.2d v11, v3, v3
+  mov x13, #10899
+  fsub.2d v13, v6, v11
+  movk x13, #30709, lsl 16
+  fmla.2d v13, v3, v3
+  add.2d v3, v9, v11
+  movk x13, #61551, lsl 32
+  add.2d v7, v7, v13
+  movk x13, #45784, lsl 48
+  usra.2d v10, v8, #52
+  mov x14, #36612
+  usra.2d v12, v10, #52
+  usra.2d v14, v12, #52
+  movk x14, #63402, lsl 16
+  usra.2d v15, v14, #52
+  movk x14, #47623, lsl 32
+  and.16b v8, v8, v4
+  movk x14, #9430, lsl 48
+  and.16b v9, v10, v4
+  mul x15, x9, x11
+  and.16b v10, v12, v4
+  and.16b v4, v14, v4
+  umulh x9, x9, x11
+  ucvtf.2d v8, v8
+  adds x12, x15, x12
+  cinc x9, x9, hs
+  mov x15, #37864
+  mul x16, x10, x11
+  movk x15, #1815, lsl 16
+  movk x15, #28960, lsl 32
+  umulh x10, x10, x11
+  movk x15, #17153, lsl 48
+  adds x9, x16, x9
+  cinc x10, x10, hs
+  dup.2d v11, x15
+  adds x0, x9, x0
+  cinc x9, x10, hs
+  mov.16b v12, v5
+  mul x10, x13, x11
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  umulh x13, x13, x11
+  fmla.2d v13, v8, v11
+  adds x9, x10, x9
+  cinc x10, x13, hs
+  add.2d v0, v0, v12
+  adds x1, x9, x1
+  cinc x9, x10, hs
+  add.2d v11, v15, v13
+  mov x10, #46128
+  mul x13, x14, x11
+  movk x10, #29964, lsl 16
+  umulh x11, x14, x11
+  movk x10, #7587, lsl 32
+  adds x9, x13, x9
+  cinc x11, x11, hs
+  movk x10, #17161, lsl 48
+  adds x2, x9, x2
+  cinc x9, x11, hs
+  dup.2d v12, x10
+  mov.16b v13, v5
+  add x3, x3, x9
+  fmla.2d v13, v8, v12
+  mov x9, #65535
+  fsub.2d v14, v6, v13
+  movk x9, #61439, lsl 16
+  fmla.2d v14, v8, v12
+  add.2d v1, v1, v13
+  movk x9, #62867, lsl 32
+  add.2d v0, v0, v14
+  movk x9, #49889, lsl 48
+  mov x10, #52826
+  mul x9, x9, x12
+  movk x10, #57790, lsl 16
+  mov x11, #1
+  movk x10, #55431, lsl 32
+  movk x10, #17196, lsl 48
+  movk x11, #61440, lsl 16
+  dup.2d v12, x10
+  movk x11, #62867, lsl 32
+  mov.16b v13, v5
+  movk x11, #17377, lsl 48
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  mov x10, #28817
+  fmla.2d v14, v8, v12
+  movk x10, #31161, lsl 16
+  add.2d v2, v2, v13
+  movk x10, #59464, lsl 32
+  add.2d v1, v1, v14
+  movk x10, #10291, lsl 48
+  mov x13, #31276
+  movk x13, #21262, lsl 16
+  mov x14, #22621
+  movk x13, #2304, lsl 32
+  movk x14, #33153, lsl 16
+  movk x13, #17182, lsl 48
+  movk x14, #17846, lsl 32
+  dup.2d v12, x13
+  mov.16b v13, v5
+  movk x14, #47184, lsl 48
+  fmla.2d v13, v8, v12
+  mov x13, #41001
+  fsub.2d v14, v6, v13
+  movk x13, #57649, lsl 16
+  fmla.2d v14, v8, v12
+  movk x13, #20082, lsl 32
+  add.2d v7, v7, v13
+  add.2d v2, v2, v14
+  movk x13, #12388, lsl 48
+  mov x15, #28672
+  mul x16, x11, x9
+  movk x15, #24515, lsl 16
+  umulh x11, x11, x9
+  movk x15, #54929, lsl 32
+  movk x15, #17064, lsl 48
+  cmn x16, x12
+  cinc x11, x11, hs
+  dup.2d v12, x15
+  mul x12, x10, x9
+  mov.16b v13, v5
+  umulh x10, x10, x9
+  fmla.2d v13, v8, v12
+  adds x11, x12, x11
+  cinc x10, x10, hs
+  fsub.2d v14, v6, v13
+  fmla.2d v14, v8, v12
+  adds x0, x11, x0
+  cinc x10, x10, hs
+  add.2d v3, v3, v13
+  mul x11, x14, x9
+  add.2d v7, v7, v14
+  umulh x12, x14, x9
+  ucvtf.2d v8, v9
+  mov x14, #44768
+  adds x10, x11, x10
+  cinc x11, x12, hs
+  movk x14, #51919, lsl 16
+  adds x1, x10, x1
+  cinc x10, x11, hs
+  movk x14, #6346, lsl 32
+  mul x11, x13, x9
+  movk x14, #17133, lsl 48
+  umulh x9, x13, x9
+  dup.2d v9, x14
+  mov.16b v12, v5
+  adds x10, x11, x10
+  cinc x9, x9, hs
+  fmla.2d v12, v8, v9
+  adds x2, x10, x2
+  cinc x9, x9, hs
+  fsub.2d v13, v6, v12
+  add x3, x3, x9
+  fmla.2d v13, v8, v9
+  add.2d v0, v0, v12
+  mov x9, #2
+  add.2d v9, v11, v13
+  movk x9, #57344, lsl 16
+  mov x10, #47492
+  movk x9, #60199, lsl 32
+  movk x10, #23630, lsl 16
+  movk x9, #34755, lsl 48
+  movk x10, #49985, lsl 32
+  movk x10, #17168, lsl 48
+  mov x11, #57634
+  dup.2d v11, x10
+  movk x11, #62322, lsl 16
+  mov.16b v12, v5
+  movk x11, #53392, lsl 32
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  movk x11, #20583, lsl 48
+  fmla.2d v13, v8, v11
+  mov x10, #45242
+  add.2d v1, v1, v12
+  movk x10, #770, lsl 16
+  add.2d v0, v0, v13
+  movk x10, #35693, lsl 32
+  mov x12, #57936
+  movk x12, #54828, lsl 16
+  movk x10, #28832, lsl 48
+  movk x12, #18292, lsl 32
+  mov x13, #16467
+  movk x12, #17197, lsl 48
+  movk x13, #49763, lsl 16
+  dup.2d v11, x12
+  mov.16b v12, v5
+  movk x13, #40165, lsl 32
+  fmla.2d v12, v8, v11
+  movk x13, #24776, lsl 48
+  fsub.2d v13, v6, v12
+  subs x9, x0, x9
+  sbcs x11, x1, x11
+  sbcs x10, x2, x10
+  sbcs x12, x3, x13
+  fmla.2d v13, v8, v11
+  add.2d v2, v2, v12
+  tst x3, #9223372036854775808
+  csel x0, x9, x0, mi
+  csel x1, x11, x1, mi
+  csel x2, x10, x2, mi
+  csel x3, x12, x3, mi
+  add.2d v1, v1, v13
+  mul x9, x4, x4
+  mov x10, #17708
+  umulh x11, x4, x4
+  movk x10, #43915, lsl 16
+  mul x12, x4, x5
+  movk x10, #64348, lsl 32
+  movk x10, #17188, lsl 48
+  umulh x13, x4, x5
+  dup.2d v11, x10
+  adds x10, x12, x11
+  cinc x11, x13, hs
+  mov.16b v12, v5
+  mul x14, x4, x6
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  umulh x15, x4, x6
+  fmla.2d v13, v8, v11
+  adds x11, x14, x11
+  cinc x16, x15, hs
+  add.2d v7, v7, v12
+  mul x17, x4, x7
+  add.2d v2, v2, v13
+  umulh x4, x4, x7
+  mov x20, #29184
+  movk x20, #20789, lsl 16
+  adds x16, x17, x16
+  cinc x21, x4, hs
+  movk x20, #19197, lsl 32
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  movk x20, #17083, lsl 48
+  mul x13, x5, x5
+  dup.2d v11, x20
+  mov.16b v12, v5
+  umulh x20, x5, x5
+  fmla.2d v12, v8, v11
+  adds x12, x13, x12
+  cinc x13, x20, hs
+  fsub.2d v13, v6, v12
+  adds x11, x12, x11
+  cinc x12, x13, hs
+  fmla.2d v13, v8, v11
+  mul x13, x5, x6
+  add.2d v3, v3, v12
+  add.2d v7, v7, v13
+  umulh x20, x5, x6
+  ucvtf.2d v8, v10
+  adds x12, x13, x12
+  cinc x22, x20, hs
+  mov x23, #58856
+  adds x12, x12, x16
+  cinc x16, x22, hs
+  movk x23, #14953, lsl 16
+  movk x23, #15155, lsl 32
+  mul x22, x5, x7
+  movk x23, #17181, lsl 48
+  umulh x5, x5, x7
+  dup.2d v10, x23
+  adds x16, x22, x16
+  cinc x23, x5, hs
+  mov.16b v11, v5
+  adds x16, x16, x21
+  cinc x21, x23, hs
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  adds x11, x14, x11
+  cinc x14, x15, hs
+  fmla.2d v12, v8, v10
+  adds x13, x13, x14
+  cinc x14, x20, hs
+  add.2d v0, v0, v11
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  add.2d v9, v9, v12
+  mov x14, #35392
+  mul x15, x6, x6
+  movk x14, #12477, lsl 16
+  umulh x20, x6, x6
+  movk x14, #56780, lsl 32
+  adds x13, x15, x13
+  cinc x15, x20, hs
+  movk x14, #17142, lsl 48
+  adds x13, x13, x16
+  cinc x15, x15, hs
+  dup.2d v10, x14
+  mov.16b v11, v5
+  mul x14, x6, x7
+  fmla.2d v11, v8, v10
+  umulh x6, x6, x7
+  fsub.2d v12, v6, v11
+  adds x15, x14, x15
+  cinc x16, x6, hs
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  adds x15, x15, x21
+  cinc x16, x16, hs
+  add.2d v0, v0, v12
+  adds x12, x17, x12
+  cinc x4, x4, hs
+  mov x17, #9848
+  adds x4, x22, x4
+  cinc x5, x5, hs
+  movk x17, #54501, lsl 16
+  adds x4, x4, x13
+  cinc x5, x5, hs
+  movk x17, #31540, lsl 32
+  movk x17, #17170, lsl 48
+  adds x5, x14, x5
+  cinc x6, x6, hs
+  dup.2d v10, x17
+  adds x5, x5, x15
+  cinc x6, x6, hs
+  mov.16b v11, v5
+  mul x13, x7, x7
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  umulh x7, x7, x7
+  fmla.2d v12, v8, v10
+  adds x6, x13, x6
+  cinc x7, x7, hs
+  add.2d v2, v2, v11
+  adds x6, x6, x16
+  cinc x7, x7, hs
+  add.2d v1, v1, v12
+  mov x13, #48718
+  mov x14, #9584
+  movk x14, #63883, lsl 16
+  movk x13, #4732, lsl 16
+  movk x14, #18253, lsl 32
+  movk x13, #45078, lsl 32
+  movk x14, #17190, lsl 48
+  movk x13, #39852, lsl 48
+  dup.2d v10, x14
+  mov.16b v11, v5
+  mov x14, #16676
+  fmla.2d v11, v8, v10
+  movk x14, #12692, lsl 16
+  fsub.2d v12, v6, v11
+  movk x14, #20986, lsl 32
+  fmla.2d v12, v8, v10
+  movk x14, #2848, lsl 48
+  add.2d v7, v7, v11
+  add.2d v2, v2, v12
+  mov x15, #51052
+  mov x16, #51712
+  movk x15, #24721, lsl 16
+  movk x16, #16093, lsl 16
+  movk x15, #61092, lsl 32
+  movk x16, #30633, lsl 32
+  movk x16, #17068, lsl 48
+  movk x15, #45156, lsl 48
+  dup.2d v10, x16
+  mov x16, #3197
+  mov.16b v11, v5
+  movk x16, #18936, lsl 16
+  fmla.2d v11, v8, v10
+  movk x16, #10922, lsl 32
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  movk x16, #11014, lsl 48
+  add.2d v3, v3, v11
+  mul x17, x13, x9
+  add.2d v7, v7, v12
+  umulh x13, x13, x9
+  ucvtf.2d v4, v4
+  mov x20, #34724
+  adds x12, x17, x12
+  cinc x13, x13, hs
+  movk x20, #40393, lsl 16
+  mul x17, x14, x9
+  movk x20, #23752, lsl 32
+  umulh x14, x14, x9
+  movk x20, #17184, lsl 48
+  adds x13, x17, x13
+  cinc x14, x14, hs
+  dup.2d v8, x20
+  mov.16b v10, v5
+  adds x4, x13, x4
+  cinc x13, x14, hs
+  fmla.2d v10, v4, v8
+  mul x14, x15, x9
+  fsub.2d v11, v6, v10
+  umulh x15, x15, x9
+  fmla.2d v11, v4, v8
+  add.2d v0, v0, v10
+  adds x13, x14, x13
+  cinc x14, x15, hs
+  add.2d v8, v9, v11
+  adds x5, x13, x5
+  cinc x13, x14, hs
+  mov x14, #25532
+  mul x15, x16, x9
+  movk x14, #31025, lsl 16
+  umulh x9, x16, x9
+  movk x14, #10002, lsl 32
+  movk x14, #17199, lsl 48
+  adds x13, x15, x13
+  cinc x9, x9, hs
+  dup.2d v9, x14
+  adds x6, x13, x6
+  cinc x9, x9, hs
+  mov.16b v10, v5
+  add x7, x7, x9
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  mov x9, #56431
+  fmla.2d v11, v4, v9
+  movk x9, #30457, lsl 16
+  add.2d v1, v1, v10
+  movk x9, #30012, lsl 32
+  add.2d v0, v0, v11
+  movk x9, #6382, lsl 48
+  mov x13, #18830
+  movk x13, #2465, lsl 16
+  mov x14, #59151
+  movk x13, #36348, lsl 32
+  movk x14, #41769, lsl 16
+  movk x13, #17194, lsl 48
+  movk x14, #32276, lsl 32
+  dup.2d v9, x13
+  mov.16b v10, v5
+  movk x14, #21677, lsl 48
+  fmla.2d v10, v4, v9
+  mov x13, #34015
+  fsub.2d v11, v6, v10
+  movk x13, #20342, lsl 16
+  fmla.2d v11, v4, v9
+  movk x13, #13935, lsl 32
+  add.2d v2, v2, v10
+  add.2d v1, v1, v11
+  movk x13, #11030, lsl 48
+  mov x15, #21566
+  mov x16, #13689
+  movk x15, #43708, lsl 16
+  movk x16, #8159, lsl 16
+  movk x15, #57685, lsl 32
+  movk x15, #17185, lsl 48
+  movk x16, #215, lsl 32
+  dup.2d v9, x15
+  movk x16, #4913, lsl 48
+  mov.16b v10, v5
+  mul x15, x9, x10
+  fmla.2d v10, v4, v9
+  umulh x9, x9, x10
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  adds x12, x15, x12
+  cinc x9, x9, hs
+  add.2d v7, v7, v10
+  mul x15, x14, x10
+  add.2d v2, v2, v11
+  umulh x14, x14, x10
+  mov x17, #3072
+  movk x17, #8058, lsl 16
+  adds x9, x15, x9
+  cinc x14, x14, hs
+  movk x17, #46097, lsl 32
+  adds x4, x9, x4
+  cinc x9, x14, hs
+  movk x17, #17047, lsl 48
+  mul x14, x13, x10
+  dup.2d v9, x17
+  mov.16b v10, v5
+  umulh x13, x13, x10
+  fmla.2d v10, v4, v9
+  adds x9, x14, x9
+  cinc x13, x13, hs
+  fsub.2d v11, v6, v10
+  adds x5, x9, x5
+  cinc x9, x13, hs
+  fmla.2d v11, v4, v9
+  mul x13, x16, x10
+  add.2d v3, v3, v10
+  add.2d v4, v7, v11
+  umulh x10, x16, x10
+  mov x14, #65535
+  adds x9, x13, x9
+  cinc x10, x10, hs
+  movk x14, #61439, lsl 16
+  adds x6, x9, x6
+  cinc x9, x10, hs
+  movk x14, #62867, lsl 32
+  movk x14, #1, lsl 48
+  add x7, x7, x9
+  umov x9, v8.d[0]
+  mov x10, #61005
+  umov x13, v8.d[1]
+  movk x10, #58262, lsl 16
+  mul x9, x9, x14
+  movk x10, #32851, lsl 32
+  mul x13, x13, x14
+  and x9, x9, x8
+  movk x10, #11582, lsl 48
+  and x8, x13, x8
+  mov x13, #37581
+  ins v7.d[0], x9
+  ins v7.d[1], x8
+  movk x13, #43836, lsl 16
+  ucvtf.2d v7, v7
+  mov x8, #16
+  movk x13, #36286, lsl 32
+  movk x8, #22847, lsl 32
+  movk x13, #51783, lsl 48
+  movk x8, #17151, lsl 48
+  mov x9, #10899
+  dup.2d v9, x8
+  movk x9, #30709, lsl 16
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  movk x9, #61551, lsl 32
+  fsub.2d v11, v6, v10
+  movk x9, #45784, lsl 48
+  fmla.2d v11, v7, v9
+  mov x8, #36612
+  add.2d v0, v0, v10
+  add.2d v8, v8, v11
+  movk x8, #63402, lsl 16
+  mov x14, #20728
+  movk x8, #47623, lsl 32
+  movk x14, #23588, lsl 16
+  movk x8, #9430, lsl 48
+  movk x14, #7790, lsl 32
+  mul x15, x10, x11
+  movk x14, #17170, lsl 48
+  dup.2d v9, x14
+  umulh x10, x10, x11
+  mov.16b v10, v5
+  adds x12, x15, x12
+  cinc x10, x10, hs
+  fmla.2d v10, v7, v9
+  mul x14, x13, x11
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  umulh x13, x13, x11
+  add.2d v1, v1, v10
+  adds x10, x14, x10
+  cinc x13, x13, hs
+  add.2d v0, v0, v11
+  adds x4, x10, x4
+  cinc x10, x13, hs
+  mov x13, #16000
+  mul x14, x9, x11
+  movk x13, #53891, lsl 16
+  movk x13, #5509, lsl 32
+  umulh x9, x9, x11
+  movk x13, #17144, lsl 48
+  adds x10, x14, x10
+  cinc x9, x9, hs
+  dup.2d v9, x13
+  adds x5, x10, x5
+  cinc x9, x9, hs
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  mul x10, x8, x11
+  fsub.2d v11, v6, v10
+  umulh x8, x8, x11
+  fmla.2d v11, v7, v9
+  adds x9, x10, x9
+  cinc x8, x8, hs
+  add.2d v2, v2, v10
+  adds x6, x9, x6
+  cinc x8, x8, hs
+  add.2d v1, v1, v11
+  mov x9, #46800
+  add x7, x7, x8
+  movk x9, #2568, lsl 16
+  mov x8, #65535
+  movk x9, #1335, lsl 32
+  movk x8, #61439, lsl 16
+  movk x9, #17188, lsl 48
+  dup.2d v9, x9
+  movk x8, #62867, lsl 32
+  mov.16b v10, v5
+  movk x8, #49889, lsl 48
+  fmla.2d v10, v7, v9
+  mul x8, x8, x12
+  fsub.2d v11, v6, v10
+  mov x9, #1
+  fmla.2d v11, v7, v9
+  add.2d v4, v4, v10
+  movk x9, #61440, lsl 16
+  add.2d v2, v2, v11
+  movk x9, #62867, lsl 32
+  mov x10, #39040
+  movk x9, #17377, lsl 48
+  movk x10, #14704, lsl 16
+  movk x10, #12839, lsl 32
+  mov x11, #28817
+  movk x10, #17096, lsl 48
+  movk x11, #31161, lsl 16
+  dup.2d v9, x10
+  movk x11, #59464, lsl 32
+  mov.16b v5, v5
+  movk x11, #10291, lsl 48
+  fmla.2d v5, v7, v9
+  fsub.2d v6, v6, v5
+  mov x10, #22621
+  fmla.2d v6, v7, v9
+  movk x10, #33153, lsl 16
+  add.2d v3, v3, v5
+  movk x10, #17846, lsl 32
+  add.2d v4, v4, v6
+  mov x13, #140737488355328
+  movk x10, #47184, lsl 48
+  dup.2d v5, x13
+  mov x13, #41001
+  and.16b v5, v3, v5
+  movk x13, #57649, lsl 16
+  cmeq.2d v5, v5, #0
+  movk x13, #20082, lsl 32
+  mov x14, #2
+  movk x14, #57344, lsl 16
+  movk x13, #12388, lsl 48
+  movk x14, #60199, lsl 32
+  mul x15, x9, x8
+  movk x14, #3, lsl 48
+  umulh x9, x9, x8
+  dup.2d v6, x14
+  bic.16b v6, v6, v5
+  cmn x15, x12
+  cinc x9, x9, hs
+  mov x12, #10364
+  mul x14, x11, x8
+  movk x12, #11794, lsl 16
+  umulh x11, x11, x8
+  movk x12, #3895, lsl 32
+  adds x9, x14, x9
+  cinc x11, x11, hs
+  movk x12, #9, lsl 48
+  dup.2d v7, x12
+  adds x4, x9, x4
+  cinc x9, x11, hs
+  bic.16b v7, v7, v5
+  mul x11, x10, x8
+  mov x12, #26576
+  umulh x10, x10, x8
+  movk x12, #47696, lsl 16
+  movk x12, #688, lsl 32
+  adds x9, x11, x9
+  cinc x10, x10, hs
+  movk x12, #3, lsl 48
+  adds x5, x9, x5
+  cinc x9, x10, hs
+  dup.2d v9, x12
+  mul x10, x13, x8
+  bic.16b v9, v9, v5
+  umulh x8, x13, x8
+  mov x11, #46800
+  movk x11, #2568, lsl 16
+  adds x9, x10, x9
+  cinc x8, x8, hs
+  movk x11, #1335, lsl 32
+  adds x6, x9, x6
+  cinc x8, x8, hs
+  movk x11, #4, lsl 48
+  add x7, x7, x8
+  dup.2d v10, x11
+  bic.16b v10, v10, v5
+  mov x8, #2
+  mov x9, #49763
+  movk x8, #57344, lsl 16
+  movk x9, #40165, lsl 16
+  movk x8, #60199, lsl 32
+  movk x9, #24776, lsl 32
+  movk x8, #34755, lsl 48
+  dup.2d v11, x9
+  bic.16b v5, v11, v5
+  mov x9, #57634
+  sub.2d v0, v0, v6
+  movk x9, #62322, lsl 16
+  ssra.2d v0, v8, #52
+  movk x9, #53392, lsl 32
+  sub.2d v6, v1, v7
+  ssra.2d v6, v0, #52
+  movk x9, #20583, lsl 48
+  sub.2d v7, v2, v9
+  mov x10, #45242
+  ssra.2d v7, v6, #52
+  movk x10, #770, lsl 16
+  sub.2d v4, v4, v10
+  movk x10, #35693, lsl 32
+  ssra.2d v4, v7, #52
+  sub.2d v5, v3, v5
+  movk x10, #28832, lsl 48
+  ssra.2d v5, v4, #52
+  mov x11, #16467
+  ushr.2d v1, v6, #12
+  movk x11, #49763, lsl 16
+  ushr.2d v2, v7, #24
+  ushr.2d v3, v4, #36
+  movk x11, #40165, lsl 32
+  sli.2d v0, v6, #52
+  movk x11, #24776, lsl 48
+  sli.2d v1, v7, #40
+  subs x8, x4, x8
+  sbcs x9, x5, x9
+  sbcs x10, x6, x10
+  sbcs x11, x7, x11
+  sli.2d v2, v4, #28
+  sli.2d v3, v5, #16
+  tst x7, #9223372036854775808
+  csel x4, x8, x4, mi
+  csel x5, x9, x5, mi
+  csel x6, x10, x6, mi
+  csel x7, x11, x7, mi

--- a/block-multiplier/src/constants.rs
+++ b/block-multiplier/src/constants.rs
@@ -140,3 +140,12 @@ const fn pow_2(n: u32) -> f64 {
     let exp = ((n as u64 + 1023) & 0x7ff) << 52;
     f64::from_bits(exp)
 }
+
+// BOUNDS
+/// Upper bound of 2**256-2p
+pub const OUTPUT_MAX: [u64; 4] = [
+    0x783c14d81ffffffe,
+    0xaf982f6f0c8d1edd,
+    0x8f5f7492fcfd4f45,
+    0x9f37631a3d9cbfac,
+];

--- a/block-multiplier/src/lib.rs
+++ b/block-multiplier/src/lib.rs
@@ -11,6 +11,7 @@ mod utils;
 pub use crate::{
     aarch64::{
         montgomery_interleaved_3, montgomery_interleaved_4, montgomery_square_interleaved_3,
+        montgomery_square_interleaved_4,
     },
     block_simd::{block_mul, block_sqr},
     portable_simd::{simd_mul, simd_sqr},

--- a/block-multiplier/src/lib.rs
+++ b/block-multiplier/src/lib.rs
@@ -9,7 +9,9 @@ mod scalar;
 mod utils;
 
 pub use crate::{
-    aarch64::{montgomery_interleaved_3, montgomery_interleaved_4},
+    aarch64::{
+        montgomery_interleaved_3, montgomery_interleaved_4, montgomery_square_interleaved_3,
+    },
     block_simd::{block_mul, block_sqr},
     portable_simd::{simd_mul, simd_sqr},
     scalar::{scalar_mul, scalar_sqr},

--- a/block-multiplier/src/lib.rs
+++ b/block-multiplier/src/lib.rs
@@ -6,6 +6,7 @@ mod block_simd;
 pub mod constants;
 mod portable_simd;
 mod scalar;
+mod test_utils;
 mod utils;
 
 pub use crate::{

--- a/block-multiplier/src/scalar.rs
+++ b/block-multiplier/src/scalar.rs
@@ -203,32 +203,4 @@ mod tests {
             assert_eq!(mod_mul(U256(s0), r_inv), mod_mul(s0_a, s0_a));
         }
     }
-
-    #[test]
-    fn test_max_multiprecision_strategy() {
-        let upper_bounds = proptest::array::uniform4(any::<u64>());
-        let pairs = upper_bounds.prop_flat_map(|upper_bound| {
-            max_multiprecision(upper_bound.to_vec()).prop_map(move |value| (upper_bound, value))
-        });
-        proptest!(|(pair in pairs)| {
-            let (upper_bound, value) = pair;
-            // Check if value <= max by comparing limbs from most significant to least
-            assert!(value[3] <= upper_bound[3], "value[3] exceeds max[3]");
-            assert!(
-                !(value[3] == upper_bound[3] && value[2] > upper_bound[2]),
-                "value[2] exceeds max[2] when higher limbs are equal"
-            );
-            assert!(
-                !(value[3] == upper_bound[3] && value[2] == upper_bound[2] && value[1] > upper_bound[1]),
-                "value[1] exceeds max[1] when higher limbs are equal"
-            );
-            assert!(
-                !(value[3] == upper_bound[3]
-                    && value[2] == upper_bound[2]
-                    && value[1] == upper_bound[1]
-                    && value[0] > upper_bound[0]),
-                "value[0] exceeds max[0] when higher limbs are equal"
-            );
-        });
-    }
 }

--- a/block-multiplier/src/scalar.rs
+++ b/block-multiplier/src/scalar.rs
@@ -137,7 +137,7 @@ mod tests {
         super::*,
         crate::{constants, test_utils::*},
         ark_bn254::Fr,
-        ark_ff::{BigInt, Field},
+        ark_ff::BigInt,
         primitive_types::U256,
         proptest::proptest,
         rand::{Rng, SeedableRng, rngs},
@@ -145,11 +145,8 @@ mod tests {
 
     #[test]
     fn test_mul_field() {
-        let sigma = Fr::from(2).pow([256]).inverse().unwrap();
         proptest!(|(l in safe_bn254_montgomery_input(), r in safe_bn254_montgomery_input())| {
-            let fl = Fr::new(BigInt(l));
-            let fr = Fr::new(BigInt(r));
-            let fe = fl * fr * sigma;
+            let fe = ark_ff_reference(l, r);
             let r = scalar_mul(l, r);
             let fr = Fr::new(BigInt(r));
             assert_eq!(fr, fe);

--- a/block-multiplier/src/test_utils.rs
+++ b/block-multiplier/src/test_utils.rs
@@ -56,9 +56,11 @@ pub fn ark_ff_reference(l: [u64; 4], r: [u64; 4]) -> Fr {
 
 #[test]
 fn test_max_multiprecision_strategy() {
-    proptest!(|(pair in proptest::array::uniform4(any::<u64>()).prop_flat_map(|upper_bound| {
+    let upper_bounds = proptest::array::uniform4(any::<u64>());
+    let pairs = upper_bounds.prop_flat_map(|upper_bound| {
         max_multiprecision(upper_bound.to_vec()).prop_map(move |value| (upper_bound, value))
-    }))| {
+    });
+    proptest!(|(pair in pairs)| {
         let (upper_bound, value) = pair;
         // Check if value <= max by comparing limbs from most significant to least
         assert!(value[3] <= upper_bound[3], "value[3] exceeds max[3]");

--- a/block-multiplier/src/test_utils.rs
+++ b/block-multiplier/src/test_utils.rs
@@ -1,0 +1,81 @@
+#![cfg(test)]
+
+use {
+    crate::constants::OUTPUT_MAX,
+    proptest::{
+        collection,
+        prelude::{Strategy, any},
+        proptest,
+    },
+    std::simd::Simd,
+};
+
+/// Given a multiprecision integer in little-endian format, returns a
+/// `Strategy` that generates values uniformly in the range `0..=max`.
+fn max_multiprecision(max: Vec<u64>) -> impl Strategy<Value = Vec<u64>> {
+    // Takes ownership of a vector rather to deal with the 'static
+    // requirement of boxed()
+    let size = max.len();
+    (0..=max[size - 1]).prop_flat_map(move |limb| {
+        // If the generated most significant limb is smaller than the MSL of max the
+        // the remaining limbs can be unconstrained.
+        if limb < max[size - 1] {
+            collection::vec(any::<u64>(), size..size + 1)
+                .prop_map(move |mut arr| {
+                    arr[size - 1] = limb;
+                    assert_eq!(arr.len(), size);
+                    arr
+                })
+                .boxed()
+        } else {
+            // If MSL is equal to max constrain the next limbs
+            max_multiprecision(max[..size - 1].to_owned())
+                .prop_map(move |mut arr| {
+                    arr.push(limb);
+                    assert_eq!(arr.len(), size);
+                    arr
+                })
+                .boxed()
+        }
+    })
+}
+
+pub fn safe_bn254_montgomery_input() -> impl Strategy<Value = [u64; 4]> {
+    max_multiprecision(OUTPUT_MAX.to_vec()).prop_map(|vec| vec.try_into().unwrap())
+}
+
+pub fn safe_simd_input() -> impl Strategy<Value = [Simd<u64, 2>; 4]> {
+    (safe_bn254_montgomery_input(), safe_bn254_montgomery_input()).prop_map(|(a, b)| {
+        let mut result = [Simd::splat(0); 4];
+        for i in 0..4 {
+            result[i] = Simd::from_array([a[i], b[i]]);
+        }
+        result
+    })
+}
+
+#[test]
+fn test_max_multiprecision_strategy() {
+    proptest!(|(pair in proptest::array::uniform4(any::<u64>()).prop_flat_map(|upper_bound| {
+        max_multiprecision(upper_bound.to_vec()).prop_map(move |value| (upper_bound, value))
+    }))| {
+        let (upper_bound, value) = pair;
+        // Check if value <= max by comparing limbs from most significant to least
+        assert!(value[3] <= upper_bound[3], "value[3] exceeds max[3]");
+        assert!(
+            !(value[3] == upper_bound[3] && value[2] > upper_bound[2]),
+            "value[2] exceeds max[2] when higher limbs are equal"
+        );
+        assert!(
+            !(value[3] == upper_bound[3] && value[2] == upper_bound[2] && value[1] > upper_bound[1]),
+            "value[1] exceeds max[1] when higher limbs are equal"
+        );
+        assert!(
+            !(value[3] == upper_bound[3]
+                && value[2] == upper_bound[2]
+                && value[1] == upper_bound[1]
+                && value[0] > upper_bound[0]),
+            "value[0] exceeds max[0] when higher limbs are equal"
+        );
+    });
+}

--- a/hla/src/frontend.rs
+++ b/hla/src/frontend.rs
@@ -113,8 +113,9 @@ pub struct PointerReg<'a, T> {
     _marker:           PhantomData<T>,
 }
 
+type DelayedInstruction<'a, T> = Box<dyn Fn(&mut FreshAllocator, &mut Assembler) -> T + 'a>;
 pub enum Lazy<'a, T> {
-    Thunk(Box<dyn Fn(&mut FreshAllocator, &mut Assembler) -> T + 'a>),
+    Thunk(DelayedInstruction<'a, T>),
     Forced(T),
 }
 

--- a/hla/src/frontend.rs
+++ b/hla/src/frontend.rs
@@ -94,6 +94,53 @@ impl FreshVariable {
     }
 }
 
+/// [`Lazy`] allows for defining operations beforehand and defer the execution
+/// till the first time the result is needed. This is useful in situations where
+/// otherwise too many registers will be allocated at once.
+pub struct Lazy<'a, T>(LazyInner<'a, T>);
+enum LazyInner<'a, T> {
+    // To extract FnOnce without having to resort to unsafe we wrap it in an Option.
+    Thunk(Option<DelayedInstruction<'a, T>>),
+    Forced(T),
+}
+
+type DelayedInstruction<'a, T> = Box<dyn FnOnce(&mut FreshAllocator, &mut Assembler) -> T + 'a>;
+
+impl<T> Lazy<'_, T> {
+    pub fn thunk<'a>(inst: DelayedInstruction<'a, T>) -> Lazy<'a, T> {
+        Lazy(LazyInner::Thunk(Some(inst)))
+    }
+
+    pub fn forced<'a>(val: T) -> Lazy<'a, T> {
+        Lazy(LazyInner::Forced(val))
+    }
+
+    fn force(&mut self, alloc: &mut FreshAllocator, asm: &mut Assembler) {
+        if let LazyInner::Thunk(optf) = &mut self.0 {
+            match optf.take() {
+                Some(f) => self.0 = LazyInner::Forced(f(alloc, asm)),
+                None => unreachable!(),
+            };
+        }
+    }
+
+    pub fn as_(&mut self, alloc: &mut FreshAllocator, asm: &mut Assembler) -> &T {
+        self.force(alloc, asm);
+        match &self.0 {
+            LazyInner::Forced(t) => t,
+            LazyInner::Thunk(_) => unreachable!(),
+        }
+    }
+
+    pub fn into_(mut self, alloc: &mut FreshAllocator, asm: &mut Assembler) -> T {
+        self.force(alloc, asm);
+        match self.0 {
+            LazyInner::Forced(t) => t,
+            LazyInner::Thunk(_) => unreachable!(),
+        }
+    }
+}
+
 /// Represents a single hardware registers by modelling it as
 /// a fresh variable.
 /// This value does not have a clone or copy trait to prevent aliasing
@@ -111,36 +158,6 @@ pub struct PointerReg<'a, T> {
     // x and w without having to recalculate the offset
     pub(crate) offset: usize,
     _marker:           PhantomData<T>,
-}
-
-type DelayedInstruction<'a, T> = Box<dyn Fn(&mut FreshAllocator, &mut Assembler) -> T + 'a>;
-pub enum Lazy<'a, T> {
-    Thunk(DelayedInstruction<'a, T>),
-    Forced(T),
-}
-
-impl<T> Lazy<'_, T> {
-    fn force(&mut self, alloc: &mut FreshAllocator, asm: &mut Assembler) {
-        if let Lazy::Thunk(f) = self {
-            *self = Lazy::Forced(f(alloc, asm));
-        }
-    }
-
-    pub fn as_(&mut self, alloc: &mut FreshAllocator, asm: &mut Assembler) -> &T {
-        self.force(alloc, asm);
-        match self {
-            Lazy::Forced(t) => t,
-            Lazy::Thunk(_) => unreachable!(),
-        }
-    }
-
-    pub fn into_(mut self, alloc: &mut FreshAllocator, asm: &mut Assembler) -> T {
-        self.force(alloc, asm);
-        match self {
-            Lazy::Forced(t) => t,
-            Lazy::Thunk(_) => unreachable!(),
-        }
-    }
 }
 
 impl<T, const N: usize> Reg<*mut [T; N]> {

--- a/skyscraper/src/block3.rs
+++ b/skyscraper/src/block3.rs
@@ -21,7 +21,7 @@ fn compress(guard: &RoundingGuard<Zero>, input: [[[u64; 4]; 2]; 3]) -> [[u64; 4]
 fn square(guard: &RoundingGuard<Zero>, n: [[u64; 4]; 3]) -> [[u64; 4]; 3] {
     let [a, b, c] = n;
     let v = array::from_fn(|i| std::simd::u64x2::from_array([b[i], c[i]]));
-    let (a, v) = block_multiplier::montgomery_interleaved_3(guard, a, a, v, v);
+    let (a, v) = block_multiplier::montgomery_square_interleaved_3(guard, a, v);
     let b = v.map(|e| e[0]);
     let c = v.map(|e| e[1]);
     [a, b, c]

--- a/skyscraper/src/block4.rs
+++ b/skyscraper/src/block4.rs
@@ -21,7 +21,7 @@ fn compress(guard: &RoundingGuard<Zero>, input: [[[u64; 4]; 2]; 4]) -> [[u64; 4]
 fn square(guard: &RoundingGuard<Zero>, n: [[u64; 4]; 4]) -> [[u64; 4]; 4] {
     let [a, b, c, d] = n;
     let v = array::from_fn(|i| std::simd::u64x2::from_array([c[i], d[i]]));
-    let (a, b, v) = block_multiplier::montgomery_interleaved_4(guard, a, a, b, b, v, v);
+    let (a, b, v) = block_multiplier::montgomery_square_interleaved_4(guard, a, b, v);
     let c = v.map(|e| e[0]);
     let d = v.map(|e| e[1]);
     [a, b, c, d]


### PR DESCRIPTION
This PR introduces optimised Montgomery squaring for both scalar and SIMD.

Additionally:
- the block multipliers in Skyscraper are replaced by the squaring operations.
- code generators and assembly for blocks of size 3 and 4. Due to a small reordering the code of the block multipliers also changed. 
- HLA now has support for lazy evaluation for use in code generators. This made it easier to write the squaring algorithm in the scalar case. 
- `test_utils` to share code between tests. 
- comparison test between the block squarer and ark_ff.

**Note:** the reducer hasn't been taken out yet. That will be done in a follow-up PR. 