### PR TITLE
Reductionless block multipliers

### DIFF
--- a/block-multiplier-codegen/src/main.rs
+++ b/block-multiplier-codegen/src/main.rs
@@ -19,6 +19,13 @@ fn main() {
         ),
     );
     build_includable(
+        "./asm/montgomery_square_log_interleaved_3.s",
+        Interleaving::par(
+            Interleaving::single(scalar::setup_square_log_jump),
+            Interleaving::single(simd::setup_square_single_step),
+        ),
+    );
+    build_includable(
         "./asm/montgomery_interleaved_4.s",
         Interleaving::par(
             Interleaving::seq(vec![scalar::setup_single_step, scalar::setup_single_step]),
@@ -31,6 +38,16 @@ fn main() {
             Interleaving::seq(vec![
                 scalar::setup_square_single_step,
                 scalar::setup_square_single_step,
+            ]),
+            Interleaving::single(simd::setup_square_single_step),
+        ),
+    );
+    build_includable(
+        "./asm/montgomery_square_log_interleaved_4.s",
+        Interleaving::par(
+            Interleaving::seq(vec![
+                scalar::setup_square_log_jump,
+                scalar::setup_square_log_jump,
             ]),
             Interleaving::single(simd::setup_square_single_step),
         ),

--- a/block-multiplier-codegen/src/main.rs
+++ b/block-multiplier-codegen/src/main.rs
@@ -43,4 +43,8 @@ fn main() {
         "./asm/montgomery_square.s",
         Interleaving::single(scalar::setup_square_single_step),
     );
+    build_includable(
+        "./asm/montgomery_log_jump.s",
+        Interleaving::single(scalar::setup_log_jump),
+    );
 }

--- a/block-multiplier-codegen/src/scalar.rs
+++ b/block-multiplier-codegen/src/scalar.rs
@@ -49,6 +49,22 @@ pub fn setup_single_step(
         FreshVariable::new("out", &s),
     )
 }
+/// Sets up the assembly generation context for bn254 u256 Montgomery squaring.
+///
+/// Initializes the necessary registers and calls `montgomery`.
+/// Returns the input and output variables for the generated assembly function.
+pub fn setup_square_single_step(
+    alloc: &mut FreshAllocator,
+    asm: &mut Assembler,
+) -> (Vec<FreshVariable>, FreshVariable) {
+    let a = alloc.fresh_array();
+
+    let s = square_single_step(alloc, asm, &a);
+    (
+        vec![FreshVariable::new("a", &a)],
+        FreshVariable::new("out", &s),
+    )
+}
 
 /// Sets up the assembly generation context for Montgomery multiplication of two
 /// u256 numbers.
@@ -73,19 +89,18 @@ pub fn setup_log_jump(
 ///
 /// Initializes the necessary registers and calls `montgomery`.
 /// Returns the input and output variables for the generated assembly function.
-pub fn setup_square_single_step(
+pub fn setup_square_log_jump(
     alloc: &mut FreshAllocator,
     asm: &mut Assembler,
 ) -> (Vec<FreshVariable>, FreshVariable) {
     let a = alloc.fresh_array();
 
-    let s = square_single_step(alloc, asm, &a);
+    let s = square_log_jump(alloc, asm, &a);
     (
         vec![FreshVariable::new("a", &a)],
         FreshVariable::new("out", &s),
     )
 }
-
 /// Sets up the assembly generation context for a u256 multiply-add-limb
 /// operation (`r = r + a * b`).
 ///
@@ -325,6 +340,20 @@ pub fn log_jump(
     b: &[Reg<u64>; 4],
 ) -> [Reg<u64>; 4] {
     let t = widening_mul_u256(alloc, asm, a, b);
+    log_jump_reduction(alloc, asm, t)
+}
+
+/// Computes the Montgomery multiplication of two 4-limb (256-bit) numbers `a`
+/// and `b`.
+///
+/// Implements the Domb's log jump Montgomery multiplication algorithm.
+/// The result is less than `3P`.
+pub fn square_log_jump(
+    alloc: &mut FreshAllocator,
+    asm: &mut Assembler,
+    a: &[Reg<u64>; 4],
+) -> [Reg<u64>; 4] {
+    let t = square_u256(alloc, asm, a);
     log_jump_reduction(alloc, asm, t)
 }
 

--- a/block-multiplier-codegen/src/scalar.rs
+++ b/block-multiplier-codegen/src/scalar.rs
@@ -322,10 +322,7 @@ fn single_step_reduction(
     let m = mul(alloc, asm, &mu0, &r3[0]);
 
     let p = U64_P.map(|val| load_const(alloc, asm, val));
-    let r4 = madd_u256_limb_truncate(alloc, asm, r3, &p, &m);
-
-    // TODO(xrvdg): take out this reducer. Let the caller reduce.
-    reduce(alloc, asm, r4)
+    madd_u256_limb_truncate(alloc, asm, r3, &p, &m)
 }
 
 /// Computes the Montgomery multiplication of two 4-limb (256-bit) numbers `a`
@@ -377,10 +374,7 @@ fn log_jump_reduction(
     let m = mul(alloc, asm, &mu0, &r3[0]);
 
     let p = U64_P.map(|val| load_const(alloc, asm, val));
-    let r4 = madd_u256_limb_truncate(alloc, asm, r3, &p, &m);
-
-    // TODO(xrvdg): take out this reducer. Let the caller reduce.
-    reduce(alloc, asm, r4)
+    madd_u256_limb_truncate(alloc, asm, r3, &p, &m)
 }
 
 /// Computes the 128-bit widening multiplication of two 64-bit registers `a` and

--- a/block-multiplier/src/aarch64/mod.rs
+++ b/block-multiplier/src/aarch64/mod.rs
@@ -161,8 +161,42 @@ pub fn montgomery_square_interleaved_4(
             lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _,
             lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _,
             lateout("x17") _, lateout("x20") _, lateout("x21") _, lateout("x22") _,
-            lateout("x23") _, lateout("x24") _, lateout("v4") _, lateout("v5") _, lateout("v6")
-            _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _,
+            lateout("x23") _, lateout("x24") _, lateout("v4") _, lateout("v5") _, lateout("v6") _,
+            lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _,
+            lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _,
+            lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _,
+            lateout("v19") _, lateout("lr") _,
+            options(nomem, nostack)
+        )
+    };
+    (out, out1, outv)
+}
+
+#[inline]
+pub fn montgomery_square_log_interleaved_4(
+    _rtz: &RoundingGuard<Zero>,
+    a: [u64; 4],
+    a1: [u64; 4],
+    av: [Simd<u64, 2>; 4],
+) -> ([u64; 4], [u64; 4], [Simd<u64, 2>; 4]) {
+    let mut out = [0; 4];
+    let mut out1 = [0; 4];
+    let mut outv = [Simd::splat(0); 4];
+    unsafe {
+        asm!(
+            include_str!("montgomery_square_log_interleaved_4.s"),
+            in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+            in("x4") a1[0], in("x5") a1[1], in("x6") a1[2], in("x7") a1[3],
+            in("v0") av[0], in("v1") av[1], in("v2") av[2], in("v3") av[3],
+            lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3")
+            out[3], lateout("x4") out1[0], lateout("x5") out1[1], lateout("x6")
+            out1[2], lateout("x7") out1[3], lateout("v0") outv[0], lateout("v1")
+            outv[1], lateout("v2") outv[2], lateout("v3") outv[3], lateout("x8") _,
+            lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _,
+            lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _,
+            lateout("x17") _, lateout("x20") _, lateout("x21") _, lateout("x22") _,
+            lateout("x23") _, lateout("x24") _, lateout("v4") _, lateout("v5") _, lateout("v6") _,
+            lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _,
             lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _,
             lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _,
             lateout("v19") _, lateout("lr") _,

--- a/block-multiplier/src/aarch64/mod.rs
+++ b/block-multiplier/src/aarch64/mod.rs
@@ -3,6 +3,24 @@ use {
     fp_rounding::{RoundingGuard, Zero},
 };
 
+#[inline]
+pub fn montgomery_log_jump(_rtz: &RoundingGuard<Zero>, a: [u64; 4], b: [u64; 4]) -> [u64; 4] {
+    let mut out = [0; 4];
+    unsafe {
+        asm!(
+            include_str!("montgomery_log_jump.s"),
+            in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+            in("x4") b[0], in("x5") b[1], in("x6") b[2], in("x7") b[3],
+            lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3") out[3],
+            lateout("x4") _, lateout("x5") _, lateout("x6") _, lateout("x7") _,
+            lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _,
+            lateout("x12") _, lateout("x13") _, lateout("x14") _, lateout("lr") _,
+            options(nomem, nostack)
+        )
+    };
+    out
+}
+
 /// A block multiplier with 3 concurrent multiplications.
 ///
 /// Raspberry Pi 5:  2.2 times the throughput compared to a single multiplier.
@@ -158,6 +176,23 @@ mod tests {
                     assert_eq!(a_squared, a_squared_interleaved);
                     assert_eq!(b_squared, b_squared_interleaved);
                     assert_eq!(c_squared, c_squared_interleaved);
+                });
+            }
+        });
+    }
+
+    #[test]
+    fn test_montgomery_log_jump() {
+        proptest!(|(
+            a in safe_bn254_montgomery_input(),
+            b in safe_bn254_montgomery_input(),
+        )| {
+            unsafe {
+                with_rounding_mode((), |rtz, _| {
+                    let ab_log = montgomery_log_jump(rtz, a, b);
+                    let ab_ff = ark_ff_reference(a, b);
+                    let ab_log = Fr::new(BigInt(ab_log));
+                    assert_eq!(ab_ff, ab_log);
                 });
             }
         });

--- a/block-multiplier/src/aarch64/mod.rs
+++ b/block-multiplier/src/aarch64/mod.rs
@@ -73,6 +73,35 @@ pub fn montgomery_square_interleaved_3(
     (out, outv)
 }
 
+#[inline]
+pub fn montgomery_square_log_interleaved_3(
+    _rtz: &RoundingGuard<Zero>,
+    a: [u64; 4],
+    av: [Simd<u64, 2>; 4],
+) -> ([u64; 4], [Simd<u64, 2>; 4]) {
+    let mut out = [0; 4];
+    let mut outv = [Simd::splat(0); 4];
+    unsafe {
+        asm!(
+            include_str!("montgomery_square_log_interleaved_3.s"),
+            in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+            in("v0") av[0], in("v1") av[1], in("v2") av[2], in("v3") av[3],
+            lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3")
+            out[3], lateout("v0") outv[0], lateout("v1") outv[1], lateout("v2")
+            outv[2], lateout("v3") outv[3], lateout("x4") _, lateout("x5") _,
+            lateout("x6") _, lateout("x7") _, lateout("x8") _, lateout("x9") _, lateout("x10") _,
+            lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _,
+            lateout("x15") _, lateout("x16") _, lateout("x17") _, lateout("v4") _, lateout("v5") _,
+            lateout("v6") _, lateout("v7") _, lateout("v8") _, lateout("v9") _,
+            lateout("v10") _, lateout("v11") _, lateout("v12") _, lateout("v13") _,
+            lateout("v14") _, lateout("v15") _, lateout("v16") _, lateout("v17") _,
+            lateout("v18") _, lateout("v19") _, lateout("lr") _,
+            options(nomem, nostack)
+        )
+    };
+    (out, outv)
+}
+
 /// A block multiplier with 4 concurrent multiplications.
 ///
 /// Raspberry Pi 5:  1.8 times the throughput compared to a single multiplier.
@@ -167,6 +196,32 @@ mod tests {
             unsafe {
                 with_rounding_mode((), |rtz, _| {
                     let (result_sqr, result_sqr_v) = montgomery_square_interleaved_3(rtz, a, av);
+                    let a_squared = ark_ff_reference(a, a);
+                    let b_squared = ark_ff_reference(b, b);
+                    let c_squared = ark_ff_reference(c, c);
+                    let a_squared_interleaved = Fr::new(BigInt(result_sqr));
+                    let b_squared_interleaved = Fr::new(BigInt(result_sqr_v.map(|e| e[0])));
+                    let c_squared_interleaved = Fr::new(BigInt(result_sqr_v.map(|e| e[1])));
+                    assert_eq!(a_squared, a_squared_interleaved);
+                    assert_eq!(b_squared, b_squared_interleaved);
+                    assert_eq!(c_squared, c_squared_interleaved);
+                });
+            }
+        });
+    }
+
+    /// test that compares square interleaved with ark_ff
+    #[test]
+    fn test_montgomery_square_log() {
+        proptest!(|(
+            a in safe_bn254_montgomery_input(),
+            b in safe_bn254_montgomery_input(),
+            c in safe_bn254_montgomery_input(),
+        )| {
+            let av = array::from_fn(|i| Simd::from_array([b[i],c[i]]));
+            unsafe {
+                with_rounding_mode((), |rtz, _| {
+                    let (result_sqr, result_sqr_v) = montgomery_square_log_interleaved_3(rtz, a, av);
                     let a_squared = ark_ff_reference(a, a);
                     let b_squared = ark_ff_reference(b, b);
                     let c_squared = ark_ff_reference(c, c);

--- a/block-multiplier/src/aarch64/montgomery_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_interleaved_3.s
@@ -20,816 +20,791 @@
   mul x10, x1, x4
   shl.2d v12, v2, #26
   shl.2d v13, v3, #38
-  umulh x12, x1, x4
   ushr.2d v3, v3, #14
+  umulh x12, x1, x4
   shl.2d v14, v0, #2
   usra.2d v11, v0, #50
+  usra.2d v12, v1, #38
   adds x10, x10, x11
   cinc x11, x12, hs
-  usra.2d v12, v1, #38
   usra.2d v13, v2, #26
   and.16b v0, v14, v8
-  mul x12, x2, x4
   and.16b v1, v11, v8
+  mul x12, x2, x4
   and.16b v2, v12, v8
-  umulh x13, x2, x4
   and.16b v11, v13, v8
   shl.2d v12, v5, #14
+  umulh x13, x2, x4
   shl.2d v13, v6, #26
-  adds x11, x12, x11
-  cinc x12, x13, hs
   shl.2d v14, v7, #38
   ushr.2d v7, v7, #14
+  adds x11, x12, x11
+  cinc x12, x13, hs
   shl.2d v15, v4, #2
-  mul x13, x3, x4
   usra.2d v12, v4, #50
   usra.2d v13, v5, #38
+  mul x13, x3, x4
   usra.2d v14, v6, #26
-  umulh x4, x3, x4
   and.16b v4, v15, v8
   and.16b v5, v12, v8
-  adds x12, x13, x12
-  cinc x4, x4, hs
+  umulh x4, x3, x4
   and.16b v6, v13, v8
   and.16b v12, v14, v8
-  mov x13, #13605374474286268416
-  mul x14, x0, x5
-  dup.2d v13, x13
+  mov x14, #13605374474286268416
+  adds x12, x13, x12
+  cinc x4, x4, hs
+  dup.2d v13, x14
   mov x13, #6440147467139809280
   dup.2d v14, x13
-  umulh x13, x0, x5
-  mov x15, #3688448094816436224
-  dup.2d v15, x15
-  adds x10, x14, x10
-  cinc x13, x13, hs
+  mul x13, x0, x5
+  mov x14, #3688448094816436224
+  dup.2d v15, x14
   mov x14, #9209861237972664320
+  umulh x15, x0, x5
   dup.2d v16, x14
   mov x14, #12218265789056155648
-  mul x15, x1, x5
   dup.2d v17, x14
+  adds x10, x13, x10
+  cinc x13, x15, hs
   mov x14, #17739678932212383744
   dup.2d v18, x14
+  mov x14, #2301339409586323456
+  mul x15, x1, x5
+  dup.2d v19, x14
+  mov x14, #7822752552742551552
+  dup.2d v20, x14
   umulh x14, x1, x5
-  mov x16, #2301339409586323456
-  dup.2d v19, x16
+  mov x16, #5071053180419178496
+  dup.2d v21, x16
+  mov x16, #16352570246982270976
   adds x13, x15, x13
   cinc x14, x14, hs
-  mov x15, #7822752552742551552
-  dup.2d v20, x15
-  mov x15, #5071053180419178496
-  adds x11, x13, x11
-  cinc x13, x14, hs
-  dup.2d v21, x15
-  mov x14, #16352570246982270976
-  dup.2d v22, x14
-  mul x14, x2, x5
+  dup.2d v22, x16
   ucvtf.2d v0, v0
   ucvtf.2d v1, v1
+  adds x11, x13, x11
+  cinc x13, x14, hs
   ucvtf.2d v2, v2
-  umulh x15, x2, x5
   ucvtf.2d v11, v11
   ucvtf.2d v3, v3
-  adds x13, x14, x13
-  cinc x14, x15, hs
+  mul x14, x2, x5
   ucvtf.2d v4, v4
   ucvtf.2d v5, v5
   ucvtf.2d v6, v6
-  adds x12, x13, x12
-  cinc x13, x14, hs
+  umulh x15, x2, x5
   ucvtf.2d v12, v12
   ucvtf.2d v7, v7
   mov.16b v23, v9
-  mul x14, x3, x5
+  adds x13, x14, x13
+  cinc x14, x15, hs
   fmla.2d v23, v0, v4
   fsub.2d v24, v10, v23
-  umulh x5, x3, x5
   fmla.2d v24, v0, v4
+  adds x12, x13, x12
+  cinc x13, x14, hs
   add.2d v15, v15, v23
   add.2d v13, v13, v24
+  mov.16b v23, v9
+  mul x14, x3, x5
+  fmla.2d v23, v0, v5
+  fsub.2d v24, v10, v23
+  umulh x5, x3, x5
+  fmla.2d v24, v0, v5
+  add.2d v17, v17, v23
+  add.2d v15, v15, v24
   adds x13, x14, x13
   cinc x5, x5, hs
   mov.16b v23, v9
-  fmla.2d v23, v0, v5
+  fmla.2d v23, v0, v6
   fsub.2d v24, v10, v23
   adds x4, x13, x4
   cinc x5, x5, hs
-  fmla.2d v24, v0, v5
-  add.2d v17, v17, v23
-  mul x13, x0, x6
-  add.2d v15, v15, v24
-  mov.16b v23, v9
-  fmla.2d v23, v0, v6
-  umulh x14, x0, x6
-  fsub.2d v24, v10, v23
   fmla.2d v24, v0, v6
   add.2d v19, v19, v23
-  adds x11, x13, x11
-  cinc x13, x14, hs
   add.2d v17, v17, v24
+  mul x13, x0, x6
   mov.16b v23, v9
   fmla.2d v23, v0, v12
-  mul x14, x1, x6
   fsub.2d v24, v10, v23
+  umulh x14, x0, x6
   fmla.2d v24, v0, v12
-  umulh x15, x1, x6
   add.2d v21, v21, v23
   add.2d v19, v19, v24
+  adds x11, x13, x11
+  cinc x13, x14, hs
   mov.16b v23, v9
-  adds x13, x14, x13
-  cinc x14, x15, hs
   fmla.2d v23, v0, v7
   fsub.2d v24, v10, v23
+  mul x14, x1, x6
   fmla.2d v24, v0, v7
-  adds x12, x13, x12
-  cinc x13, x14, hs
   add.2d v0, v22, v23
   add.2d v21, v21, v24
-  mul x14, x2, x6
+  umulh x15, x1, x6
   mov.16b v22, v9
   fmla.2d v22, v1, v4
   fsub.2d v23, v10, v22
-  umulh x15, x2, x6
+  adds x13, x14, x13
+  cinc x14, x15, hs
   fmla.2d v23, v1, v4
   add.2d v17, v17, v22
   add.2d v15, v15, v23
-  adds x13, x14, x13
-  cinc x14, x15, hs
+  adds x12, x13, x12
+  cinc x13, x14, hs
   mov.16b v22, v9
   fmla.2d v22, v1, v5
-  adds x4, x13, x4
-  cinc x13, x14, hs
   fsub.2d v23, v10, v22
+  mul x14, x2, x6
   fmla.2d v23, v1, v5
   add.2d v19, v19, v22
-  mul x14, x3, x6
   add.2d v17, v17, v23
+  umulh x15, x2, x6
   mov.16b v22, v9
   fmla.2d v22, v1, v6
-  umulh x6, x3, x6
   fsub.2d v23, v10, v22
+  adds x13, x14, x13
+  cinc x14, x15, hs
   fmla.2d v23, v1, v6
   add.2d v21, v21, v22
-  adds x13, x14, x13
-  cinc x6, x6, hs
   add.2d v19, v19, v23
+  adds x4, x13, x4
+  cinc x13, x14, hs
   mov.16b v22, v9
-  adds x5, x13, x5
-  cinc x6, x6, hs
   fmla.2d v22, v1, v12
   fsub.2d v23, v10, v22
+  mul x14, x3, x6
   fmla.2d v23, v1, v12
-  mul x13, x0, x7
   add.2d v0, v0, v22
   add.2d v21, v21, v23
+  umulh x6, x3, x6
   mov.16b v22, v9
-  umulh x0, x0, x7
   fmla.2d v22, v1, v7
   fsub.2d v23, v10, v22
-  adds x12, x13, x12
-  cinc x0, x0, hs
+  adds x13, x14, x13
+  cinc x6, x6, hs
   fmla.2d v23, v1, v7
   add.2d v1, v20, v22
   add.2d v0, v0, v23
-  mul x13, x1, x7
+  adds x5, x13, x5
+  cinc x6, x6, hs
   mov.16b v20, v9
   fmla.2d v20, v2, v4
   fsub.2d v22, v10, v20
-  umulh x1, x1, x7
+  mul x13, x0, x7
   fmla.2d v22, v2, v4
   add.2d v19, v19, v20
-  adds x0, x13, x0
-  cinc x1, x1, hs
   add.2d v17, v17, v22
+  umulh x0, x0, x7
   mov.16b v20, v9
   fmla.2d v20, v2, v5
-  adds x0, x0, x4
-  cinc x1, x1, hs
   fsub.2d v22, v10, v20
+  adds x12, x13, x12
+  cinc x0, x0, hs
   fmla.2d v22, v2, v5
   add.2d v20, v21, v20
-  mul x4, x2, x7
   add.2d v19, v19, v22
+  mul x13, x1, x7
   mov.16b v21, v9
   fmla.2d v21, v2, v6
-  umulh x2, x2, x7
   fsub.2d v22, v10, v21
+  umulh x1, x1, x7
   fmla.2d v22, v2, v6
-  adds x1, x4, x1
-  cinc x2, x2, hs
   add.2d v0, v0, v21
   add.2d v20, v20, v22
+  adds x0, x13, x0
+  cinc x1, x1, hs
   mov.16b v21, v9
-  adds x1, x1, x5
-  cinc x2, x2, hs
   fmla.2d v21, v2, v12
+  adds x0, x0, x4
+  cinc x1, x1, hs
   fsub.2d v22, v10, v21
   fmla.2d v22, v2, v12
-  mul x4, x3, x7
   add.2d v1, v1, v21
+  mul x4, x2, x7
   add.2d v0, v0, v22
-  umulh x3, x3, x7
   mov.16b v21, v9
   fmla.2d v21, v2, v7
+  umulh x2, x2, x7
   fsub.2d v22, v10, v21
-  adds x2, x4, x2
-  cinc x3, x3, hs
   fmla.2d v22, v2, v7
   add.2d v2, v18, v21
+  adds x1, x4, x1
+  cinc x2, x2, hs
   add.2d v1, v1, v22
-  adds x2, x2, x6
-  cinc x3, x3, hs
   mov.16b v18, v9
   fmla.2d v18, v11, v4
-  mov x4, #48718
+  adds x1, x1, x5
+  cinc x2, x2, hs
   fsub.2d v21, v10, v18
   fmla.2d v21, v11, v4
   add.2d v18, v20, v18
-  movk x4, #4732, lsl 16
+  mul x4, x3, x7
   add.2d v19, v19, v21
   mov.16b v20, v9
   fmla.2d v20, v11, v5
-  movk x4, #45078, lsl 32
+  umulh x3, x3, x7
   fsub.2d v21, v10, v20
   fmla.2d v21, v11, v5
   add.2d v0, v0, v20
-  movk x4, #39852, lsl 48
+  adds x2, x4, x2
+  cinc x3, x3, hs
   add.2d v18, v18, v21
   mov.16b v20, v9
-  mov x5, #16676
   fmla.2d v20, v11, v6
+  adds x2, x2, x6
+  cinc x3, x3, hs
   fsub.2d v21, v10, v20
   fmla.2d v21, v11, v6
-  movk x5, #12692, lsl 16
   add.2d v1, v1, v20
+  mov x4, #48718
   add.2d v0, v0, v21
   mov.16b v20, v9
-  movk x5, #20986, lsl 32
   fmla.2d v20, v11, v12
+  movk x4, #4732, lsl 16
   fsub.2d v21, v10, v20
-  movk x5, #2848, lsl 48
   fmla.2d v21, v11, v12
   add.2d v2, v2, v20
+  movk x4, #45078, lsl 32
   add.2d v1, v1, v21
-  mov x6, #51052
   mov.16b v20, v9
   fmla.2d v20, v11, v7
+  movk x4, #39852, lsl 48
   fsub.2d v21, v10, v20
-  movk x6, #24721, lsl 16
   fmla.2d v21, v11, v7
   add.2d v11, v16, v20
-  movk x6, #61092, lsl 32
+  mov x5, #16676
   add.2d v2, v2, v21
   mov.16b v16, v9
   fmla.2d v16, v3, v4
-  movk x6, #45156, lsl 48
+  movk x5, #12692, lsl 16
   fsub.2d v20, v10, v16
   fmla.2d v20, v3, v4
   add.2d v0, v0, v16
-  mov x7, #3197
+  movk x5, #20986, lsl 32
   add.2d v4, v18, v20
   mov.16b v16, v9
   fmla.2d v16, v3, v5
-  movk x7, #18936, lsl 16
+  movk x5, #2848, lsl 48
   fsub.2d v18, v10, v16
   fmla.2d v18, v3, v5
-  movk x7, #10922, lsl 32
   add.2d v1, v1, v16
+  mov x6, #51052
   add.2d v0, v0, v18
   mov.16b v5, v9
-  movk x7, #11014, lsl 48
   fmla.2d v5, v3, v6
+  movk x6, #24721, lsl 16
   fsub.2d v16, v10, v5
   fmla.2d v16, v3, v6
-  mul x13, x4, x9
   add.2d v2, v2, v5
+  movk x6, #61092, lsl 32
   add.2d v1, v1, v16
-  umulh x4, x4, x9
   mov.16b v5, v9
   fmla.2d v5, v3, v12
+  movk x6, #45156, lsl 48
   fsub.2d v6, v10, v5
-  adds x12, x13, x12
-  cinc x4, x4, hs
   fmla.2d v6, v3, v12
   add.2d v5, v11, v5
+  mov x7, #3197
   add.2d v2, v2, v6
-  mul x13, x5, x9
   mov.16b v6, v9
   fmla.2d v6, v3, v7
-  umulh x5, x5, x9
+  movk x7, #18936, lsl 16
   fsub.2d v11, v10, v6
   fmla.2d v11, v3, v7
+  movk x7, #10922, lsl 32
   add.2d v3, v14, v6
-  adds x4, x13, x4
-  cinc x5, x5, hs
   add.2d v5, v5, v11
   usra.2d v15, v13, #52
+  movk x7, #11014, lsl 48
   usra.2d v17, v15, #52
-  adds x0, x4, x0
-  cinc x4, x5, hs
   usra.2d v19, v17, #52
   usra.2d v4, v19, #52
+  mul x13, x4, x9
   and.16b v6, v13, v8
-  mul x5, x6, x9
   and.16b v7, v15, v8
   and.16b v11, v17, v8
-  umulh x6, x6, x9
+  umulh x4, x4, x9
   and.16b v8, v19, v8
   ucvtf.2d v6, v6
-  mov x13, #37864
+  mov x14, #37864
+  adds x12, x13, x12
+  cinc x4, x4, hs
+  movk x14, #1815, lsl 16
+  movk x14, #28960, lsl 32
+  movk x14, #17153, lsl 48
+  mul x13, x5, x9
+  dup.2d v12, x14
+  mov.16b v13, v9
+  fmla.2d v13, v6, v12
+  umulh x5, x5, x9
+  fsub.2d v14, v10, v13
+  fmla.2d v14, v6, v12
+  add.2d v0, v0, v13
+  adds x4, x13, x4
+  cinc x5, x5, hs
+  add.2d v4, v4, v14
+  mov x13, #46128
+  movk x13, #29964, lsl 16
+  adds x0, x4, x0
+  cinc x4, x5, hs
+  movk x13, #7587, lsl 32
+  movk x13, #17161, lsl 48
+  dup.2d v12, x13
+  mul x5, x6, x9
+  mov.16b v13, v9
+  fmla.2d v13, v6, v12
+  fsub.2d v14, v10, v13
+  umulh x6, x6, x9
+  fmla.2d v14, v6, v12
+  add.2d v1, v1, v13
+  add.2d v0, v0, v14
   adds x4, x5, x4
   cinc x5, x6, hs
-  movk x13, #1815, lsl 16
-  movk x13, #28960, lsl 32
-  movk x13, #17153, lsl 48
+  mov x6, #52826
+  movk x6, #57790, lsl 16
+  movk x6, #55431, lsl 32
   adds x1, x4, x1
   cinc x4, x5, hs
-  dup.2d v12, x13
+  movk x6, #17196, lsl 48
+  dup.2d v12, x6
   mov.16b v13, v9
   mul x5, x7, x9
   fmla.2d v13, v6, v12
   fsub.2d v14, v10, v13
   fmla.2d v14, v6, v12
   umulh x6, x7, x9
-  add.2d v0, v0, v13
-  add.2d v4, v4, v14
-  mov x7, #46128
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  movk x7, #29964, lsl 16
-  movk x7, #7587, lsl 32
-  adds x2, x4, x2
-  cinc x4, x5, hs
-  movk x7, #17161, lsl 48
-  dup.2d v12, x7
-  mov.16b v13, v9
-  add x3, x3, x4
-  fmla.2d v13, v6, v12
-  fsub.2d v14, v10, v13
-  fmla.2d v14, v6, v12
-  mov x4, #56431
-  add.2d v1, v1, v13
-  add.2d v0, v0, v14
-  mov x5, #52826
-  movk x4, #30457, lsl 16
-  movk x5, #57790, lsl 16
-  movk x5, #55431, lsl 32
-  movk x4, #30012, lsl 32
-  movk x5, #17196, lsl 48
-  dup.2d v12, x5
-  mov.16b v13, v9
-  movk x4, #6382, lsl 48
-  fmla.2d v13, v6, v12
-  fsub.2d v14, v10, v13
-  fmla.2d v14, v6, v12
-  mov x5, #59151
   add.2d v2, v2, v13
   add.2d v1, v1, v14
-  movk x5, #41769, lsl 16
-  mov x6, #31276
-  movk x6, #21262, lsl 16
-  movk x6, #2304, lsl 32
-  movk x5, #32276, lsl 32
-  movk x6, #17182, lsl 48
-  dup.2d v12, x6
-  mov.16b v13, v9
-  movk x5, #21677, lsl 48
-  fmla.2d v13, v6, v12
-  fsub.2d v14, v10, v13
-  mov x6, #34015
-  fmla.2d v14, v6, v12
-  add.2d v5, v5, v13
-  add.2d v2, v2, v14
-  movk x6, #20342, lsl 16
-  mov x7, #28672
-  movk x7, #24515, lsl 16
-  movk x7, #54929, lsl 32
-  movk x6, #13935, lsl 32
-  movk x7, #17064, lsl 48
+  mov x7, #31276
+  adds x4, x5, x4
+  cinc x5, x6, hs
+  movk x7, #21262, lsl 16
+  movk x7, #2304, lsl 32
+  movk x7, #17182, lsl 48
+  adds x2, x4, x2
+  cinc x4, x5, hs
   dup.2d v12, x7
   mov.16b v13, v9
-  movk x6, #11030, lsl 48
+  fmla.2d v13, v6, v12
+  add x3, x3, x4
+  fsub.2d v14, v10, v13
+  fmla.2d v14, v6, v12
+  add.2d v5, v5, v13
+  mov x4, #56431
+  add.2d v2, v2, v14
+  mov x5, #28672
+  movk x5, #24515, lsl 16
+  movk x4, #30457, lsl 16
+  movk x5, #54929, lsl 32
+  movk x5, #17064, lsl 48
+  dup.2d v12, x5
+  movk x4, #30012, lsl 32
+  mov.16b v13, v9
   fmla.2d v13, v6, v12
   fsub.2d v14, v10, v13
-  mov x7, #13689
+  movk x4, #6382, lsl 48
   fmla.2d v14, v6, v12
   add.2d v3, v3, v13
   add.2d v5, v5, v14
-  movk x7, #8159, lsl 16
+  mov x5, #59151
   ucvtf.2d v6, v7
-  mov x9, #44768
-  movk x9, #51919, lsl 16
+  mov x6, #44768
+  movk x6, #51919, lsl 16
+  movk x5, #41769, lsl 16
+  movk x6, #6346, lsl 32
+  movk x6, #17133, lsl 48
+  movk x5, #32276, lsl 32
+  dup.2d v7, x6
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
+  movk x5, #21677, lsl 48
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
+  add.2d v0, v0, v12
+  mov x6, #34015
+  add.2d v4, v4, v13
+  mov x7, #47492
+  movk x7, #23630, lsl 16
+  movk x6, #20342, lsl 16
+  movk x7, #49985, lsl 32
+  movk x7, #17168, lsl 48
+  dup.2d v7, x7
+  movk x6, #13935, lsl 32
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
+  movk x6, #11030, lsl 48
+  fmla.2d v13, v6, v7
+  add.2d v1, v1, v12
+  add.2d v0, v0, v13
+  mov x7, #13689
+  mov x9, #57936
+  movk x9, #54828, lsl 16
+  movk x9, #18292, lsl 32
+  movk x7, #8159, lsl 16
+  movk x9, #17197, lsl 48
+  dup.2d v7, x9
+  mov.16b v12, v9
   movk x7, #215, lsl 32
-  movk x9, #6346, lsl 32
-  movk x9, #17133, lsl 48
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
   movk x7, #4913, lsl 48
+  add.2d v2, v2, v12
+  add.2d v1, v1, v13
+  mov x9, #17708
+  mul x13, x4, x10
+  movk x9, #43915, lsl 16
+  movk x9, #64348, lsl 32
+  movk x9, #17188, lsl 48
+  umulh x4, x4, x10
   dup.2d v7, x9
   mov.16b v12, v9
   fmla.2d v12, v6, v7
-  mul x9, x4, x10
-  fsub.2d v13, v10, v12
-  fmla.2d v13, v6, v7
-  add.2d v0, v0, v12
-  umulh x4, x4, x10
-  add.2d v4, v4, v13
-  mov x13, #47492
-  adds x9, x9, x12
+  adds x9, x13, x12
   cinc x4, x4, hs
-  movk x13, #23630, lsl 16
-  movk x13, #49985, lsl 32
-  movk x13, #17168, lsl 48
-  mul x12, x5, x10
-  dup.2d v7, x13
-  mov.16b v12, v9
-  fmla.2d v12, v6, v7
-  umulh x5, x5, x10
   fsub.2d v13, v10, v12
   fmla.2d v13, v6, v7
-  add.2d v1, v1, v12
+  add.2d v5, v5, v12
+  mul x12, x5, x10
+  add.2d v2, v2, v13
+  mov x13, #29184
+  movk x13, #20789, lsl 16
+  umulh x5, x5, x10
+  movk x13, #19197, lsl 32
+  movk x13, #17083, lsl 48
+  dup.2d v7, x13
   adds x4, x12, x4
   cinc x5, x5, hs
-  add.2d v0, v0, v13
-  mov x12, #57936
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
   adds x0, x4, x0
   cinc x4, x5, hs
-  movk x12, #54828, lsl 16
-  movk x12, #18292, lsl 32
-  movk x12, #17197, lsl 48
-  mul x5, x6, x10
-  dup.2d v7, x12
-  mov.16b v12, v9
-  fmla.2d v12, v6, v7
-  umulh x6, x6, x10
-  fsub.2d v13, v10, v12
   fmla.2d v13, v6, v7
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  add.2d v2, v2, v12
-  add.2d v1, v1, v13
-  mov x6, #17708
-  adds x1, x4, x1
-  cinc x4, x5, hs
-  movk x6, #43915, lsl 16
-  movk x6, #64348, lsl 32
-  movk x6, #17188, lsl 48
-  mul x5, x7, x10
-  dup.2d v7, x6
-  mov.16b v12, v9
-  umulh x6, x7, x10
-  fmla.2d v12, v6, v7
-  fsub.2d v13, v10, v12
-  fmla.2d v13, v6, v7
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  add.2d v5, v5, v12
-  add.2d v2, v2, v13
-  mov x6, #29184
-  adds x2, x4, x2
-  cinc x4, x5, hs
-  movk x6, #20789, lsl 16
-  movk x6, #19197, lsl 32
-  movk x6, #17083, lsl 48
-  add x3, x3, x4
-  dup.2d v7, x6
-  mov.16b v12, v9
-  mov x4, #61005
-  fmla.2d v12, v6, v7
-  fsub.2d v13, v10, v12
-  fmla.2d v13, v6, v7
-  movk x4, #58262, lsl 16
   add.2d v3, v3, v12
   add.2d v5, v5, v13
+  mul x5, x6, x10
   ucvtf.2d v6, v11
-  movk x4, #32851, lsl 32
-  mov x5, #58856
-  movk x5, #14953, lsl 16
-  movk x4, #11582, lsl 48
-  movk x5, #15155, lsl 32
-  movk x5, #17181, lsl 48
-  dup.2d v7, x5
-  mov x5, #37581
+  mov x12, #58856
+  movk x12, #14953, lsl 16
+  umulh x6, x6, x10
+  movk x12, #15155, lsl 32
+  movk x12, #17181, lsl 48
+  dup.2d v7, x12
+  adds x4, x5, x4
+  cinc x5, x6, hs
   mov.16b v11, v9
   fmla.2d v11, v6, v7
   fsub.2d v12, v10, v11
-  movk x5, #43836, lsl 16
+  adds x1, x4, x1
+  cinc x4, x5, hs
   fmla.2d v12, v6, v7
   add.2d v0, v0, v11
-  movk x5, #36286, lsl 32
   add.2d v4, v4, v12
+  mul x5, x7, x10
   mov x6, #35392
   movk x6, #12477, lsl 16
-  movk x5, #51783, lsl 48
   movk x6, #56780, lsl 32
+  umulh x7, x7, x10
   movk x6, #17142, lsl 48
   dup.2d v7, x6
-  mov x6, #10899
   mov.16b v11, v9
+  adds x4, x5, x4
+  cinc x5, x7, hs
   fmla.2d v11, v6, v7
   fsub.2d v12, v10, v11
-  movk x6, #30709, lsl 16
+  adds x2, x4, x2
+  cinc x4, x5, hs
   fmla.2d v12, v6, v7
   add.2d v1, v1, v11
-  movk x6, #61551, lsl 32
   add.2d v0, v0, v12
-  mov x7, #9848
-  movk x7, #54501, lsl 16
-  movk x6, #45784, lsl 48
-  movk x7, #31540, lsl 32
-  movk x7, #17170, lsl 48
-  dup.2d v7, x7
-  mov x7, #36612
+  add x3, x3, x4
+  mov x4, #9848
+  movk x4, #54501, lsl 16
+  movk x4, #31540, lsl 32
+  mov x5, #61005
+  movk x4, #17170, lsl 48
+  dup.2d v7, x4
   mov.16b v11, v9
+  movk x5, #58262, lsl 16
   fmla.2d v11, v6, v7
-  movk x7, #63402, lsl 16
   fsub.2d v12, v10, v11
   fmla.2d v12, v6, v7
+  movk x5, #32851, lsl 32
   add.2d v2, v2, v11
-  movk x7, #47623, lsl 32
   add.2d v1, v1, v12
-  mov x10, #9584
-  movk x10, #63883, lsl 16
-  movk x7, #9430, lsl 48
-  movk x10, #18253, lsl 32
-  movk x10, #17190, lsl 48
-  mul x12, x4, x11
-  dup.2d v7, x10
+  mov x4, #9584
+  movk x5, #11582, lsl 48
+  movk x4, #63883, lsl 16
+  movk x4, #18253, lsl 32
+  movk x4, #17190, lsl 48
+  mov x6, #37581
+  dup.2d v7, x4
   mov.16b v11, v9
   fmla.2d v11, v6, v7
-  umulh x4, x4, x11
+  movk x6, #43836, lsl 16
   fsub.2d v12, v10, v11
   fmla.2d v12, v6, v7
   add.2d v5, v5, v11
-  adds x9, x12, x9
-  cinc x4, x4, hs
+  movk x6, #36286, lsl 32
   add.2d v2, v2, v12
-  mov x10, #51712
-  movk x10, #16093, lsl 16
-  mul x12, x5, x11
-  movk x10, #30633, lsl 32
-  movk x10, #17068, lsl 48
-  umulh x5, x5, x11
-  dup.2d v7, x10
+  mov x4, #51712
+  movk x4, #16093, lsl 16
+  movk x6, #51783, lsl 48
+  movk x4, #30633, lsl 32
+  movk x4, #17068, lsl 48
+  dup.2d v7, x4
+  mov x4, #10899
   mov.16b v11, v9
   fmla.2d v11, v6, v7
-  adds x4, x12, x4
-  cinc x5, x5, hs
   fsub.2d v12, v10, v11
+  movk x4, #30709, lsl 16
   fmla.2d v12, v6, v7
   add.2d v3, v3, v11
-  adds x0, x4, x0
-  cinc x4, x5, hs
   add.2d v5, v5, v12
+  movk x4, #61551, lsl 32
   ucvtf.2d v6, v8
-  mul x5, x6, x11
-  mov x10, #34724
-  movk x10, #40393, lsl 16
-  movk x10, #23752, lsl 32
-  umulh x6, x6, x11
-  movk x10, #17184, lsl 48
-  dup.2d v7, x10
+  mov x7, #34724
+  movk x7, #40393, lsl 16
+  movk x4, #45784, lsl 48
+  movk x7, #23752, lsl 32
+  movk x7, #17184, lsl 48
+  dup.2d v7, x7
+  mov x7, #36612
   mov.16b v8, v9
-  adds x4, x5, x4
-  cinc x5, x6, hs
   fmla.2d v8, v6, v7
   fsub.2d v11, v10, v8
-  adds x1, x4, x1
-  cinc x4, x5, hs
+  movk x7, #63402, lsl 16
   fmla.2d v11, v6, v7
   add.2d v0, v0, v8
   add.2d v4, v4, v11
-  mul x5, x7, x11
-  mov x6, #25532
-  movk x6, #31025, lsl 16
-  movk x6, #10002, lsl 32
-  umulh x7, x7, x11
-  movk x6, #17199, lsl 48
-  dup.2d v7, x6
+  movk x7, #47623, lsl 32
+  mov x10, #25532
+  movk x10, #31025, lsl 16
+  movk x10, #10002, lsl 32
+  movk x7, #9430, lsl 48
+  movk x10, #17199, lsl 48
+  dup.2d v7, x10
   mov.16b v8, v9
-  adds x4, x5, x4
-  cinc x5, x7, hs
+  mul x10, x5, x11
   fmla.2d v8, v6, v7
   fsub.2d v11, v10, v8
-  adds x2, x4, x2
-  cinc x4, x5, hs
   fmla.2d v11, v6, v7
+  umulh x5, x5, x11
   add.2d v1, v1, v8
   add.2d v0, v0, v11
-  add x3, x3, x4
-  mov x4, #18830
-  movk x4, #2465, lsl 16
-  movk x4, #36348, lsl 32
-  mov x5, #65535
-  movk x4, #17194, lsl 48
-  dup.2d v7, x4
-  movk x5, #61439, lsl 16
+  mov x12, #18830
+  adds x9, x10, x9
+  cinc x5, x5, hs
+  movk x12, #2465, lsl 16
+  movk x12, #36348, lsl 32
+  movk x12, #17194, lsl 48
+  mul x10, x6, x11
+  dup.2d v7, x12
   mov.16b v8, v9
   fmla.2d v8, v6, v7
+  umulh x6, x6, x11
   fsub.2d v11, v10, v8
-  movk x5, #62867, lsl 32
   fmla.2d v11, v6, v7
+  adds x5, x10, x5
+  cinc x6, x6, hs
   add.2d v2, v2, v8
   add.2d v1, v1, v11
-  movk x5, #49889, lsl 48
-  mov x4, #21566
-  movk x4, #43708, lsl 16
-  mul x5, x5, x9
-  movk x4, #57685, lsl 32
-  movk x4, #17185, lsl 48
-  dup.2d v7, x4
-  mov x4, #1
+  mov x10, #21566
+  adds x0, x5, x0
+  cinc x5, x6, hs
+  movk x10, #43708, lsl 16
+  movk x10, #57685, lsl 32
+  movk x10, #17185, lsl 48
+  mul x6, x4, x11
+  dup.2d v7, x10
   mov.16b v8, v9
   fmla.2d v8, v6, v7
+  umulh x4, x4, x11
   fsub.2d v11, v10, v8
-  movk x4, #61440, lsl 16
   fmla.2d v11, v6, v7
   add.2d v5, v5, v8
+  adds x5, x6, x5
+  cinc x4, x4, hs
   add.2d v2, v2, v11
-  movk x4, #62867, lsl 32
   mov x6, #3072
   movk x6, #8058, lsl 16
-  movk x4, #17377, lsl 48
+  adds x1, x5, x1
+  cinc x4, x4, hs
   movk x6, #46097, lsl 32
   movk x6, #17047, lsl 48
   dup.2d v7, x6
-  mov x6, #28817
+  mul x5, x7, x11
   mov.16b v8, v9
   fmla.2d v8, v6, v7
   fsub.2d v11, v10, v8
-  movk x6, #31161, lsl 16
+  umulh x6, x7, x11
   fmla.2d v11, v6, v7
   add.2d v3, v3, v8
-  movk x6, #59464, lsl 32
   add.2d v5, v5, v11
-  mov x7, #65535
-  movk x7, #61439, lsl 16
-  movk x6, #10291, lsl 48
-  movk x7, #62867, lsl 32
-  movk x7, #1, lsl 48
-  umov x10, v4.d[0]
-  mov x11, #22621
-  umov x12, v4.d[1]
-  mul x10, x10, x7
-  movk x11, #33153, lsl 16
-  mul x7, x12, x7
-  and x10, x10, x8
-  and x7, x7, x8
-  movk x11, #17846, lsl 32
-  ins v6.d[0], x10
-  ins v6.d[1], x7
+  adds x4, x5, x4
+  cinc x5, x6, hs
+  mov x6, #65535
+  movk x6, #61439, lsl 16
+  movk x6, #62867, lsl 32
+  adds x2, x4, x2
+  cinc x4, x5, hs
+  movk x6, #1, lsl 48
+  umov x5, v4.d[0]
+  umov x7, v4.d[1]
+  add x3, x3, x4
+  mul x4, x5, x6
+  mul x5, x7, x6
+  and x4, x4, x8
+  mov x6, #65535
+  and x5, x5, x8
+  ins v6.d[0], x4
+  ins v6.d[1], x5
   ucvtf.2d v6, v6
-  mov x7, #16
-  movk x11, #47184, lsl 48
-  movk x7, #22847, lsl 32
-  movk x7, #17151, lsl 48
-  dup.2d v7, x7
-  mov x7, #41001
+  movk x6, #61439, lsl 16
+  mov x4, #16
+  movk x4, #22847, lsl 32
+  movk x4, #17151, lsl 48
+  movk x6, #62867, lsl 32
+  dup.2d v7, x4
   mov.16b v8, v9
   fmla.2d v8, v6, v7
-  movk x7, #57649, lsl 16
+  movk x6, #49889, lsl 48
   fsub.2d v11, v10, v8
   fmla.2d v11, v6, v7
   add.2d v0, v0, v8
-  movk x7, #20082, lsl 32
+  mul x4, x6, x9
   add.2d v4, v4, v11
-  mov x8, #20728
-  movk x8, #23588, lsl 16
-  movk x7, #12388, lsl 48
-  movk x8, #7790, lsl 32
-  movk x8, #17170, lsl 48
-  mul x10, x4, x5
-  dup.2d v7, x8
+  mov x5, #20728
+  movk x5, #23588, lsl 16
+  mov x6, #1
+  movk x5, #7790, lsl 32
+  movk x5, #17170, lsl 48
+  dup.2d v7, x5
+  movk x6, #61440, lsl 16
   mov.16b v8, v9
   fmla.2d v8, v6, v7
-  umulh x4, x4, x5
   fsub.2d v11, v10, v8
+  movk x6, #62867, lsl 32
   fmla.2d v11, v6, v7
   add.2d v1, v1, v8
-  cmn x10, x9
-  cinc x4, x4, hs
   add.2d v0, v0, v11
-  mov x8, #16000
-  mul x9, x6, x5
-  movk x8, #53891, lsl 16
-  movk x8, #5509, lsl 32
-  movk x8, #17144, lsl 48
-  umulh x6, x6, x5
-  dup.2d v7, x8
+  movk x6, #17377, lsl 48
+  mov x5, #16000
+  movk x5, #53891, lsl 16
+  movk x5, #5509, lsl 32
+  mov x7, #28817
+  movk x5, #17144, lsl 48
+  dup.2d v7, x5
   mov.16b v8, v9
+  movk x7, #31161, lsl 16
   fmla.2d v8, v6, v7
-  adds x4, x9, x4
-  cinc x6, x6, hs
   fsub.2d v11, v10, v8
   fmla.2d v11, v6, v7
+  movk x7, #59464, lsl 32
   add.2d v2, v2, v8
-  adds x0, x4, x0
-  cinc x4, x6, hs
   add.2d v1, v1, v11
-  mov x6, #46800
-  mul x8, x11, x5
-  movk x6, #2568, lsl 16
-  movk x6, #1335, lsl 32
-  movk x6, #17188, lsl 48
-  umulh x9, x11, x5
-  dup.2d v7, x6
+  mov x5, #46800
+  movk x7, #10291, lsl 48
+  movk x5, #2568, lsl 16
+  movk x5, #1335, lsl 32
+  mov x8, #22621
+  movk x5, #17188, lsl 48
+  dup.2d v7, x5
   mov.16b v8, v9
+  movk x8, #33153, lsl 16
   fmla.2d v8, v6, v7
-  adds x4, x8, x4
-  cinc x6, x9, hs
   fsub.2d v11, v10, v8
   fmla.2d v11, v6, v7
-  adds x1, x4, x1
-  cinc x4, x6, hs
+  movk x8, #17846, lsl 32
   add.2d v5, v5, v8
   add.2d v2, v2, v11
-  mov x6, #39040
-  mul x8, x7, x5
-  movk x6, #14704, lsl 16
-  movk x6, #12839, lsl 32
-  movk x6, #17096, lsl 48
-  umulh x5, x7, x5
-  dup.2d v7, x6
+  mov x5, #39040
+  movk x8, #47184, lsl 48
+  movk x5, #14704, lsl 16
+  movk x5, #12839, lsl 32
+  movk x5, #17096, lsl 48
+  mov x10, #41001
+  dup.2d v7, x5
   mov.16b v8, v9
-  adds x4, x8, x4
-  cinc x5, x5, hs
   fmla.2d v8, v6, v7
+  movk x10, #57649, lsl 16
   fsub.2d v9, v10, v8
   fmla.2d v9, v6, v7
-  adds x2, x4, x2
-  cinc x4, x5, hs
   add.2d v3, v3, v8
+  movk x10, #20082, lsl 32
   add.2d v5, v5, v9
   mov x5, #140737488355328
-  add x3, x3, x4
   dup.2d v6, x5
+  movk x10, #12388, lsl 48
   and.16b v6, v3, v6
   cmeq.2d v6, v6, #0
-  mov x4, #2
   mov x5, #2
+  mul x11, x6, x4
   movk x5, #57344, lsl 16
-  movk x4, #57344, lsl 16
   movk x5, #60199, lsl 32
   movk x5, #3, lsl 48
+  umulh x6, x6, x4
   dup.2d v7, x5
-  movk x4, #60199, lsl 32
   bic.16b v7, v7, v6
   mov x5, #10364
+  cmn x11, x9
+  cinc x6, x6, hs
   movk x5, #11794, lsl 16
-  movk x4, #34755, lsl 48
   movk x5, #3895, lsl 32
   movk x5, #9, lsl 48
-  mov x6, #57634
+  mul x9, x7, x4
   dup.2d v8, x5
   bic.16b v8, v8, v6
   mov x5, #26576
-  movk x6, #62322, lsl 16
+  umulh x7, x7, x4
   movk x5, #47696, lsl 16
   movk x5, #688, lsl 32
   movk x5, #3, lsl 48
-  movk x6, #53392, lsl 32
+  adds x6, x9, x6
+  cinc x7, x7, hs
   dup.2d v9, x5
   bic.16b v9, v9, v6
-  movk x6, #20583, lsl 48
   mov x5, #46800
+  adds x0, x6, x0
+  cinc x6, x7, hs
   movk x5, #2568, lsl 16
   movk x5, #1335, lsl 32
-  mov x7, #45242
   movk x5, #4, lsl 48
+  mul x7, x8, x4
   dup.2d v10, x5
   bic.16b v10, v10, v6
-  movk x7, #770, lsl 16
   mov x5, #49763
+  umulh x8, x8, x4
   movk x5, #40165, lsl 16
   movk x5, #24776, lsl 32
-  movk x7, #35693, lsl 32
   dup.2d v11, x5
+  adds x5, x7, x6
+  cinc x6, x8, hs
   bic.16b v6, v11, v6
-  movk x7, #28832, lsl 48
   sub.2d v0, v0, v7
   ssra.2d v0, v4, #52
+  adds x1, x5, x1
+  cinc x5, x6, hs
   sub.2d v4, v1, v8
-  mov x5, #16467
   ssra.2d v4, v0, #52
   sub.2d v7, v2, v9
+  mul x6, x10, x4
   ssra.2d v7, v4, #52
-  movk x5, #49763, lsl 16
   sub.2d v5, v5, v10
   ssra.2d v5, v7, #52
-  movk x5, #40165, lsl 32
+  umulh x4, x10, x4
   sub.2d v6, v3, v6
   ssra.2d v6, v5, #52
   ushr.2d v1, v4, #12
-  movk x5, #24776, lsl 48
+  adds x5, x6, x5
+  cinc x4, x4, hs
   ushr.2d v2, v7, #24
   ushr.2d v3, v5, #36
   sli.2d v0, v4, #52
-  subs x4, x0, x4
-  sbcs x6, x1, x6
-  sbcs x7, x2, x7
-  sbcs x5, x3, x5
+  adds x2, x5, x2
+  cinc x4, x4, hs
   sli.2d v1, v7, #40
   sli.2d v2, v5, #28
   sli.2d v3, v6, #16
-  tst x3, #9223372036854775808
-  csel x0, x4, x0, mi
-  csel x1, x6, x1, mi
-  csel x2, x7, x2, mi
-  csel x3, x5, x3, mi
+  add x3, x3, x4

--- a/block-multiplier/src/aarch64/montgomery_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_interleaved_3.s
@@ -24,787 +24,749 @@
   umulh x12, x1, x4
   shl.2d v14, v0, #2
   usra.2d v11, v0, #50
-  usra.2d v12, v1, #38
   adds x10, x10, x11
   cinc x11, x12, hs
+  usra.2d v12, v1, #38
   usra.2d v13, v2, #26
   and.16b v0, v14, v8
-  and.16b v1, v11, v8
   mul x12, x2, x4
+  and.16b v1, v11, v8
   and.16b v2, v12, v8
   and.16b v11, v13, v8
-  shl.2d v12, v5, #14
   umulh x13, x2, x4
+  shl.2d v12, v5, #14
   shl.2d v13, v6, #26
   shl.2d v14, v7, #38
-  ushr.2d v7, v7, #14
   adds x11, x12, x11
   cinc x12, x13, hs
+  ushr.2d v7, v7, #14
   shl.2d v15, v4, #2
+  mul x13, x3, x4
   usra.2d v12, v4, #50
   usra.2d v13, v5, #38
-  mul x13, x3, x4
   usra.2d v14, v6, #26
+  umulh x4, x3, x4
   and.16b v4, v15, v8
   and.16b v5, v12, v8
-  umulh x4, x3, x4
   and.16b v6, v13, v8
-  and.16b v12, v14, v8
-  mov x14, #13605374474286268416
   adds x12, x13, x12
   cinc x4, x4, hs
-  dup.2d v13, x14
-  mov x13, #6440147467139809280
-  dup.2d v14, x13
+  and.16b v12, v14, v8
+  mov x13, #13605374474286268416
+  dup.2d v13, x13
   mul x13, x0, x5
-  mov x14, #3688448094816436224
-  dup.2d v15, x14
-  mov x14, #9209861237972664320
-  umulh x15, x0, x5
-  dup.2d v16, x14
+  mov x14, #6440147467139809280
+  dup.2d v14, x14
+  umulh x14, x0, x5
+  mov x15, #3688448094816436224
+  dup.2d v15, x15
+  mov x15, #9209861237972664320
+  adds x10, x13, x10
+  cinc x13, x14, hs
+  dup.2d v16, x15
   mov x14, #12218265789056155648
   dup.2d v17, x14
-  adds x10, x13, x10
-  cinc x13, x15, hs
-  mov x14, #17739678932212383744
-  dup.2d v18, x14
-  mov x14, #2301339409586323456
-  mul x15, x1, x5
-  dup.2d v19, x14
-  mov x14, #7822752552742551552
-  dup.2d v20, x14
-  umulh x14, x1, x5
-  mov x16, #5071053180419178496
-  dup.2d v21, x16
-  mov x16, #16352570246982270976
-  adds x13, x15, x13
-  cinc x14, x14, hs
-  dup.2d v22, x16
-  ucvtf.2d v0, v0
-  ucvtf.2d v1, v1
+  mul x14, x1, x5
+  mov x15, #17739678932212383744
+  dup.2d v18, x15
+  mov x15, #2301339409586323456
+  umulh x16, x1, x5
+  dup.2d v19, x15
+  mov x15, #7822752552742551552
+  adds x13, x14, x13
+  cinc x14, x16, hs
+  dup.2d v20, x15
+  mov x15, #5071053180419178496
+  dup.2d v21, x15
   adds x11, x13, x11
   cinc x13, x14, hs
+  mov x14, #16352570246982270976
+  dup.2d v22, x14
+  ucvtf.2d v0, v0
+  mul x14, x2, x5
+  ucvtf.2d v1, v1
   ucvtf.2d v2, v2
   ucvtf.2d v11, v11
-  ucvtf.2d v3, v3
-  mul x14, x2, x5
-  ucvtf.2d v4, v4
-  ucvtf.2d v5, v5
-  ucvtf.2d v6, v6
   umulh x15, x2, x5
-  ucvtf.2d v12, v12
-  ucvtf.2d v7, v7
-  mov.16b v23, v9
+  ucvtf.2d v3, v3
+  ucvtf.2d v4, v4
   adds x13, x14, x13
   cinc x14, x15, hs
-  fmla.2d v23, v0, v4
-  fsub.2d v24, v10, v23
-  fmla.2d v24, v0, v4
+  ucvtf.2d v5, v5
+  ucvtf.2d v6, v6
+  ucvtf.2d v12, v12
   adds x12, x13, x12
   cinc x13, x14, hs
+  ucvtf.2d v7, v7
+  mov.16b v23, v9
+  fmla.2d v23, v0, v4
+  mul x14, x3, x5
+  fsub.2d v24, v10, v23
+  fmla.2d v24, v0, v4
   add.2d v15, v15, v23
+  umulh x5, x3, x5
   add.2d v13, v13, v24
   mov.16b v23, v9
-  mul x14, x3, x5
-  fmla.2d v23, v0, v5
-  fsub.2d v24, v10, v23
-  umulh x5, x3, x5
-  fmla.2d v24, v0, v5
-  add.2d v17, v17, v23
-  add.2d v15, v15, v24
   adds x13, x14, x13
   cinc x5, x5, hs
-  mov.16b v23, v9
-  fmla.2d v23, v0, v6
+  fmla.2d v23, v0, v5
   fsub.2d v24, v10, v23
+  fmla.2d v24, v0, v5
   adds x4, x13, x4
   cinc x5, x5, hs
+  add.2d v17, v17, v23
+  add.2d v15, v15, v24
+  mov.16b v23, v9
+  mul x13, x0, x6
+  fmla.2d v23, v0, v6
+  fsub.2d v24, v10, v23
   fmla.2d v24, v0, v6
+  umulh x14, x0, x6
   add.2d v19, v19, v23
   add.2d v17, v17, v24
-  mul x13, x0, x6
+  adds x11, x13, x11
+  cinc x13, x14, hs
   mov.16b v23, v9
   fmla.2d v23, v0, v12
   fsub.2d v24, v10, v23
-  umulh x14, x0, x6
+  mul x14, x1, x6
   fmla.2d v24, v0, v12
   add.2d v21, v21, v23
   add.2d v19, v19, v24
-  adds x11, x13, x11
-  cinc x13, x14, hs
+  umulh x15, x1, x6
   mov.16b v23, v9
   fmla.2d v23, v0, v7
   fsub.2d v24, v10, v23
-  mul x14, x1, x6
+  adds x13, x14, x13
+  cinc x14, x15, hs
   fmla.2d v24, v0, v7
   add.2d v0, v22, v23
-  add.2d v21, v21, v24
-  umulh x15, x1, x6
-  mov.16b v22, v9
-  fmla.2d v22, v1, v4
-  fsub.2d v23, v10, v22
-  adds x13, x14, x13
-  cinc x14, x15, hs
-  fmla.2d v23, v1, v4
-  add.2d v17, v17, v22
-  add.2d v15, v15, v23
   adds x12, x13, x12
   cinc x13, x14, hs
+  add.2d v21, v21, v24
+  mov.16b v22, v9
+  fmla.2d v22, v1, v4
+  mul x14, x2, x6
+  fsub.2d v23, v10, v22
+  fmla.2d v23, v1, v4
+  add.2d v17, v17, v22
+  umulh x15, x2, x6
+  add.2d v15, v15, v23
   mov.16b v22, v9
   fmla.2d v22, v1, v5
-  fsub.2d v23, v10, v22
-  mul x14, x2, x6
-  fmla.2d v23, v1, v5
-  add.2d v19, v19, v22
-  add.2d v17, v17, v23
-  umulh x15, x2, x6
-  mov.16b v22, v9
-  fmla.2d v22, v1, v6
-  fsub.2d v23, v10, v22
   adds x13, x14, x13
   cinc x14, x15, hs
-  fmla.2d v23, v1, v6
-  add.2d v21, v21, v22
-  add.2d v19, v19, v23
+  fsub.2d v23, v10, v22
+  fmla.2d v23, v1, v5
   adds x4, x13, x4
   cinc x13, x14, hs
+  add.2d v19, v19, v22
+  add.2d v17, v17, v23
   mov.16b v22, v9
+  mul x14, x3, x6
+  fmla.2d v22, v1, v6
+  fsub.2d v23, v10, v22
+  fmla.2d v23, v1, v6
+  umulh x6, x3, x6
+  add.2d v21, v21, v22
+  add.2d v19, v19, v23
+  mov.16b v22, v9
+  adds x13, x14, x13
+  cinc x6, x6, hs
   fmla.2d v22, v1, v12
   fsub.2d v23, v10, v22
-  mul x14, x3, x6
   fmla.2d v23, v1, v12
+  adds x5, x13, x5
+  cinc x6, x6, hs
   add.2d v0, v0, v22
   add.2d v21, v21, v23
-  umulh x6, x3, x6
+  mul x13, x0, x7
   mov.16b v22, v9
   fmla.2d v22, v1, v7
   fsub.2d v23, v10, v22
-  adds x13, x14, x13
-  cinc x6, x6, hs
+  umulh x0, x0, x7
   fmla.2d v23, v1, v7
   add.2d v1, v20, v22
   add.2d v0, v0, v23
-  adds x5, x13, x5
-  cinc x6, x6, hs
+  adds x12, x13, x12
+  cinc x0, x0, hs
   mov.16b v20, v9
   fmla.2d v20, v2, v4
   fsub.2d v22, v10, v20
-  mul x13, x0, x7
+  mul x13, x1, x7
   fmla.2d v22, v2, v4
   add.2d v19, v19, v20
+  umulh x1, x1, x7
   add.2d v17, v17, v22
-  umulh x0, x0, x7
   mov.16b v20, v9
   fmla.2d v20, v2, v5
-  fsub.2d v22, v10, v20
-  adds x12, x13, x12
-  cinc x0, x0, hs
-  fmla.2d v22, v2, v5
-  add.2d v20, v21, v20
-  add.2d v19, v19, v22
-  mul x13, x1, x7
-  mov.16b v21, v9
-  fmla.2d v21, v2, v6
-  fsub.2d v22, v10, v21
-  umulh x1, x1, x7
-  fmla.2d v22, v2, v6
-  add.2d v0, v0, v21
-  add.2d v20, v20, v22
   adds x0, x13, x0
   cinc x1, x1, hs
-  mov.16b v21, v9
-  fmla.2d v21, v2, v12
+  fsub.2d v22, v10, v20
+  fmla.2d v22, v2, v5
+  add.2d v20, v21, v20
   adds x0, x0, x4
   cinc x1, x1, hs
-  fsub.2d v22, v10, v21
-  fmla.2d v22, v2, v12
-  add.2d v1, v1, v21
-  mul x4, x2, x7
-  add.2d v0, v0, v22
+  add.2d v19, v19, v22
   mov.16b v21, v9
-  fmla.2d v21, v2, v7
-  umulh x2, x2, x7
+  fmla.2d v21, v2, v6
+  mul x4, x2, x7
   fsub.2d v22, v10, v21
-  fmla.2d v22, v2, v7
-  add.2d v2, v18, v21
+  fmla.2d v22, v2, v6
+  umulh x2, x2, x7
+  add.2d v0, v0, v21
+  add.2d v20, v20, v22
+  mov.16b v21, v9
   adds x1, x4, x1
   cinc x2, x2, hs
-  add.2d v1, v1, v22
-  mov.16b v18, v9
-  fmla.2d v18, v11, v4
+  fmla.2d v21, v2, v12
+  fsub.2d v22, v10, v21
+  fmla.2d v22, v2, v12
   adds x1, x1, x5
   cinc x2, x2, hs
+  add.2d v1, v1, v21
+  add.2d v0, v0, v22
+  mov.16b v21, v9
+  mul x4, x3, x7
+  fmla.2d v21, v2, v7
+  fsub.2d v22, v10, v21
+  umulh x3, x3, x7
+  fmla.2d v22, v2, v7
+  add.2d v2, v18, v21
+  add.2d v1, v1, v22
+  adds x2, x4, x2
+  cinc x3, x3, hs
+  mov.16b v18, v9
+  fmla.2d v18, v11, v4
   fsub.2d v21, v10, v18
+  adds x2, x2, x6
+  cinc x3, x3, hs
   fmla.2d v21, v11, v4
   add.2d v18, v20, v18
-  mul x4, x3, x7
   add.2d v19, v19, v21
+  mov x4, #48718
   mov.16b v20, v9
   fmla.2d v20, v11, v5
-  umulh x3, x3, x7
+  movk x4, #4732, lsl 16
   fsub.2d v21, v10, v20
   fmla.2d v21, v11, v5
   add.2d v0, v0, v20
-  adds x2, x4, x2
-  cinc x3, x3, hs
+  movk x4, #45078, lsl 32
   add.2d v18, v18, v21
   mov.16b v20, v9
   fmla.2d v20, v11, v6
-  adds x2, x2, x6
-  cinc x3, x3, hs
+  movk x4, #39852, lsl 48
   fsub.2d v21, v10, v20
   fmla.2d v21, v11, v6
   add.2d v1, v1, v20
-  mov x4, #48718
+  mov x5, #16676
   add.2d v0, v0, v21
   mov.16b v20, v9
+  movk x5, #12692, lsl 16
   fmla.2d v20, v11, v12
-  movk x4, #4732, lsl 16
   fsub.2d v21, v10, v20
   fmla.2d v21, v11, v12
+  movk x5, #20986, lsl 32
   add.2d v2, v2, v20
-  movk x4, #45078, lsl 32
   add.2d v1, v1, v21
   mov.16b v20, v9
+  movk x5, #2848, lsl 48
   fmla.2d v20, v11, v7
-  movk x4, #39852, lsl 48
   fsub.2d v21, v10, v20
   fmla.2d v21, v11, v7
+  mov x6, #51052
   add.2d v11, v16, v20
-  mov x5, #16676
   add.2d v2, v2, v21
+  movk x6, #24721, lsl 16
   mov.16b v16, v9
   fmla.2d v16, v3, v4
-  movk x5, #12692, lsl 16
   fsub.2d v20, v10, v16
+  movk x6, #61092, lsl 32
   fmla.2d v20, v3, v4
   add.2d v0, v0, v16
-  movk x5, #20986, lsl 32
   add.2d v4, v18, v20
+  movk x6, #45156, lsl 48
   mov.16b v16, v9
   fmla.2d v16, v3, v5
-  movk x5, #2848, lsl 48
   fsub.2d v18, v10, v16
+  mov x7, #3197
   fmla.2d v18, v3, v5
   add.2d v1, v1, v16
-  mov x6, #51052
+  movk x7, #18936, lsl 16
   add.2d v0, v0, v18
   mov.16b v5, v9
   fmla.2d v5, v3, v6
-  movk x6, #24721, lsl 16
+  movk x7, #10922, lsl 32
   fsub.2d v16, v10, v5
   fmla.2d v16, v3, v6
   add.2d v2, v2, v5
-  movk x6, #61092, lsl 32
+  movk x7, #11014, lsl 48
   add.2d v1, v1, v16
   mov.16b v5, v9
   fmla.2d v5, v3, v12
-  movk x6, #45156, lsl 48
+  mul x13, x4, x9
   fsub.2d v6, v10, v5
   fmla.2d v6, v3, v12
+  umulh x4, x4, x9
   add.2d v5, v11, v5
-  mov x7, #3197
   add.2d v2, v2, v6
   mov.16b v6, v9
+  adds x12, x13, x12
+  cinc x4, x4, hs
   fmla.2d v6, v3, v7
-  movk x7, #18936, lsl 16
   fsub.2d v11, v10, v6
   fmla.2d v11, v3, v7
-  movk x7, #10922, lsl 32
+  mul x13, x5, x9
   add.2d v3, v14, v6
   add.2d v5, v5, v11
   usra.2d v15, v13, #52
-  movk x7, #11014, lsl 48
+  umulh x5, x5, x9
   usra.2d v17, v15, #52
   usra.2d v19, v17, #52
   usra.2d v4, v19, #52
-  mul x13, x4, x9
-  and.16b v6, v13, v8
-  and.16b v7, v15, v8
-  and.16b v11, v17, v8
-  umulh x4, x4, x9
-  and.16b v8, v19, v8
-  ucvtf.2d v6, v6
-  mov x14, #37864
-  adds x12, x13, x12
-  cinc x4, x4, hs
-  movk x14, #1815, lsl 16
-  movk x14, #28960, lsl 32
-  movk x14, #17153, lsl 48
-  mul x13, x5, x9
-  dup.2d v12, x14
-  mov.16b v13, v9
-  fmla.2d v13, v6, v12
-  umulh x5, x5, x9
-  fsub.2d v14, v10, v13
-  fmla.2d v14, v6, v12
-  add.2d v0, v0, v13
   adds x4, x13, x4
   cinc x5, x5, hs
-  add.2d v4, v4, v14
-  mov x13, #46128
-  movk x13, #29964, lsl 16
+  and.16b v6, v13, v8
+  and.16b v7, v15, v8
   adds x0, x4, x0
   cinc x4, x5, hs
-  movk x13, #7587, lsl 32
-  movk x13, #17161, lsl 48
-  dup.2d v12, x13
+  and.16b v11, v17, v8
+  and.16b v8, v19, v8
+  ucvtf.2d v6, v6
   mul x5, x6, x9
+  mov x13, #37864
+  movk x13, #1815, lsl 16
+  movk x13, #28960, lsl 32
+  umulh x6, x6, x9
+  movk x13, #17153, lsl 48
+  dup.2d v12, x13
   mov.16b v13, v9
+  adds x4, x5, x4
+  cinc x5, x6, hs
   fmla.2d v13, v6, v12
   fsub.2d v14, v10, v13
-  umulh x6, x6, x9
+  adds x1, x4, x1
+  cinc x4, x5, hs
+  fmla.2d v14, v6, v12
+  add.2d v0, v0, v13
+  add.2d v4, v4, v14
+  mul x5, x7, x9
+  mov x6, #46128
+  movk x6, #29964, lsl 16
+  movk x6, #7587, lsl 32
+  umulh x7, x7, x9
+  movk x6, #17161, lsl 48
+  dup.2d v12, x6
+  mov.16b v13, v9
+  adds x4, x5, x4
+  cinc x5, x7, hs
+  fmla.2d v13, v6, v12
+  fsub.2d v14, v10, v13
+  adds x2, x4, x2
+  cinc x4, x5, hs
   fmla.2d v14, v6, v12
   add.2d v1, v1, v13
   add.2d v0, v0, v14
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  mov x6, #52826
-  movk x6, #57790, lsl 16
-  movk x6, #55431, lsl 32
-  adds x1, x4, x1
-  cinc x4, x5, hs
-  movk x6, #17196, lsl 48
-  dup.2d v12, x6
+  add x3, x3, x4
+  mov x4, #52826
+  movk x4, #57790, lsl 16
+  movk x4, #55431, lsl 32
+  mov x5, #56431
+  movk x4, #17196, lsl 48
+  dup.2d v12, x4
   mov.16b v13, v9
-  mul x5, x7, x9
+  movk x5, #30457, lsl 16
   fmla.2d v13, v6, v12
   fsub.2d v14, v10, v13
+  movk x5, #30012, lsl 32
   fmla.2d v14, v6, v12
-  umulh x6, x7, x9
   add.2d v2, v2, v13
   add.2d v1, v1, v14
-  mov x7, #31276
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  movk x7, #21262, lsl 16
-  movk x7, #2304, lsl 32
-  movk x7, #17182, lsl 48
-  adds x2, x4, x2
-  cinc x4, x5, hs
-  dup.2d v12, x7
+  movk x5, #6382, lsl 48
+  mov x4, #31276
+  movk x4, #21262, lsl 16
+  movk x4, #2304, lsl 32
+  mov x6, #59151
+  movk x4, #17182, lsl 48
+  dup.2d v12, x4
   mov.16b v13, v9
+  movk x6, #41769, lsl 16
   fmla.2d v13, v6, v12
-  add x3, x3, x4
   fsub.2d v14, v10, v13
+  movk x6, #32276, lsl 32
   fmla.2d v14, v6, v12
   add.2d v5, v5, v13
-  mov x4, #56431
   add.2d v2, v2, v14
-  mov x5, #28672
-  movk x5, #24515, lsl 16
-  movk x4, #30457, lsl 16
-  movk x5, #54929, lsl 32
-  movk x5, #17064, lsl 48
-  dup.2d v12, x5
-  movk x4, #30012, lsl 32
+  movk x6, #21677, lsl 48
+  mov x4, #28672
+  movk x4, #24515, lsl 16
+  movk x4, #54929, lsl 32
+  mov x7, #34015
+  movk x4, #17064, lsl 48
+  dup.2d v12, x4
   mov.16b v13, v9
+  movk x7, #20342, lsl 16
   fmla.2d v13, v6, v12
   fsub.2d v14, v10, v13
-  movk x4, #6382, lsl 48
+  movk x7, #13935, lsl 32
   fmla.2d v14, v6, v12
   add.2d v3, v3, v13
   add.2d v5, v5, v14
-  mov x5, #59151
+  movk x7, #11030, lsl 48
   ucvtf.2d v6, v7
-  mov x6, #44768
-  movk x6, #51919, lsl 16
-  movk x5, #41769, lsl 16
-  movk x6, #6346, lsl 32
-  movk x6, #17133, lsl 48
-  movk x5, #32276, lsl 32
-  dup.2d v7, x6
+  mov x4, #44768
+  movk x4, #51919, lsl 16
+  mov x9, #13689
+  movk x4, #6346, lsl 32
+  movk x4, #17133, lsl 48
+  dup.2d v7, x4
+  movk x9, #8159, lsl 16
   mov.16b v12, v9
   fmla.2d v12, v6, v7
-  movk x5, #21677, lsl 48
+  movk x9, #215, lsl 32
   fsub.2d v13, v10, v12
   fmla.2d v13, v6, v7
   add.2d v0, v0, v12
-  mov x6, #34015
+  movk x9, #4913, lsl 48
   add.2d v4, v4, v13
-  mov x7, #47492
-  movk x7, #23630, lsl 16
-  movk x6, #20342, lsl 16
-  movk x7, #49985, lsl 32
-  movk x7, #17168, lsl 48
-  dup.2d v7, x7
-  movk x6, #13935, lsl 32
+  mov x4, #47492
+  movk x4, #23630, lsl 16
+  mul x13, x5, x10
+  movk x4, #49985, lsl 32
+  movk x4, #17168, lsl 48
+  dup.2d v7, x4
+  umulh x4, x5, x10
   mov.16b v12, v9
   fmla.2d v12, v6, v7
-  fsub.2d v13, v10, v12
-  movk x6, #11030, lsl 48
-  fmla.2d v13, v6, v7
-  add.2d v1, v1, v12
-  add.2d v0, v0, v13
-  mov x7, #13689
-  mov x9, #57936
-  movk x9, #54828, lsl 16
-  movk x9, #18292, lsl 32
-  movk x7, #8159, lsl 16
-  movk x9, #17197, lsl 48
-  dup.2d v7, x9
-  mov.16b v12, v9
-  movk x7, #215, lsl 32
-  fmla.2d v12, v6, v7
-  fsub.2d v13, v10, v12
-  fmla.2d v13, v6, v7
-  movk x7, #4913, lsl 48
-  add.2d v2, v2, v12
-  add.2d v1, v1, v13
-  mov x9, #17708
-  mul x13, x4, x10
-  movk x9, #43915, lsl 16
-  movk x9, #64348, lsl 32
-  movk x9, #17188, lsl 48
-  umulh x4, x4, x10
-  dup.2d v7, x9
-  mov.16b v12, v9
-  fmla.2d v12, v6, v7
-  adds x9, x13, x12
+  adds x5, x13, x12
   cinc x4, x4, hs
   fsub.2d v13, v10, v12
   fmla.2d v13, v6, v7
-  add.2d v5, v5, v12
-  mul x12, x5, x10
-  add.2d v2, v2, v13
-  mov x13, #29184
-  movk x13, #20789, lsl 16
-  umulh x5, x5, x10
-  movk x13, #19197, lsl 32
-  movk x13, #17083, lsl 48
+  add.2d v1, v1, v12
+  mul x12, x6, x10
+  add.2d v0, v0, v13
+  mov x13, #57936
+  movk x13, #54828, lsl 16
+  umulh x6, x6, x10
+  movk x13, #18292, lsl 32
+  movk x13, #17197, lsl 48
   dup.2d v7, x13
   adds x4, x12, x4
-  cinc x5, x5, hs
+  cinc x6, x6, hs
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
+  adds x0, x4, x0
+  cinc x4, x6, hs
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
+  add.2d v2, v2, v12
+  mul x6, x7, x10
+  add.2d v1, v1, v13
+  mov x12, #17708
+  movk x12, #43915, lsl 16
+  umulh x7, x7, x10
+  movk x12, #64348, lsl 32
+  movk x12, #17188, lsl 48
+  dup.2d v7, x12
+  adds x4, x6, x4
+  cinc x6, x7, hs
   mov.16b v12, v9
   fmla.2d v12, v6, v7
   fsub.2d v13, v10, v12
-  adds x0, x4, x0
-  cinc x4, x5, hs
+  adds x1, x4, x1
+  cinc x4, x6, hs
+  fmla.2d v13, v6, v7
+  add.2d v5, v5, v12
+  mul x6, x9, x10
+  add.2d v2, v2, v13
+  mov x7, #29184
+  movk x7, #20789, lsl 16
+  umulh x9, x9, x10
+  movk x7, #19197, lsl 32
+  movk x7, #17083, lsl 48
+  dup.2d v7, x7
+  adds x4, x6, x4
+  cinc x6, x9, hs
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
+  adds x2, x4, x2
+  cinc x4, x6, hs
   fmla.2d v13, v6, v7
   add.2d v3, v3, v12
-  add.2d v5, v5, v13
-  mul x5, x6, x10
-  ucvtf.2d v6, v11
-  mov x12, #58856
-  movk x12, #14953, lsl 16
-  umulh x6, x6, x10
-  movk x12, #15155, lsl 32
-  movk x12, #17181, lsl 48
-  dup.2d v7, x12
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  mov.16b v11, v9
-  fmla.2d v11, v6, v7
-  fsub.2d v12, v10, v11
-  adds x1, x4, x1
-  cinc x4, x5, hs
-  fmla.2d v12, v6, v7
-  add.2d v0, v0, v11
-  add.2d v4, v4, v12
-  mul x5, x7, x10
-  mov x6, #35392
-  movk x6, #12477, lsl 16
-  movk x6, #56780, lsl 32
-  umulh x7, x7, x10
-  movk x6, #17142, lsl 48
-  dup.2d v7, x6
-  mov.16b v11, v9
-  adds x4, x5, x4
-  cinc x5, x7, hs
-  fmla.2d v11, v6, v7
-  fsub.2d v12, v10, v11
-  adds x2, x4, x2
-  cinc x4, x5, hs
-  fmla.2d v12, v6, v7
-  add.2d v1, v1, v11
-  add.2d v0, v0, v12
   add x3, x3, x4
-  mov x4, #9848
-  movk x4, #54501, lsl 16
-  movk x4, #31540, lsl 32
-  mov x5, #61005
-  movk x4, #17170, lsl 48
+  add.2d v5, v5, v13
+  ucvtf.2d v6, v11
+  mov x4, #58856
+  mov x6, #61005
+  movk x4, #14953, lsl 16
+  movk x4, #15155, lsl 32
+  movk x4, #17181, lsl 48
+  movk x6, #58262, lsl 16
   dup.2d v7, x4
   mov.16b v11, v9
-  movk x5, #58262, lsl 16
   fmla.2d v11, v6, v7
+  movk x6, #32851, lsl 32
   fsub.2d v12, v10, v11
   fmla.2d v12, v6, v7
-  movk x5, #32851, lsl 32
+  movk x6, #11582, lsl 48
+  add.2d v0, v0, v11
+  add.2d v4, v4, v12
+  mov x4, #35392
+  mov x7, #37581
+  movk x4, #12477, lsl 16
+  movk x4, #56780, lsl 32
+  movk x4, #17142, lsl 48
+  movk x7, #43836, lsl 16
+  dup.2d v7, x4
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
+  movk x7, #36286, lsl 32
+  fsub.2d v12, v10, v11
+  fmla.2d v12, v6, v7
+  movk x7, #51783, lsl 48
+  add.2d v1, v1, v11
+  add.2d v0, v0, v12
+  mov x4, #9848
+  mov x9, #10899
+  movk x4, #54501, lsl 16
+  movk x4, #31540, lsl 32
+  movk x4, #17170, lsl 48
+  movk x9, #30709, lsl 16
+  dup.2d v7, x4
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
+  movk x9, #61551, lsl 32
+  fsub.2d v12, v10, v11
+  fmla.2d v12, v6, v7
+  movk x9, #45784, lsl 48
   add.2d v2, v2, v11
   add.2d v1, v1, v12
   mov x4, #9584
-  movk x5, #11582, lsl 48
+  mov x10, #36612
   movk x4, #63883, lsl 16
   movk x4, #18253, lsl 32
   movk x4, #17190, lsl 48
-  mov x6, #37581
+  movk x10, #63402, lsl 16
   dup.2d v7, x4
   mov.16b v11, v9
   fmla.2d v11, v6, v7
-  movk x6, #43836, lsl 16
+  movk x10, #47623, lsl 32
   fsub.2d v12, v10, v11
   fmla.2d v12, v6, v7
+  movk x10, #9430, lsl 48
   add.2d v5, v5, v11
-  movk x6, #36286, lsl 32
   add.2d v2, v2, v12
   mov x4, #51712
+  mul x12, x6, x11
   movk x4, #16093, lsl 16
-  movk x6, #51783, lsl 48
   movk x4, #30633, lsl 32
   movk x4, #17068, lsl 48
+  umulh x6, x6, x11
   dup.2d v7, x4
-  mov x4, #10899
   mov.16b v11, v9
   fmla.2d v11, v6, v7
+  adds x4, x12, x5
+  cinc x5, x6, hs
   fsub.2d v12, v10, v11
-  movk x4, #30709, lsl 16
   fmla.2d v12, v6, v7
+  mul x6, x7, x11
   add.2d v3, v3, v11
   add.2d v5, v5, v12
-  movk x4, #61551, lsl 32
   ucvtf.2d v6, v8
-  mov x7, #34724
-  movk x7, #40393, lsl 16
-  movk x4, #45784, lsl 48
-  movk x7, #23752, lsl 32
-  movk x7, #17184, lsl 48
-  dup.2d v7, x7
-  mov x7, #36612
-  mov.16b v8, v9
-  fmla.2d v8, v6, v7
-  fsub.2d v11, v10, v8
-  movk x7, #63402, lsl 16
-  fmla.2d v11, v6, v7
-  add.2d v0, v0, v8
-  add.2d v4, v4, v11
-  movk x7, #47623, lsl 32
-  mov x10, #25532
-  movk x10, #31025, lsl 16
-  movk x10, #10002, lsl 32
-  movk x7, #9430, lsl 48
-  movk x10, #17199, lsl 48
-  dup.2d v7, x10
-  mov.16b v8, v9
-  mul x10, x5, x11
-  fmla.2d v8, v6, v7
-  fsub.2d v11, v10, v8
-  fmla.2d v11, v6, v7
-  umulh x5, x5, x11
-  add.2d v1, v1, v8
-  add.2d v0, v0, v11
-  mov x12, #18830
-  adds x9, x10, x9
-  cinc x5, x5, hs
-  movk x12, #2465, lsl 16
-  movk x12, #36348, lsl 32
-  movk x12, #17194, lsl 48
-  mul x10, x6, x11
+  umulh x7, x7, x11
+  mov x12, #34724
+  movk x12, #40393, lsl 16
+  movk x12, #23752, lsl 32
+  adds x5, x6, x5
+  cinc x6, x7, hs
+  movk x12, #17184, lsl 48
   dup.2d v7, x12
   mov.16b v8, v9
-  fmla.2d v8, v6, v7
-  umulh x6, x6, x11
-  fsub.2d v11, v10, v8
-  fmla.2d v11, v6, v7
-  adds x5, x10, x5
-  cinc x6, x6, hs
-  add.2d v2, v2, v8
-  add.2d v1, v1, v11
-  mov x10, #21566
   adds x0, x5, x0
   cinc x5, x6, hs
-  movk x10, #43708, lsl 16
-  movk x10, #57685, lsl 32
-  movk x10, #17185, lsl 48
-  mul x6, x4, x11
-  dup.2d v7, x10
-  mov.16b v8, v9
-  fmla.2d v8, v6, v7
-  umulh x4, x4, x11
-  fsub.2d v11, v10, v8
-  fmla.2d v11, v6, v7
-  add.2d v5, v5, v8
-  adds x5, x6, x5
-  cinc x4, x4, hs
-  add.2d v2, v2, v11
-  mov x6, #3072
-  movk x6, #8058, lsl 16
-  adds x1, x5, x1
-  cinc x4, x4, hs
-  movk x6, #46097, lsl 32
-  movk x6, #17047, lsl 48
-  dup.2d v7, x6
-  mul x5, x7, x11
-  mov.16b v8, v9
   fmla.2d v8, v6, v7
   fsub.2d v11, v10, v8
-  umulh x6, x7, x11
-  fmla.2d v11, v6, v7
-  add.2d v3, v3, v8
-  add.2d v5, v5, v11
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  mov x6, #65535
-  movk x6, #61439, lsl 16
-  movk x6, #62867, lsl 32
-  adds x2, x4, x2
-  cinc x4, x5, hs
-  movk x6, #1, lsl 48
-  umov x5, v4.d[0]
-  umov x7, v4.d[1]
-  add x3, x3, x4
-  mul x4, x5, x6
-  mul x5, x7, x6
-  and x4, x4, x8
-  mov x6, #65535
-  and x5, x5, x8
-  ins v6.d[0], x4
-  ins v6.d[1], x5
-  ucvtf.2d v6, v6
-  movk x6, #61439, lsl 16
-  mov x4, #16
-  movk x4, #22847, lsl 32
-  movk x4, #17151, lsl 48
-  movk x6, #62867, lsl 32
-  dup.2d v7, x4
-  mov.16b v8, v9
-  fmla.2d v8, v6, v7
-  movk x6, #49889, lsl 48
-  fsub.2d v11, v10, v8
+  mul x6, x9, x11
   fmla.2d v11, v6, v7
   add.2d v0, v0, v8
-  mul x4, x6, x9
   add.2d v4, v4, v11
-  mov x5, #20728
-  movk x5, #23588, lsl 16
-  mov x6, #1
-  movk x5, #7790, lsl 32
-  movk x5, #17170, lsl 48
-  dup.2d v7, x5
-  movk x6, #61440, lsl 16
+  umulh x7, x9, x11
+  mov x9, #25532
+  movk x9, #31025, lsl 16
+  movk x9, #10002, lsl 32
+  adds x5, x6, x5
+  cinc x6, x7, hs
+  movk x9, #17199, lsl 48
+  dup.2d v7, x9
   mov.16b v8, v9
+  adds x1, x5, x1
+  cinc x5, x6, hs
   fmla.2d v8, v6, v7
   fsub.2d v11, v10, v8
-  movk x6, #62867, lsl 32
+  mul x6, x10, x11
   fmla.2d v11, v6, v7
   add.2d v1, v1, v8
   add.2d v0, v0, v11
-  movk x6, #17377, lsl 48
-  mov x5, #16000
-  movk x5, #53891, lsl 16
-  movk x5, #5509, lsl 32
-  mov x7, #28817
-  movk x5, #17144, lsl 48
-  dup.2d v7, x5
+  umulh x7, x10, x11
+  mov x9, #18830
+  movk x9, #2465, lsl 16
+  movk x9, #36348, lsl 32
+  adds x5, x6, x5
+  cinc x6, x7, hs
+  movk x9, #17194, lsl 48
+  dup.2d v7, x9
   mov.16b v8, v9
-  movk x7, #31161, lsl 16
+  adds x2, x5, x2
+  cinc x5, x6, hs
   fmla.2d v8, v6, v7
   fsub.2d v11, v10, v8
   fmla.2d v11, v6, v7
-  movk x7, #59464, lsl 32
+  add x3, x3, x5
   add.2d v2, v2, v8
   add.2d v1, v1, v11
-  mov x5, #46800
-  movk x7, #10291, lsl 48
-  movk x5, #2568, lsl 16
-  movk x5, #1335, lsl 32
+  mov x5, #65535
+  mov x6, #21566
+  movk x6, #43708, lsl 16
+  movk x6, #57685, lsl 32
+  movk x5, #61439, lsl 16
+  movk x6, #17185, lsl 48
+  dup.2d v7, x6
+  mov.16b v8, v9
+  movk x5, #62867, lsl 32
+  fmla.2d v8, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  movk x5, #49889, lsl 48
+  add.2d v5, v5, v8
+  add.2d v2, v2, v11
+  mul x5, x5, x4
+  mov x6, #3072
+  movk x6, #8058, lsl 16
+  movk x6, #46097, lsl 32
+  mov x7, #1
+  movk x6, #17047, lsl 48
+  dup.2d v7, x6
+  mov.16b v8, v9
+  movk x7, #61440, lsl 16
+  fmla.2d v8, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  movk x7, #62867, lsl 32
+  add.2d v3, v3, v8
+  add.2d v5, v5, v11
+  movk x7, #17377, lsl 48
+  mov x6, #65535
+  movk x6, #61439, lsl 16
+  movk x6, #62867, lsl 32
+  mov x9, #28817
+  movk x6, #1, lsl 48
+  umov x10, v4.d[0]
+  umov x11, v4.d[1]
+  movk x9, #31161, lsl 16
+  mul x10, x10, x6
+  mul x6, x11, x6
+  and x10, x10, x8
+  movk x9, #59464, lsl 32
+  and x6, x6, x8
+  ins v6.d[0], x10
+  ins v6.d[1], x6
+  movk x9, #10291, lsl 48
+  ucvtf.2d v6, v6
+  mov x6, #16
+  movk x6, #22847, lsl 32
   mov x8, #22621
-  movk x5, #17188, lsl 48
-  dup.2d v7, x5
+  movk x6, #17151, lsl 48
+  dup.2d v7, x6
   mov.16b v8, v9
   movk x8, #33153, lsl 16
   fmla.2d v8, v6, v7
   fsub.2d v11, v10, v8
   fmla.2d v11, v6, v7
   movk x8, #17846, lsl 32
-  add.2d v5, v5, v8
-  add.2d v2, v2, v11
-  mov x5, #39040
+  add.2d v0, v0, v8
+  add.2d v4, v4, v11
   movk x8, #47184, lsl 48
-  movk x5, #14704, lsl 16
-  movk x5, #12839, lsl 32
-  movk x5, #17096, lsl 48
+  mov x6, #20728
+  movk x6, #23588, lsl 16
+  movk x6, #7790, lsl 32
   mov x10, #41001
-  dup.2d v7, x5
+  movk x6, #17170, lsl 48
+  dup.2d v7, x6
   mov.16b v8, v9
-  fmla.2d v8, v6, v7
   movk x10, #57649, lsl 16
-  fsub.2d v9, v10, v8
-  fmla.2d v9, v6, v7
-  add.2d v3, v3, v8
+  fmla.2d v8, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
   movk x10, #20082, lsl 32
-  add.2d v5, v5, v9
-  mov x5, #140737488355328
-  dup.2d v6, x5
+  add.2d v1, v1, v8
+  add.2d v0, v0, v11
   movk x10, #12388, lsl 48
-  and.16b v6, v3, v6
-  cmeq.2d v6, v6, #0
-  mov x5, #2
-  mul x11, x6, x4
-  movk x5, #57344, lsl 16
-  movk x5, #60199, lsl 32
-  movk x5, #3, lsl 48
-  umulh x6, x6, x4
-  dup.2d v7, x5
-  bic.16b v7, v7, v6
-  mov x5, #10364
-  cmn x11, x9
+  mov x6, #16000
+  movk x6, #53891, lsl 16
+  movk x6, #5509, lsl 32
+  mul x11, x7, x5
+  movk x6, #17144, lsl 48
+  dup.2d v7, x6
+  mov.16b v8, v9
+  umulh x6, x7, x5
+  fmla.2d v8, v6, v7
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  cmn x11, x4
   cinc x6, x6, hs
-  movk x5, #11794, lsl 16
-  movk x5, #3895, lsl 32
-  movk x5, #9, lsl 48
-  mul x9, x7, x4
-  dup.2d v8, x5
-  bic.16b v8, v8, v6
-  mov x5, #26576
-  umulh x7, x7, x4
-  movk x5, #47696, lsl 16
-  movk x5, #688, lsl 32
-  movk x5, #3, lsl 48
-  adds x6, x9, x6
-  cinc x7, x7, hs
-  dup.2d v9, x5
-  bic.16b v9, v9, v6
-  mov x5, #46800
-  adds x0, x6, x0
-  cinc x6, x7, hs
-  movk x5, #2568, lsl 16
-  movk x5, #1335, lsl 32
-  movk x5, #4, lsl 48
-  mul x7, x8, x4
-  dup.2d v10, x5
-  bic.16b v10, v10, v6
-  mov x5, #49763
-  umulh x8, x8, x4
-  movk x5, #40165, lsl 16
-  movk x5, #24776, lsl 32
-  dup.2d v11, x5
-  adds x5, x7, x6
+  add.2d v2, v2, v8
+  add.2d v7, v1, v11
+  mul x4, x9, x5
+  mov x7, #46800
+  movk x7, #2568, lsl 16
+  movk x7, #1335, lsl 32
+  umulh x9, x9, x5
+  movk x7, #17188, lsl 48
+  dup.2d v1, x7
+  mov.16b v8, v9
+  adds x4, x4, x6
+  cinc x6, x9, hs
+  fmla.2d v8, v6, v1
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v1
+  adds x0, x4, x0
+  cinc x4, x6, hs
+  add.2d v1, v5, v8
+  add.2d v5, v2, v11
+  mul x6, x8, x5
+  mov x7, #39040
+  movk x7, #14704, lsl 16
+  movk x7, #12839, lsl 32
+  umulh x8, x8, x5
+  movk x7, #17096, lsl 48
+  dup.2d v2, x7
+  mov.16b v8, v9
+  adds x4, x6, x4
   cinc x6, x8, hs
-  bic.16b v6, v11, v6
-  sub.2d v0, v0, v7
+  fmla.2d v8, v6, v2
+  fsub.2d v9, v10, v8
+  fmla.2d v9, v6, v2
+  adds x1, x4, x1
+  cinc x4, x6, hs
+  add.2d v6, v3, v8
+  add.2d v8, v1, v9
+  mul x6, x10, x5
   ssra.2d v0, v4, #52
-  adds x1, x5, x1
-  cinc x5, x6, hs
-  sub.2d v4, v1, v8
-  ssra.2d v4, v0, #52
-  sub.2d v7, v2, v9
-  mul x6, x10, x4
-  ssra.2d v7, v4, #52
-  sub.2d v5, v5, v10
+  ssra.2d v7, v0, #52
   ssra.2d v5, v7, #52
-  umulh x4, x10, x4
-  sub.2d v6, v3, v6
-  ssra.2d v6, v5, #52
-  ushr.2d v1, v4, #12
-  adds x5, x6, x5
-  cinc x4, x4, hs
-  ushr.2d v2, v7, #24
-  ushr.2d v3, v5, #36
-  sli.2d v0, v4, #52
-  adds x2, x5, x2
-  cinc x4, x4, hs
-  sli.2d v1, v7, #40
-  sli.2d v2, v5, #28
+  umulh x5, x10, x5
+  ssra.2d v8, v5, #52
+  ssra.2d v6, v8, #52
+  ushr.2d v1, v7, #12
+  adds x4, x6, x4
+  cinc x5, x5, hs
+  ushr.2d v2, v5, #24
+  ushr.2d v3, v8, #36
+  sli.2d v0, v7, #52
+  adds x2, x4, x2
+  cinc x4, x5, hs
+  sli.2d v1, v5, #40
+  sli.2d v2, v8, #28
   sli.2d v3, v6, #16
   add x3, x3, x4

--- a/block-multiplier/src/aarch64/montgomery_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_interleaved_4.s
@@ -20,1085 +20,1035 @@
   mov x22, #1
   umulh x23, x1, x4
   movk x22, #18032, lsl 48
+  dup.2d v10, x22
   adds x20, x21, x20
   cinc x21, x23, hs
-  dup.2d v10, x22
   shl.2d v11, v1, #14
   mul x22, x2, x4
   shl.2d v12, v2, #26
-  umulh x23, x2, x4
   shl.2d v13, v3, #38
+  umulh x23, x2, x4
+  ushr.2d v3, v3, #14
   adds x21, x22, x21
   cinc x22, x23, hs
-  ushr.2d v3, v3, #14
   shl.2d v14, v0, #2
-  mul x23, x3, x4
   usra.2d v11, v0, #50
-  umulh x4, x3, x4
+  mul x23, x3, x4
   usra.2d v12, v1, #38
-  adds x22, x23, x22
-  cinc x4, x4, hs
+  umulh x4, x3, x4
   usra.2d v13, v2, #26
   and.16b v0, v14, v8
-  mul x23, x0, x5
+  adds x22, x23, x22
+  cinc x4, x4, hs
   and.16b v1, v11, v8
-  umulh x24, x0, x5
+  mul x23, x0, x5
   and.16b v2, v12, v8
+  and.16b v11, v13, v8
+  umulh x24, x0, x5
+  shl.2d v12, v5, #14
   adds x20, x23, x20
   cinc x23, x24, hs
-  and.16b v11, v13, v8
-  shl.2d v12, v5, #14
-  mul x24, x1, x5
   shl.2d v13, v6, #26
-  umulh x25, x1, x5
   shl.2d v14, v7, #38
+  mul x24, x1, x5
+  ushr.2d v7, v7, #14
+  umulh x25, x1, x5
+  shl.2d v15, v4, #2
+  usra.2d v12, v4, #50
   adds x23, x24, x23
   cinc x24, x25, hs
-  ushr.2d v7, v7, #14
-  shl.2d v15, v4, #2
+  usra.2d v13, v5, #38
   adds x21, x23, x21
   cinc x23, x24, hs
-  usra.2d v12, v4, #50
-  mul x24, x2, x5
-  usra.2d v13, v5, #38
   usra.2d v14, v6, #26
-  umulh x25, x2, x5
   and.16b v4, v15, v8
-  adds x23, x24, x23
-  cinc x24, x25, hs
+  mul x24, x2, x5
   and.16b v5, v12, v8
-  adds x22, x23, x22
-  cinc x23, x24, hs
+  umulh x25, x2, x5
   and.16b v6, v13, v8
   and.16b v12, v14, v8
-  mul x24, x3, x5
-  mov x25, #13605374474286268416
-  umulh x5, x3, x5
-  dup.2d v13, x25
-  adds x23, x24, x23
-  cinc x5, x5, hs
-  mov x24, #6440147467139809280
-  dup.2d v14, x24
-  adds x4, x23, x4
-  cinc x5, x5, hs
-  mov x23, #3688448094816436224
-  mul x24, x0, x6
-  dup.2d v15, x23
-  umulh x23, x0, x6
-  mov x25, #9209861237972664320
-  dup.2d v16, x25
-  adds x21, x24, x21
-  cinc x23, x23, hs
-  mov x24, #12218265789056155648
-  mul x25, x1, x6
-  dup.2d v17, x24
-  umulh x24, x1, x6
-  mov x26, #17739678932212383744
-  dup.2d v18, x26
-  adds x23, x25, x23
-  cinc x24, x24, hs
-  mov x25, #2301339409586323456
-  adds x22, x23, x22
-  cinc x23, x24, hs
-  dup.2d v19, x25
-  mul x24, x2, x6
-  mov x25, #7822752552742551552
-  dup.2d v20, x25
-  umulh x25, x2, x6
-  mov x26, #5071053180419178496
   adds x23, x24, x23
   cinc x24, x25, hs
-  dup.2d v21, x26
+  mov x25, #13605374474286268416
+  adds x22, x23, x22
+  cinc x23, x24, hs
+  dup.2d v13, x25
+  mov x24, #6440147467139809280
+  mul x25, x3, x5
+  dup.2d v14, x24
+  umulh x5, x3, x5
+  mov x24, #3688448094816436224
+  adds x23, x25, x23
+  cinc x5, x5, hs
+  dup.2d v15, x24
+  mov x24, #9209861237972664320
+  adds x4, x23, x4
+  cinc x5, x5, hs
+  dup.2d v16, x24
+  mul x23, x0, x6
+  mov x24, #12218265789056155648
+  dup.2d v17, x24
+  umulh x24, x0, x6
+  mov x25, #17739678932212383744
+  adds x21, x23, x21
+  cinc x23, x24, hs
+  dup.2d v18, x25
+  mov x24, #2301339409586323456
+  mul x25, x1, x6
+  dup.2d v19, x24
+  umulh x24, x1, x6
+  mov x26, #7822752552742551552
+  dup.2d v20, x26
+  adds x23, x25, x23
+  cinc x24, x24, hs
+  mov x25, #5071053180419178496
+  adds x22, x23, x22
+  cinc x23, x24, hs
+  dup.2d v21, x25
+  mov x24, #16352570246982270976
+  mul x25, x2, x6
+  dup.2d v22, x24
+  umulh x24, x2, x6
+  ucvtf.2d v0, v0
+  ucvtf.2d v1, v1
+  adds x23, x25, x23
+  cinc x24, x24, hs
+  ucvtf.2d v2, v2
   adds x4, x23, x4
   cinc x23, x24, hs
-  mov x24, #16352570246982270976
-  dup.2d v22, x24
+  ucvtf.2d v11, v11
+  ucvtf.2d v3, v3
   mul x24, x3, x6
-  ucvtf.2d v0, v0
+  ucvtf.2d v4, v4
   umulh x6, x3, x6
-  ucvtf.2d v1, v1
-  ucvtf.2d v2, v2
+  ucvtf.2d v5, v5
+  ucvtf.2d v6, v6
   adds x23, x24, x23
   cinc x6, x6, hs
-  ucvtf.2d v11, v11
+  ucvtf.2d v12, v12
   adds x5, x23, x5
   cinc x6, x6, hs
-  ucvtf.2d v3, v3
-  mul x23, x0, x7
-  ucvtf.2d v4, v4
-  ucvtf.2d v5, v5
-  umulh x0, x0, x7
-  ucvtf.2d v6, v6
-  adds x22, x23, x22
-  cinc x0, x0, hs
-  ucvtf.2d v12, v12
-  mul x23, x1, x7
   ucvtf.2d v7, v7
   mov.16b v23, v9
-  umulh x1, x1, x7
+  mul x23, x0, x7
   fmla.2d v23, v0, v4
+  umulh x0, x0, x7
+  fsub.2d v24, v10, v23
+  fmla.2d v24, v0, v4
+  adds x22, x23, x22
+  cinc x0, x0, hs
+  add.2d v15, v15, v23
+  mul x23, x1, x7
+  add.2d v13, v13, v24
+  mov.16b v23, v9
+  umulh x1, x1, x7
+  fmla.2d v23, v0, v5
   adds x0, x23, x0
   cinc x1, x1, hs
   fsub.2d v24, v10, v23
   adds x0, x0, x4
   cinc x1, x1, hs
-  fmla.2d v24, v0, v4
-  add.2d v15, v15, v23
+  fmla.2d v24, v0, v5
+  add.2d v17, v17, v23
   mul x4, x2, x7
-  add.2d v13, v13, v24
+  add.2d v15, v15, v24
   umulh x2, x2, x7
   mov.16b v23, v9
+  fmla.2d v23, v0, v6
   adds x1, x4, x1
   cinc x2, x2, hs
-  fmla.2d v23, v0, v5
   fsub.2d v24, v10, v23
   adds x1, x1, x5
   cinc x2, x2, hs
-  fmla.2d v24, v0, v5
-  mul x4, x3, x7
-  add.2d v17, v17, v23
-  umulh x3, x3, x7
-  add.2d v15, v15, v24
-  mov.16b v23, v9
-  adds x2, x4, x2
-  cinc x3, x3, hs
-  fmla.2d v23, v0, v6
-  adds x2, x2, x6
-  cinc x3, x3, hs
-  fsub.2d v24, v10, v23
-  mov x4, #48718
   fmla.2d v24, v0, v6
   add.2d v19, v19, v23
-  movk x4, #4732, lsl 16
+  mul x4, x3, x7
   add.2d v17, v17, v24
-  movk x4, #45078, lsl 32
+  umulh x3, x3, x7
   mov.16b v23, v9
   fmla.2d v23, v0, v12
-  movk x4, #39852, lsl 48
+  adds x2, x4, x2
+  cinc x3, x3, hs
   fsub.2d v24, v10, v23
-  mov x5, #16676
+  adds x2, x2, x6
+  cinc x3, x3, hs
   fmla.2d v24, v0, v12
-  movk x5, #12692, lsl 16
   add.2d v21, v21, v23
+  mov x4, #48718
   add.2d v19, v19, v24
-  movk x5, #20986, lsl 32
+  movk x4, #4732, lsl 16
   mov.16b v23, v9
-  movk x5, #2848, lsl 48
   fmla.2d v23, v0, v7
-  mov x6, #51052
+  movk x4, #45078, lsl 32
   fsub.2d v24, v10, v23
+  movk x4, #39852, lsl 48
   fmla.2d v24, v0, v7
-  movk x6, #24721, lsl 16
   add.2d v0, v22, v23
-  movk x6, #61092, lsl 32
+  mov x5, #16676
   add.2d v21, v21, v24
-  movk x6, #45156, lsl 48
+  movk x5, #12692, lsl 16
   mov.16b v22, v9
   fmla.2d v22, v1, v4
-  mov x7, #3197
+  movk x5, #20986, lsl 32
   fsub.2d v23, v10, v22
-  movk x7, #18936, lsl 16
+  movk x5, #2848, lsl 48
   fmla.2d v23, v1, v4
-  movk x7, #10922, lsl 32
   add.2d v17, v17, v22
+  mov x6, #51052
   add.2d v15, v15, v23
-  movk x7, #11014, lsl 48
+  movk x6, #24721, lsl 16
   mov.16b v22, v9
-  mul x23, x4, x17
   fmla.2d v22, v1, v5
-  umulh x4, x4, x17
+  movk x6, #61092, lsl 32
   fsub.2d v23, v10, v22
+  movk x6, #45156, lsl 48
   fmla.2d v23, v1, v5
+  add.2d v19, v19, v22
+  mov x7, #3197
+  add.2d v17, v17, v23
+  movk x7, #18936, lsl 16
+  mov.16b v22, v9
+  movk x7, #10922, lsl 32
+  fmla.2d v22, v1, v6
+  fsub.2d v23, v10, v22
+  movk x7, #11014, lsl 48
+  fmla.2d v23, v1, v6
+  mul x23, x4, x17
+  add.2d v21, v21, v22
+  add.2d v19, v19, v23
+  umulh x4, x4, x17
+  mov.16b v22, v9
   adds x22, x23, x22
   cinc x4, x4, hs
-  add.2d v19, v19, v22
-  mul x23, x5, x17
-  add.2d v17, v17, v23
-  umulh x5, x5, x17
-  mov.16b v22, v9
-  fmla.2d v22, v1, v6
-  adds x4, x23, x4
-  cinc x5, x5, hs
-  fsub.2d v23, v10, v22
-  adds x0, x4, x0
-  cinc x4, x5, hs
-  fmla.2d v23, v1, v6
-  add.2d v21, v21, v22
-  mul x5, x6, x17
-  add.2d v19, v19, v23
-  umulh x6, x6, x17
-  mov.16b v22, v9
-  adds x4, x5, x4
-  cinc x5, x6, hs
   fmla.2d v22, v1, v12
   fsub.2d v23, v10, v22
-  adds x1, x4, x1
-  cinc x4, x5, hs
+  mul x23, x5, x17
   fmla.2d v23, v1, v12
-  mul x5, x7, x17
+  umulh x5, x5, x17
   add.2d v0, v0, v22
-  umulh x6, x7, x17
   add.2d v21, v21, v23
+  adds x4, x23, x4
+  cinc x5, x5, hs
   mov.16b v22, v9
+  adds x0, x4, x0
+  cinc x4, x5, hs
+  fmla.2d v22, v1, v7
+  fsub.2d v23, v10, v22
+  mul x5, x6, x17
+  fmla.2d v23, v1, v7
+  umulh x6, x6, x17
+  add.2d v1, v20, v22
+  add.2d v0, v0, v23
   adds x4, x5, x4
   cinc x5, x6, hs
-  fmla.2d v22, v1, v7
-  adds x2, x4, x2
-  cinc x4, x5, hs
-  fsub.2d v23, v10, v22
-  add x3, x3, x4
-  fmla.2d v23, v1, v7
-  add.2d v1, v20, v22
-  mov x4, #56431
-  add.2d v0, v0, v23
-  movk x4, #30457, lsl 16
   mov.16b v20, v9
-  movk x4, #30012, lsl 32
+  adds x1, x4, x1
+  cinc x4, x5, hs
   fmla.2d v20, v2, v4
   fsub.2d v22, v10, v20
-  movk x4, #6382, lsl 48
+  mul x5, x7, x17
   fmla.2d v22, v2, v4
-  mov x5, #59151
+  umulh x6, x7, x17
   add.2d v19, v19, v20
-  movk x5, #41769, lsl 16
   add.2d v17, v17, v22
+  adds x4, x5, x4
+  cinc x5, x6, hs
   mov.16b v20, v9
-  movk x5, #32276, lsl 32
+  adds x2, x4, x2
+  cinc x4, x5, hs
   fmla.2d v20, v2, v5
-  movk x5, #21677, lsl 48
   fsub.2d v22, v10, v20
-  mov x6, #34015
+  add x3, x3, x4
   fmla.2d v22, v2, v5
+  mov x4, #56431
   add.2d v20, v21, v20
-  movk x6, #20342, lsl 16
   add.2d v19, v19, v22
-  movk x6, #13935, lsl 32
+  movk x4, #30457, lsl 16
   mov.16b v21, v9
+  movk x4, #30012, lsl 32
   fmla.2d v21, v2, v6
-  movk x6, #11030, lsl 48
   fsub.2d v22, v10, v21
-  mov x7, #13689
+  movk x4, #6382, lsl 48
   fmla.2d v22, v2, v6
-  movk x7, #8159, lsl 16
+  mov x5, #59151
   add.2d v0, v0, v21
   add.2d v20, v20, v22
-  movk x7, #215, lsl 32
+  movk x5, #41769, lsl 16
   mov.16b v21, v9
-  movk x7, #4913, lsl 48
+  movk x5, #32276, lsl 32
   fmla.2d v21, v2, v12
-  mul x17, x4, x20
+  movk x5, #21677, lsl 48
   fsub.2d v22, v10, v21
   fmla.2d v22, v2, v12
-  umulh x4, x4, x20
+  mov x6, #34015
   add.2d v1, v1, v21
-  adds x17, x17, x22
-  cinc x4, x4, hs
+  movk x6, #20342, lsl 16
   add.2d v0, v0, v22
-  mul x22, x5, x20
   mov.16b v21, v9
+  movk x6, #13935, lsl 32
   fmla.2d v21, v2, v7
-  umulh x5, x5, x20
+  movk x6, #11030, lsl 48
   fsub.2d v22, v10, v21
-  adds x4, x22, x4
-  cinc x5, x5, hs
   fmla.2d v22, v2, v7
-  adds x0, x4, x0
-  cinc x4, x5, hs
+  mov x7, #13689
   add.2d v2, v18, v21
+  movk x7, #8159, lsl 16
   add.2d v1, v1, v22
-  mul x5, x6, x20
   mov.16b v18, v9
-  umulh x6, x6, x20
+  movk x7, #215, lsl 32
   fmla.2d v18, v11, v4
-  adds x4, x5, x4
-  cinc x5, x6, hs
+  movk x7, #4913, lsl 48
   fsub.2d v21, v10, v18
   fmla.2d v21, v11, v4
-  adds x1, x4, x1
-  cinc x4, x5, hs
+  mul x17, x4, x20
   add.2d v18, v20, v18
-  mul x5, x7, x20
+  umulh x4, x4, x20
   add.2d v19, v19, v21
-  umulh x6, x7, x20
   mov.16b v20, v9
-  fmla.2d v20, v11, v5
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  fsub.2d v21, v10, v20
-  adds x2, x4, x2
-  cinc x4, x5, hs
-  fmla.2d v21, v11, v5
-  add.2d v0, v0, v20
-  add x3, x3, x4
-  add.2d v18, v18, v21
-  mov x4, #61005
-  mov.16b v20, v9
-  movk x4, #58262, lsl 16
-  fmla.2d v20, v11, v6
-  fsub.2d v21, v10, v20
-  movk x4, #32851, lsl 32
-  fmla.2d v21, v11, v6
-  movk x4, #11582, lsl 48
-  add.2d v1, v1, v20
-  mov x5, #37581
-  add.2d v0, v0, v21
-  mov.16b v20, v9
-  movk x5, #43836, lsl 16
-  fmla.2d v20, v11, v12
-  movk x5, #36286, lsl 32
-  fsub.2d v21, v10, v20
-  movk x5, #51783, lsl 48
-  fmla.2d v21, v11, v12
-  add.2d v2, v2, v20
-  mov x6, #10899
-  add.2d v1, v1, v21
-  movk x6, #30709, lsl 16
-  mov.16b v20, v9
-  movk x6, #61551, lsl 32
-  fmla.2d v20, v11, v7
-  fsub.2d v21, v10, v20
-  movk x6, #45784, lsl 48
-  fmla.2d v21, v11, v7
-  mov x7, #36612
-  add.2d v11, v16, v20
-  movk x7, #63402, lsl 16
-  add.2d v2, v2, v21
-  mov.16b v16, v9
-  movk x7, #47623, lsl 32
-  fmla.2d v16, v3, v4
-  movk x7, #9430, lsl 48
-  fsub.2d v20, v10, v16
-  mul x20, x4, x21
-  fmla.2d v20, v3, v4
-  add.2d v0, v0, v16
-  umulh x4, x4, x21
-  add.2d v4, v18, v20
-  adds x17, x20, x17
+  adds x17, x17, x22
   cinc x4, x4, hs
-  mov.16b v16, v9
-  fmla.2d v16, v3, v5
-  mul x20, x5, x21
-  fsub.2d v18, v10, v16
-  umulh x5, x5, x21
-  fmla.2d v18, v3, v5
-  adds x4, x20, x4
+  fmla.2d v20, v11, v5
+  mul x22, x5, x20
+  fsub.2d v21, v10, v20
+  fmla.2d v21, v11, v5
+  umulh x5, x5, x20
+  add.2d v0, v0, v20
+  adds x4, x22, x4
   cinc x5, x5, hs
-  add.2d v1, v1, v16
-  add.2d v0, v0, v18
+  add.2d v18, v18, v21
+  mov.16b v20, v9
   adds x0, x4, x0
   cinc x4, x5, hs
-  mov.16b v5, v9
-  mul x5, x6, x21
-  fmla.2d v5, v3, v6
-  umulh x6, x6, x21
-  fsub.2d v16, v10, v5
-  fmla.2d v16, v3, v6
+  fmla.2d v20, v11, v6
+  mul x5, x6, x20
+  fsub.2d v21, v10, v20
+  fmla.2d v21, v11, v6
+  umulh x6, x6, x20
+  add.2d v1, v1, v20
   adds x4, x5, x4
   cinc x5, x6, hs
-  add.2d v2, v2, v5
+  add.2d v0, v0, v21
+  mov.16b v20, v9
   adds x1, x4, x1
   cinc x4, x5, hs
-  add.2d v1, v1, v16
-  mul x5, x7, x21
-  mov.16b v5, v9
-  fmla.2d v5, v3, v12
-  umulh x6, x7, x21
-  fsub.2d v6, v10, v5
+  fmla.2d v20, v11, v12
+  mul x5, x7, x20
+  fsub.2d v21, v10, v20
+  fmla.2d v21, v11, v12
+  umulh x6, x7, x20
+  add.2d v2, v2, v20
   adds x4, x5, x4
   cinc x5, x6, hs
-  fmla.2d v6, v3, v12
+  add.2d v1, v1, v21
   adds x2, x4, x2
   cinc x4, x5, hs
-  add.2d v5, v11, v5
-  add.2d v2, v2, v6
+  mov.16b v20, v9
+  fmla.2d v20, v11, v7
   add x3, x3, x4
+  fsub.2d v21, v10, v20
+  mov x4, #61005
+  fmla.2d v21, v11, v7
+  add.2d v11, v16, v20
+  movk x4, #58262, lsl 16
+  add.2d v2, v2, v21
+  movk x4, #32851, lsl 32
+  mov.16b v16, v9
+  fmla.2d v16, v3, v4
+  movk x4, #11582, lsl 48
+  fsub.2d v20, v10, v16
+  mov x5, #37581
+  fmla.2d v20, v3, v4
+  add.2d v0, v0, v16
+  movk x5, #43836, lsl 16
+  add.2d v4, v18, v20
+  movk x5, #36286, lsl 32
+  mov.16b v16, v9
+  fmla.2d v16, v3, v5
+  movk x5, #51783, lsl 48
+  fsub.2d v18, v10, v16
+  mov x6, #10899
+  fmla.2d v18, v3, v5
+  add.2d v1, v1, v16
+  movk x6, #30709, lsl 16
+  add.2d v0, v0, v18
+  movk x6, #61551, lsl 32
+  mov.16b v5, v9
+  fmla.2d v5, v3, v6
+  movk x6, #45784, lsl 48
+  fsub.2d v16, v10, v5
+  mov x7, #36612
+  fmla.2d v16, v3, v6
+  add.2d v2, v2, v5
+  movk x7, #63402, lsl 16
+  add.2d v1, v1, v16
+  movk x7, #47623, lsl 32
+  mov.16b v5, v9
+  fmla.2d v5, v3, v12
+  movk x7, #9430, lsl 48
+  fsub.2d v6, v10, v5
+  mul x20, x4, x21
+  fmla.2d v6, v3, v12
+  add.2d v5, v11, v5
+  umulh x4, x4, x21
+  add.2d v2, v2, v6
+  adds x17, x20, x17
+  cinc x4, x4, hs
   mov.16b v6, v9
-  mov x4, #65535
   fmla.2d v6, v3, v7
-  movk x4, #61439, lsl 16
+  mul x20, x5, x21
   fsub.2d v11, v10, v6
+  umulh x5, x5, x21
   fmla.2d v11, v3, v7
-  movk x4, #62867, lsl 32
+  adds x4, x20, x4
+  cinc x5, x5, hs
   add.2d v3, v14, v6
-  movk x4, #49889, lsl 48
   add.2d v5, v5, v11
-  mul x4, x4, x17
+  adds x0, x4, x0
+  cinc x4, x5, hs
   usra.2d v15, v13, #52
+  mul x5, x6, x21
   usra.2d v17, v15, #52
-  mov x5, #1
   usra.2d v19, v17, #52
-  movk x5, #61440, lsl 16
+  umulh x6, x6, x21
   usra.2d v4, v19, #52
+  adds x4, x5, x4
+  cinc x5, x6, hs
   and.16b v6, v13, v8
-  movk x5, #62867, lsl 32
   and.16b v7, v15, v8
-  movk x5, #17377, lsl 48
+  adds x1, x4, x1
+  cinc x4, x5, hs
   and.16b v11, v17, v8
-  mov x6, #28817
+  mul x5, x7, x21
   and.16b v8, v19, v8
   ucvtf.2d v6, v6
-  movk x6, #31161, lsl 16
+  umulh x6, x7, x21
   mov x7, #37864
-  movk x6, #59464, lsl 32
+  adds x4, x5, x4
+  cinc x5, x6, hs
   movk x7, #1815, lsl 16
-  movk x6, #10291, lsl 48
   movk x7, #28960, lsl 32
+  adds x2, x4, x2
+  cinc x4, x5, hs
   movk x7, #17153, lsl 48
-  mov x20, #22621
+  add x3, x3, x4
   dup.2d v12, x7
+  mov.16b v13, v9
+  mov x4, #65535
+  fmla.2d v13, v6, v12
+  movk x4, #61439, lsl 16
+  fsub.2d v14, v10, v13
+  fmla.2d v14, v6, v12
+  movk x4, #62867, lsl 32
+  add.2d v0, v0, v13
+  movk x4, #49889, lsl 48
+  add.2d v4, v4, v14
+  mov x5, #46128
+  mul x4, x4, x17
+  movk x5, #29964, lsl 16
+  mov x6, #1
+  movk x5, #7587, lsl 32
+  movk x5, #17161, lsl 48
+  movk x6, #61440, lsl 16
+  dup.2d v12, x5
+  movk x6, #62867, lsl 32
+  mov.16b v13, v9
+  fmla.2d v13, v6, v12
+  movk x6, #17377, lsl 48
+  fsub.2d v14, v10, v13
+  mov x5, #28817
+  fmla.2d v14, v6, v12
+  add.2d v1, v1, v13
+  movk x5, #31161, lsl 16
+  add.2d v0, v0, v14
+  movk x5, #59464, lsl 32
+  mov x7, #52826
+  movk x7, #57790, lsl 16
+  movk x5, #10291, lsl 48
+  movk x7, #55431, lsl 32
+  mov x20, #22621
+  movk x7, #17196, lsl 48
   movk x20, #33153, lsl 16
+  dup.2d v12, x7
   mov.16b v13, v9
   movk x20, #17846, lsl 32
   fmla.2d v13, v6, v12
-  fsub.2d v14, v10, v13
   movk x20, #47184, lsl 48
+  fsub.2d v14, v10, v13
   fmla.2d v14, v6, v12
   mov x7, #41001
-  add.2d v0, v0, v13
-  movk x7, #57649, lsl 16
-  add.2d v4, v4, v14
-  mov x21, #46128
-  movk x7, #20082, lsl 32
-  movk x21, #29964, lsl 16
-  movk x7, #12388, lsl 48
-  movk x21, #7587, lsl 32
-  mul x22, x5, x4
-  movk x21, #17161, lsl 48
-  dup.2d v12, x21
-  umulh x5, x5, x4
-  mov.16b v13, v9
-  cmn x22, x17
-  cinc x5, x5, hs
-  fmla.2d v13, v6, v12
-  mul x17, x6, x4
-  fsub.2d v14, v10, v13
-  fmla.2d v14, v6, v12
-  umulh x6, x6, x4
-  add.2d v1, v1, v13
-  adds x5, x17, x5
-  cinc x6, x6, hs
-  add.2d v0, v0, v14
-  mov x17, #52826
-  adds x0, x5, x0
-  cinc x5, x6, hs
-  movk x17, #57790, lsl 16
-  mul x6, x20, x4
-  movk x17, #55431, lsl 32
-  umulh x20, x20, x4
-  movk x17, #17196, lsl 48
-  dup.2d v12, x17
-  adds x5, x6, x5
-  cinc x6, x20, hs
-  mov.16b v13, v9
-  adds x1, x5, x1
-  cinc x5, x6, hs
-  fmla.2d v13, v6, v12
-  mul x6, x7, x4
-  fsub.2d v14, v10, v13
-  fmla.2d v14, v6, v12
-  umulh x4, x7, x4
   add.2d v2, v2, v13
-  adds x5, x6, x5
-  cinc x4, x4, hs
+  movk x7, #57649, lsl 16
   add.2d v1, v1, v14
-  adds x2, x5, x2
-  cinc x4, x4, hs
-  mov x5, #31276
-  movk x5, #21262, lsl 16
-  add x3, x3, x4
-  movk x5, #2304, lsl 32
-  mov x4, #2
-  movk x5, #17182, lsl 48
-  movk x4, #57344, lsl 16
-  dup.2d v12, x5
+  mov x21, #31276
+  movk x7, #20082, lsl 32
+  movk x21, #21262, lsl 16
+  movk x7, #12388, lsl 48
+  movk x21, #2304, lsl 32
+  movk x21, #17182, lsl 48
+  mul x22, x6, x4
+  dup.2d v12, x21
+  umulh x6, x6, x4
   mov.16b v13, v9
-  movk x4, #60199, lsl 32
   fmla.2d v13, v6, v12
-  movk x4, #34755, lsl 48
+  cmn x22, x17
+  cinc x6, x6, hs
   fsub.2d v14, v10, v13
-  mov x5, #57634
+  mul x17, x5, x4
   fmla.2d v14, v6, v12
   add.2d v5, v5, v13
-  movk x5, #62322, lsl 16
+  umulh x5, x5, x4
   add.2d v2, v2, v14
-  movk x5, #53392, lsl 32
-  mov x6, #28672
-  movk x5, #20583, lsl 48
-  movk x6, #24515, lsl 16
-  movk x6, #54929, lsl 32
-  mov x7, #45242
-  movk x6, #17064, lsl 48
-  movk x7, #770, lsl 16
-  dup.2d v12, x6
+  adds x6, x17, x6
+  cinc x5, x5, hs
+  mov x17, #28672
+  movk x17, #24515, lsl 16
+  adds x0, x6, x0
+  cinc x5, x5, hs
+  movk x17, #54929, lsl 32
+  mul x6, x20, x4
+  movk x17, #17064, lsl 48
+  dup.2d v12, x17
+  umulh x17, x20, x4
   mov.16b v13, v9
-  movk x7, #35693, lsl 32
+  adds x5, x6, x5
+  cinc x6, x17, hs
   fmla.2d v13, v6, v12
-  movk x7, #28832, lsl 48
   fsub.2d v14, v10, v13
-  mov x6, #16467
+  adds x1, x5, x1
+  cinc x5, x6, hs
   fmla.2d v14, v6, v12
+  mul x6, x7, x4
   add.2d v3, v3, v13
-  movk x6, #49763, lsl 16
   add.2d v5, v5, v14
-  movk x6, #40165, lsl 32
+  umulh x4, x7, x4
   ucvtf.2d v6, v7
-  movk x6, #24776, lsl 48
-  mov x17, #44768
-  movk x17, #51919, lsl 16
-  subs x4, x0, x4
-  sbcs x5, x1, x5
-  sbcs x7, x2, x7
-  sbcs x6, x3, x6
-  movk x17, #6346, lsl 32
-  tst x3, #9223372036854775808
-  csel x0, x4, x0, mi
-  csel x1, x5, x1, mi
-  csel x2, x7, x2, mi
-  csel x3, x6, x3, mi
-  movk x17, #17133, lsl 48
+  adds x5, x6, x5
+  cinc x4, x4, hs
+  mov x6, #44768
+  movk x6, #51919, lsl 16
+  adds x2, x5, x2
+  cinc x4, x4, hs
+  movk x6, #6346, lsl 32
+  add x3, x3, x4
+  movk x6, #17133, lsl 48
   mul x4, x8, x12
-  dup.2d v7, x17
+  dup.2d v7, x6
   mov.16b v12, v9
   umulh x5, x8, x12
   fmla.2d v12, v6, v7
   mul x6, x9, x12
   fsub.2d v13, v10, v12
-  umulh x7, x9, x12
   fmla.2d v13, v6, v7
+  umulh x7, x9, x12
   add.2d v0, v0, v12
   adds x5, x6, x5
   cinc x6, x7, hs
   add.2d v4, v4, v13
-  mul x7, x10, x12
-  mov x17, #47492
+  mov x7, #47492
+  mul x17, x10, x12
+  movk x7, #23630, lsl 16
   umulh x20, x10, x12
-  movk x17, #23630, lsl 16
-  movk x17, #49985, lsl 32
-  adds x6, x7, x6
-  cinc x7, x20, hs
-  movk x17, #17168, lsl 48
-  mul x20, x11, x12
-  dup.2d v7, x17
+  movk x7, #49985, lsl 32
+  movk x7, #17168, lsl 48
+  adds x6, x17, x6
+  cinc x17, x20, hs
+  dup.2d v7, x7
+  mul x7, x11, x12
   mov.16b v12, v9
-  umulh x12, x11, x12
   fmla.2d v12, v6, v7
-  adds x7, x20, x7
-  cinc x12, x12, hs
+  umulh x12, x11, x12
   fsub.2d v13, v10, v12
-  mul x17, x8, x13
+  adds x7, x7, x17
+  cinc x12, x12, hs
   fmla.2d v13, v6, v7
   add.2d v1, v1, v12
-  umulh x20, x8, x13
+  mul x17, x8, x13
   add.2d v0, v0, v13
+  umulh x20, x8, x13
+  mov x21, #57936
+  movk x21, #54828, lsl 16
   adds x5, x17, x5
   cinc x17, x20, hs
-  mov x20, #57936
-  mul x21, x9, x13
-  movk x20, #54828, lsl 16
-  movk x20, #18292, lsl 32
-  umulh x22, x9, x13
-  movk x20, #17197, lsl 48
-  adds x17, x21, x17
-  cinc x21, x22, hs
-  dup.2d v7, x20
-  adds x6, x17, x6
-  cinc x17, x21, hs
+  movk x21, #18292, lsl 32
+  mul x20, x9, x13
+  movk x21, #17197, lsl 48
+  dup.2d v7, x21
+  umulh x21, x9, x13
   mov.16b v12, v9
-  fmla.2d v12, v6, v7
-  mul x20, x10, x13
-  fsub.2d v13, v10, v12
-  umulh x21, x10, x13
-  fmla.2d v13, v6, v7
   adds x17, x20, x17
   cinc x20, x21, hs
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
+  adds x6, x17, x6
+  cinc x17, x20, hs
+  fmla.2d v13, v6, v7
+  mul x20, x10, x13
   add.2d v2, v2, v12
   add.2d v1, v1, v13
-  adds x7, x17, x7
-  cinc x17, x20, hs
-  mov x20, #17708
-  mul x21, x11, x13
-  movk x20, #43915, lsl 16
-  umulh x13, x11, x13
-  movk x20, #64348, lsl 32
-  movk x20, #17188, lsl 48
-  adds x17, x21, x17
-  cinc x13, x13, hs
-  dup.2d v7, x20
-  adds x12, x17, x12
-  cinc x13, x13, hs
-  mov.16b v12, v9
-  mul x17, x8, x14
-  fmla.2d v12, v6, v7
-  fsub.2d v13, v10, v12
-  umulh x20, x8, x14
-  fmla.2d v13, v6, v7
-  adds x6, x17, x6
-  cinc x17, x20, hs
-  add.2d v5, v5, v12
-  add.2d v2, v2, v13
-  mul x20, x9, x14
-  mov x21, #29184
-  umulh x22, x9, x14
-  movk x21, #20789, lsl 16
-  adds x17, x20, x17
-  cinc x20, x22, hs
-  movk x21, #19197, lsl 32
-  movk x21, #17083, lsl 48
-  adds x7, x17, x7
-  cinc x17, x20, hs
-  dup.2d v7, x21
-  mul x20, x10, x14
-  mov.16b v12, v9
-  umulh x21, x10, x14
-  fmla.2d v12, v6, v7
-  fsub.2d v13, v10, v12
+  umulh x21, x10, x13
+  mov x22, #17708
   adds x17, x20, x17
   cinc x20, x21, hs
+  movk x22, #43915, lsl 16
+  movk x22, #64348, lsl 32
+  adds x7, x17, x7
+  cinc x17, x20, hs
+  movk x22, #17188, lsl 48
+  mul x20, x11, x13
+  dup.2d v7, x22
+  umulh x13, x11, x13
+  mov.16b v12, v9
+  fmla.2d v12, v6, v7
+  adds x17, x20, x17
+  cinc x13, x13, hs
+  fsub.2d v13, v10, v12
+  adds x12, x17, x12
+  cinc x13, x13, hs
   fmla.2d v13, v6, v7
+  add.2d v5, v5, v12
+  mul x17, x8, x14
+  add.2d v2, v2, v13
+  umulh x20, x8, x14
+  mov x21, #29184
+  movk x21, #20789, lsl 16
+  adds x6, x17, x6
+  cinc x17, x20, hs
+  movk x21, #19197, lsl 32
+  mul x20, x9, x14
+  movk x21, #17083, lsl 48
+  dup.2d v7, x21
+  umulh x21, x9, x14
+  mov.16b v12, v9
+  adds x17, x20, x17
+  cinc x20, x21, hs
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
+  adds x7, x17, x7
+  cinc x17, x20, hs
+  fmla.2d v13, v6, v7
+  mul x20, x10, x14
+  add.2d v3, v3, v12
+  add.2d v5, v5, v13
+  umulh x21, x10, x14
+  ucvtf.2d v6, v11
+  adds x17, x20, x17
+  cinc x20, x21, hs
+  mov x21, #58856
+  movk x21, #14953, lsl 16
   adds x12, x17, x12
   cinc x17, x20, hs
-  add.2d v3, v3, v12
+  movk x21, #15155, lsl 32
   mul x20, x11, x14
-  add.2d v5, v5, v13
-  ucvtf.2d v6, v11
+  movk x21, #17181, lsl 48
+  dup.2d v7, x21
   umulh x14, x11, x14
-  mov x21, #58856
+  mov.16b v11, v9
   adds x17, x20, x17
   cinc x14, x14, hs
-  movk x21, #14953, lsl 16
+  fmla.2d v11, v6, v7
+  fsub.2d v12, v10, v11
   adds x13, x17, x13
   cinc x14, x14, hs
-  movk x21, #15155, lsl 32
-  movk x21, #17181, lsl 48
+  fmla.2d v12, v6, v7
   mul x17, x8, x15
-  dup.2d v7, x21
+  add.2d v0, v0, v11
+  add.2d v4, v4, v12
   umulh x8, x8, x15
-  mov.16b v11, v9
+  mov x20, #35392
   adds x7, x17, x7
   cinc x8, x8, hs
-  fmla.2d v11, v6, v7
-  fsub.2d v12, v10, v11
+  movk x20, #12477, lsl 16
+  movk x20, #56780, lsl 32
   mul x17, x9, x15
-  fmla.2d v12, v6, v7
+  movk x20, #17142, lsl 48
   umulh x9, x9, x15
-  add.2d v0, v0, v11
+  dup.2d v7, x20
+  mov.16b v11, v9
   adds x8, x17, x8
   cinc x9, x9, hs
-  add.2d v4, v4, v12
-  mov x17, #35392
+  fmla.2d v11, v6, v7
   adds x8, x8, x12
   cinc x9, x9, hs
-  movk x17, #12477, lsl 16
+  fsub.2d v12, v10, v11
   mul x12, x10, x15
-  movk x17, #56780, lsl 32
-  movk x17, #17142, lsl 48
+  fmla.2d v12, v6, v7
+  add.2d v1, v1, v11
   umulh x10, x10, x15
-  dup.2d v7, x17
+  add.2d v0, v0, v12
   adds x9, x12, x9
   cinc x10, x10, hs
-  mov.16b v11, v9
+  mov x12, #9848
+  movk x12, #54501, lsl 16
   adds x9, x9, x13
   cinc x10, x10, hs
-  fmla.2d v11, v6, v7
-  fsub.2d v12, v10, v11
-  mul x12, x11, x15
-  fmla.2d v12, v6, v7
-  umulh x11, x11, x15
-  add.2d v1, v1, v11
-  adds x10, x12, x10
-  cinc x11, x11, hs
-  add.2d v0, v0, v12
-  mov x12, #9848
-  adds x10, x10, x14
-  cinc x11, x11, hs
-  movk x12, #54501, lsl 16
-  mov x13, #48718
   movk x12, #31540, lsl 32
-  movk x13, #4732, lsl 16
+  mul x13, x11, x15
   movk x12, #17170, lsl 48
   dup.2d v7, x12
-  movk x13, #45078, lsl 32
+  umulh x11, x11, x15
   mov.16b v11, v9
-  movk x13, #39852, lsl 48
+  adds x10, x13, x10
+  cinc x11, x11, hs
   fmla.2d v11, v6, v7
-  mov x12, #16676
   fsub.2d v12, v10, v11
+  adds x10, x10, x14
+  cinc x11, x11, hs
   fmla.2d v12, v6, v7
-  movk x12, #12692, lsl 16
+  mov x12, #48718
   add.2d v2, v2, v11
-  movk x12, #20986, lsl 32
   add.2d v1, v1, v12
-  movk x12, #2848, lsl 48
-  mov x14, #9584
-  movk x14, #63883, lsl 16
-  mov x15, #51052
-  movk x14, #18253, lsl 32
-  movk x15, #24721, lsl 16
-  movk x14, #17190, lsl 48
-  movk x15, #61092, lsl 32
-  dup.2d v7, x14
+  movk x12, #4732, lsl 16
+  mov x13, #9584
+  movk x12, #45078, lsl 32
+  movk x13, #63883, lsl 16
+  movk x13, #18253, lsl 32
+  movk x12, #39852, lsl 48
+  movk x13, #17190, lsl 48
+  mov x14, #16676
+  dup.2d v7, x13
   mov.16b v11, v9
-  movk x15, #45156, lsl 48
+  movk x14, #12692, lsl 16
   fmla.2d v11, v6, v7
-  mov x14, #3197
+  movk x14, #20986, lsl 32
   fsub.2d v12, v10, v11
   fmla.2d v12, v6, v7
-  movk x14, #18936, lsl 16
+  movk x14, #2848, lsl 48
   add.2d v5, v5, v11
-  movk x14, #10922, lsl 32
+  mov x13, #51052
   add.2d v2, v2, v12
-  movk x14, #11014, lsl 48
-  mov x17, #51712
-  movk x17, #16093, lsl 16
-  mul x20, x13, x4
-  movk x17, #30633, lsl 32
-  umulh x13, x13, x4
-  movk x17, #17068, lsl 48
-  adds x7, x20, x7
-  cinc x13, x13, hs
-  dup.2d v7, x17
+  mov x15, #51712
+  movk x13, #24721, lsl 16
+  movk x15, #16093, lsl 16
+  movk x13, #61092, lsl 32
+  movk x15, #30633, lsl 32
+  movk x15, #17068, lsl 48
+  movk x13, #45156, lsl 48
+  dup.2d v7, x15
+  mov x15, #3197
   mov.16b v11, v9
-  mul x17, x12, x4
   fmla.2d v11, v6, v7
-  umulh x12, x12, x4
+  movk x15, #18936, lsl 16
   fsub.2d v12, v10, v11
-  adds x13, x17, x13
-  cinc x12, x12, hs
+  movk x15, #10922, lsl 32
   fmla.2d v12, v6, v7
+  movk x15, #11014, lsl 48
   add.2d v3, v3, v11
-  adds x8, x13, x8
-  cinc x12, x12, hs
   add.2d v5, v5, v12
-  mul x13, x15, x4
+  mul x17, x12, x4
   ucvtf.2d v6, v8
-  umulh x15, x15, x4
-  mov x17, #34724
-  movk x17, #40393, lsl 16
-  adds x12, x13, x12
-  cinc x13, x15, hs
-  movk x17, #23752, lsl 32
+  umulh x12, x12, x4
+  mov x20, #34724
+  movk x20, #40393, lsl 16
+  adds x7, x17, x7
+  cinc x12, x12, hs
+  movk x20, #23752, lsl 32
+  mul x17, x14, x4
+  movk x20, #17184, lsl 48
+  dup.2d v7, x20
+  umulh x14, x14, x4
+  mov.16b v8, v9
+  adds x12, x17, x12
+  cinc x14, x14, hs
+  fmla.2d v8, v6, v7
+  fsub.2d v11, v10, v8
+  adds x8, x12, x8
+  cinc x12, x14, hs
+  fmla.2d v11, v6, v7
+  mul x14, x13, x4
+  add.2d v0, v0, v8
+  add.2d v4, v4, v11
+  umulh x13, x13, x4
+  mov x17, #25532
+  adds x12, x14, x12
+  cinc x13, x13, hs
+  movk x17, #31025, lsl 16
+  movk x17, #10002, lsl 32
   adds x9, x12, x9
   cinc x12, x13, hs
-  movk x17, #17184, lsl 48
-  mul x13, x14, x4
+  movk x17, #17199, lsl 48
+  mul x13, x15, x4
   dup.2d v7, x17
   mov.16b v8, v9
-  umulh x4, x14, x4
+  umulh x4, x15, x4
   fmla.2d v8, v6, v7
   adds x12, x13, x12
   cinc x4, x4, hs
   fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
   adds x10, x12, x10
   cinc x4, x4, hs
-  fmla.2d v11, v6, v7
-  add.2d v0, v0, v8
-  add x4, x11, x4
-  add.2d v4, v4, v11
-  mov x11, #56431
-  mov x12, #25532
-  movk x12, #31025, lsl 16
-  movk x11, #30457, lsl 16
-  movk x12, #10002, lsl 32
-  movk x11, #30012, lsl 32
-  movk x12, #17199, lsl 48
-  movk x11, #6382, lsl 48
-  dup.2d v7, x12
-  mov.16b v8, v9
-  mov x12, #59151
-  fmla.2d v8, v6, v7
-  movk x12, #41769, lsl 16
-  fsub.2d v11, v10, v8
-  movk x12, #32276, lsl 32
-  fmla.2d v11, v6, v7
   add.2d v1, v1, v8
-  movk x12, #21677, lsl 48
+  add x4, x11, x4
   add.2d v0, v0, v11
-  mov x13, #34015
-  mov x14, #18830
-  movk x13, #20342, lsl 16
-  movk x14, #2465, lsl 16
-  movk x14, #36348, lsl 32
-  movk x13, #13935, lsl 32
-  movk x14, #17194, lsl 48
-  movk x13, #11030, lsl 48
-  dup.2d v7, x14
-  mov x14, #13689
+  mov x11, #18830
+  mov x12, #56431
+  movk x11, #2465, lsl 16
+  movk x12, #30457, lsl 16
+  movk x11, #36348, lsl 32
+  movk x11, #17194, lsl 48
+  movk x12, #30012, lsl 32
+  dup.2d v7, x11
+  movk x12, #6382, lsl 48
   mov.16b v8, v9
   fmla.2d v8, v6, v7
-  movk x14, #8159, lsl 16
+  mov x11, #59151
   fsub.2d v11, v10, v8
-  movk x14, #215, lsl 32
+  movk x11, #41769, lsl 16
   fmla.2d v11, v6, v7
-  movk x14, #4913, lsl 48
+  movk x11, #32276, lsl 32
   add.2d v2, v2, v8
   add.2d v1, v1, v11
-  mul x15, x11, x5
-  mov x17, #21566
-  umulh x11, x11, x5
-  movk x17, #43708, lsl 16
-  adds x7, x15, x7
-  cinc x11, x11, hs
-  movk x17, #57685, lsl 32
-  movk x17, #17185, lsl 48
-  mul x15, x12, x5
-  dup.2d v7, x17
+  movk x11, #21677, lsl 48
+  mov x13, #21566
+  mov x14, #34015
+  movk x13, #43708, lsl 16
+  movk x13, #57685, lsl 32
+  movk x14, #20342, lsl 16
+  movk x13, #17185, lsl 48
+  movk x14, #13935, lsl 32
+  dup.2d v7, x13
+  mov.16b v8, v9
+  movk x14, #11030, lsl 48
+  fmla.2d v8, v6, v7
+  mov x13, #13689
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  movk x13, #8159, lsl 16
+  add.2d v5, v5, v8
+  movk x13, #215, lsl 32
+  add.2d v2, v2, v11
+  mov x15, #3072
+  movk x13, #4913, lsl 48
+  movk x15, #8058, lsl 16
+  mul x17, x12, x5
+  movk x15, #46097, lsl 32
+  movk x15, #17047, lsl 48
   umulh x12, x12, x5
+  dup.2d v7, x15
+  adds x7, x17, x7
+  cinc x12, x12, hs
   mov.16b v8, v9
   fmla.2d v8, v6, v7
+  mul x15, x11, x5
+  fsub.2d v11, v10, v8
+  umulh x11, x11, x5
+  fmla.2d v11, v6, v7
+  add.2d v3, v3, v8
+  adds x12, x15, x12
+  cinc x11, x11, hs
+  add.2d v5, v5, v11
+  adds x8, x12, x8
+  cinc x11, x11, hs
+  mov x12, #65535
+  movk x12, #61439, lsl 16
+  mul x15, x14, x5
+  movk x12, #62867, lsl 32
+  umulh x14, x14, x5
+  movk x12, #1, lsl 48
+  umov x17, v4.d[0]
   adds x11, x15, x11
-  cinc x12, x12, hs
+  cinc x14, x14, hs
+  umov x15, v4.d[1]
+  adds x9, x11, x9
+  cinc x11, x14, hs
+  mul x14, x17, x12
+  mul x12, x15, x12
+  mul x15, x13, x5
+  and x14, x14, x16
+  umulh x5, x13, x5
+  and x12, x12, x16
+  ins v6.d[0], x14
+  ins v6.d[1], x12
+  adds x11, x15, x11
+  cinc x5, x5, hs
+  ucvtf.2d v6, v6
+  adds x10, x11, x10
+  cinc x5, x5, hs
+  mov x11, #16
+  add x4, x4, x5
+  movk x11, #22847, lsl 32
+  movk x11, #17151, lsl 48
+  mov x5, #61005
+  dup.2d v7, x11
+  movk x5, #58262, lsl 16
+  mov.16b v8, v9
+  fmla.2d v8, v6, v7
+  movk x5, #32851, lsl 32
+  fsub.2d v11, v10, v8
+  movk x5, #11582, lsl 48
+  fmla.2d v11, v6, v7
+  add.2d v0, v0, v8
+  mov x11, #37581
+  add.2d v4, v4, v11
+  movk x11, #43836, lsl 16
+  mov x12, #20728
+  movk x12, #23588, lsl 16
+  movk x11, #36286, lsl 32
+  movk x12, #7790, lsl 32
+  movk x11, #51783, lsl 48
+  movk x12, #17170, lsl 48
+  dup.2d v7, x12
+  mov x12, #10899
+  mov.16b v8, v9
+  movk x12, #30709, lsl 16
+  fmla.2d v8, v6, v7
+  fsub.2d v11, v10, v8
+  movk x12, #61551, lsl 32
+  fmla.2d v11, v6, v7
+  movk x12, #45784, lsl 48
+  add.2d v1, v1, v8
+  add.2d v0, v0, v11
+  mov x13, #36612
+  mov x14, #16000
+  movk x13, #63402, lsl 16
+  movk x14, #53891, lsl 16
+  movk x14, #5509, lsl 32
+  movk x13, #47623, lsl 32
+  movk x14, #17144, lsl 48
+  movk x13, #9430, lsl 48
+  dup.2d v7, x14
+  mov.16b v8, v9
+  mul x14, x5, x6
+  fmla.2d v8, v6, v7
+  umulh x5, x5, x6
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  adds x7, x14, x7
+  cinc x5, x5, hs
+  add.2d v2, v2, v8
+  mul x14, x11, x6
+  add.2d v1, v1, v11
+  mov x15, #46800
+  umulh x11, x11, x6
+  movk x15, #2568, lsl 16
+  adds x5, x14, x5
+  cinc x11, x11, hs
+  movk x15, #1335, lsl 32
+  adds x5, x5, x8
+  cinc x8, x11, hs
+  movk x15, #17188, lsl 48
+  dup.2d v7, x15
+  mul x11, x12, x6
+  mov.16b v8, v9
+  umulh x12, x12, x6
+  fmla.2d v8, v6, v7
   fsub.2d v11, v10, v8
   adds x8, x11, x8
   cinc x11, x12, hs
   fmla.2d v11, v6, v7
-  mul x12, x13, x5
+  adds x8, x8, x9
+  cinc x9, x11, hs
   add.2d v5, v5, v8
   add.2d v2, v2, v11
-  umulh x13, x13, x5
-  mov x15, #3072
-  adds x11, x12, x11
-  cinc x12, x13, hs
-  movk x15, #8058, lsl 16
+  mul x11, x13, x6
+  mov x12, #39040
+  umulh x6, x13, x6
+  movk x12, #14704, lsl 16
+  movk x12, #12839, lsl 32
   adds x9, x11, x9
-  cinc x11, x12, hs
-  movk x15, #46097, lsl 32
-  movk x15, #17047, lsl 48
-  mul x12, x14, x5
-  dup.2d v7, x15
-  umulh x5, x14, x5
-  mov.16b v8, v9
-  adds x11, x12, x11
-  cinc x5, x5, hs
-  fmla.2d v8, v6, v7
-  fsub.2d v11, v10, v8
-  adds x10, x11, x10
-  cinc x5, x5, hs
-  fmla.2d v11, v6, v7
-  add x4, x4, x5
-  add.2d v3, v3, v8
-  mov x5, #61005
-  add.2d v5, v5, v11
-  mov x11, #65535
-  movk x5, #58262, lsl 16
-  movk x11, #61439, lsl 16
-  movk x5, #32851, lsl 32
-  movk x11, #62867, lsl 32
-  movk x5, #11582, lsl 48
-  movk x11, #1, lsl 48
-  umov x12, v4.d[0]
-  mov x13, #37581
-  umov x14, v4.d[1]
-  movk x13, #43836, lsl 16
-  mul x12, x12, x11
-  movk x13, #36286, lsl 32
-  mul x11, x14, x11
-  and x12, x12, x16
-  movk x13, #51783, lsl 48
-  and x11, x11, x16
-  mov x14, #10899
-  ins v6.d[0], x12
-  ins v6.d[1], x11
-  ucvtf.2d v6, v6
-  movk x14, #30709, lsl 16
-  mov x11, #16
-  movk x14, #61551, lsl 32
-  movk x11, #22847, lsl 32
-  movk x14, #45784, lsl 48
-  movk x11, #17151, lsl 48
-  dup.2d v7, x11
-  mov x11, #36612
-  mov.16b v8, v9
-  movk x11, #63402, lsl 16
-  fmla.2d v8, v6, v7
-  movk x11, #47623, lsl 32
-  fsub.2d v11, v10, v8
-  fmla.2d v11, v6, v7
-  movk x11, #9430, lsl 48
-  add.2d v0, v0, v8
-  mul x12, x5, x6
-  add.2d v4, v4, v11
-  umulh x5, x5, x6
-  mov x15, #20728
-  movk x15, #23588, lsl 16
-  adds x7, x12, x7
-  cinc x5, x5, hs
-  movk x15, #7790, lsl 32
-  mul x12, x13, x6
-  movk x15, #17170, lsl 48
-  umulh x13, x13, x6
-  dup.2d v7, x15
-  mov.16b v8, v9
-  adds x5, x12, x5
-  cinc x12, x13, hs
-  fmla.2d v8, v6, v7
-  adds x5, x5, x8
-  cinc x8, x12, hs
-  fsub.2d v11, v10, v8
-  mul x12, x14, x6
-  fmla.2d v11, v6, v7
-  add.2d v1, v1, v8
-  umulh x13, x14, x6
-  add.2d v0, v0, v11
-  adds x8, x12, x8
-  cinc x12, x13, hs
-  mov x13, #16000
-  adds x8, x8, x9
-  cinc x9, x12, hs
-  movk x13, #53891, lsl 16
-  movk x13, #5509, lsl 32
-  mul x12, x11, x6
-  movk x13, #17144, lsl 48
-  umulh x6, x11, x6
-  dup.2d v7, x13
-  mov.16b v8, v9
-  adds x9, x12, x9
   cinc x6, x6, hs
-  fmla.2d v8, v6, v7
+  movk x12, #17096, lsl 48
   adds x9, x9, x10
   cinc x6, x6, hs
-  fsub.2d v11, v10, v8
-  add x4, x4, x6
-  fmla.2d v11, v6, v7
-  add.2d v2, v2, v8
-  mov x6, #65535
-  add.2d v1, v1, v11
-  movk x6, #61439, lsl 16
-  mov x10, #46800
-  movk x6, #62867, lsl 32
-  movk x10, #2568, lsl 16
-  movk x10, #1335, lsl 32
-  movk x6, #49889, lsl 48
-  movk x10, #17188, lsl 48
-  mul x6, x6, x7
-  dup.2d v7, x10
-  mov x10, #1
-  mov.16b v8, v9
-  fmla.2d v8, v6, v7
-  movk x10, #61440, lsl 16
-  fsub.2d v11, v10, v8
-  movk x10, #62867, lsl 32
-  fmla.2d v11, v6, v7
-  movk x10, #17377, lsl 48
-  add.2d v5, v5, v8
-  add.2d v2, v2, v11
-  mov x11, #28817
-  mov x12, #39040
-  movk x11, #31161, lsl 16
-  movk x12, #14704, lsl 16
-  movk x11, #59464, lsl 32
-  movk x12, #12839, lsl 32
-  movk x12, #17096, lsl 48
-  movk x11, #10291, lsl 48
   dup.2d v7, x12
-  mov x12, #22621
   mov.16b v8, v9
-  movk x12, #33153, lsl 16
+  add x10, x4, x6
   fmla.2d v8, v6, v7
+  mov x4, #65535
   fsub.2d v9, v10, v8
-  movk x12, #17846, lsl 32
   fmla.2d v9, v6, v7
-  movk x12, #47184, lsl 48
+  movk x4, #61439, lsl 16
   add.2d v3, v3, v8
+  movk x4, #62867, lsl 32
   add.2d v5, v5, v9
-  mov x13, #41001
-  mov x14, #140737488355328
-  movk x13, #57649, lsl 16
-  dup.2d v6, x14
-  movk x13, #20082, lsl 32
+  mov x6, #140737488355328
+  movk x4, #49889, lsl 48
+  dup.2d v6, x6
+  mul x6, x4, x7
   and.16b v6, v3, v6
   cmeq.2d v6, v6, #0
-  movk x13, #12388, lsl 48
-  mov x14, #2
-  mul x15, x10, x6
-  movk x14, #57344, lsl 16
-  umulh x10, x10, x6
-  movk x14, #60199, lsl 32
-  movk x14, #3, lsl 48
-  cmn x15, x7
-  cinc x10, x10, hs
-  dup.2d v7, x14
-  mul x7, x11, x6
+  mov x4, #1
+  mov x11, #2
+  movk x4, #61440, lsl 16
+  movk x11, #57344, lsl 16
+  movk x11, #60199, lsl 32
+  movk x4, #62867, lsl 32
+  movk x11, #3, lsl 48
+  movk x4, #17377, lsl 48
+  dup.2d v7, x11
   bic.16b v7, v7, v6
-  umulh x11, x11, x6
-  mov x14, #10364
-  movk x14, #11794, lsl 16
-  adds x7, x7, x10
-  cinc x10, x11, hs
-  movk x14, #3895, lsl 32
-  adds x5, x7, x5
-  cinc x7, x10, hs
-  movk x14, #9, lsl 48
-  mul x10, x12, x6
-  dup.2d v8, x14
+  mov x11, #28817
+  mov x12, #10364
+  movk x11, #31161, lsl 16
+  movk x12, #11794, lsl 16
+  movk x12, #3895, lsl 32
+  movk x11, #59464, lsl 32
+  movk x12, #9, lsl 48
+  movk x11, #10291, lsl 48
+  dup.2d v8, x12
+  mov x12, #22621
   bic.16b v8, v8, v6
-  umulh x11, x12, x6
-  mov x12, #26576
-  adds x7, x10, x7
-  cinc x10, x11, hs
-  movk x12, #47696, lsl 16
-  adds x7, x7, x8
-  cinc x8, x10, hs
-  movk x12, #688, lsl 32
-  movk x12, #3, lsl 48
-  mul x10, x13, x6
-  dup.2d v9, x12
-  umulh x6, x13, x6
+  mov x13, #26576
+  movk x12, #33153, lsl 16
+  movk x13, #47696, lsl 16
+  movk x12, #17846, lsl 32
+  movk x13, #688, lsl 32
+  movk x13, #3, lsl 48
+  movk x12, #47184, lsl 48
+  dup.2d v9, x13
+  mov x13, #41001
   bic.16b v9, v9, v6
-  adds x8, x10, x8
-  cinc x6, x6, hs
-  mov x10, #46800
-  movk x10, #2568, lsl 16
-  adds x8, x8, x9
-  cinc x6, x6, hs
-  movk x10, #1335, lsl 32
-  add x9, x4, x6
-  movk x10, #4, lsl 48
-  dup.2d v10, x10
-  mov x4, #2
+  mov x14, #46800
+  movk x13, #57649, lsl 16
+  movk x14, #2568, lsl 16
+  movk x13, #20082, lsl 32
+  movk x14, #1335, lsl 32
+  movk x14, #4, lsl 48
+  movk x13, #12388, lsl 48
+  dup.2d v10, x14
+  mul x14, x4, x6
   bic.16b v10, v10, v6
-  movk x4, #57344, lsl 16
-  mov x6, #49763
-  movk x4, #60199, lsl 32
-  movk x6, #40165, lsl 16
-  movk x6, #24776, lsl 32
-  movk x4, #34755, lsl 48
-  dup.2d v11, x6
-  mov x6, #57634
+  mov x15, #49763
+  umulh x4, x4, x6
+  movk x15, #40165, lsl 16
+  cmn x14, x7
+  cinc x4, x4, hs
+  movk x15, #24776, lsl 32
+  dup.2d v11, x15
+  mul x7, x11, x6
   bic.16b v6, v11, v6
-  movk x6, #62322, lsl 16
+  umulh x11, x11, x6
   sub.2d v0, v0, v7
   ssra.2d v0, v4, #52
-  movk x6, #53392, lsl 32
+  adds x4, x7, x4
+  cinc x7, x11, hs
   sub.2d v4, v1, v8
-  movk x6, #20583, lsl 48
+  adds x4, x4, x5
+  cinc x5, x7, hs
   ssra.2d v4, v0, #52
-  mov x10, #45242
   sub.2d v7, v2, v9
+  mul x7, x12, x6
   ssra.2d v7, v4, #52
-  movk x10, #770, lsl 16
+  umulh x11, x12, x6
   sub.2d v5, v5, v10
-  movk x10, #35693, lsl 32
   ssra.2d v5, v7, #52
-  movk x10, #28832, lsl 48
+  adds x5, x7, x5
+  cinc x7, x11, hs
   sub.2d v6, v3, v6
+  adds x5, x5, x8
+  cinc x7, x7, hs
   ssra.2d v6, v5, #52
-  mov x11, #16467
   ushr.2d v1, v4, #12
-  movk x11, #49763, lsl 16
+  mul x8, x13, x6
   ushr.2d v2, v7, #24
-  movk x11, #40165, lsl 32
+  umulh x6, x13, x6
   ushr.2d v3, v5, #36
   sli.2d v0, v4, #52
-  movk x11, #24776, lsl 48
+  adds x7, x8, x7
+  cinc x8, x6, hs
   sli.2d v1, v7, #40
-  subs x4, x5, x4
-  sbcs x6, x7, x6
-  sbcs x10, x8, x10
-  sbcs x11, x9, x11
+  adds x6, x7, x9
+  cinc x7, x8, hs
   sli.2d v2, v5, #28
   sli.2d v3, v6, #16
-  tst x9, #9223372036854775808
-  csel x4, x4, x5, mi
-  csel x5, x6, x7, mi
-  csel x6, x10, x8, mi
-  csel x7, x11, x9, mi
+  add x7, x10, x7

--- a/block-multiplier/src/aarch64/montgomery_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_interleaved_4.s
@@ -20,1035 +20,997 @@
   mov x22, #1
   umulh x23, x1, x4
   movk x22, #18032, lsl 48
-  dup.2d v10, x22
   adds x20, x21, x20
   cinc x21, x23, hs
+  dup.2d v10, x22
   shl.2d v11, v1, #14
   mul x22, x2, x4
   shl.2d v12, v2, #26
-  shl.2d v13, v3, #38
   umulh x23, x2, x4
+  shl.2d v13, v3, #38
   ushr.2d v3, v3, #14
   adds x21, x22, x21
   cinc x22, x23, hs
   shl.2d v14, v0, #2
-  usra.2d v11, v0, #50
   mul x23, x3, x4
-  usra.2d v12, v1, #38
+  usra.2d v11, v0, #50
   umulh x4, x3, x4
+  usra.2d v12, v1, #38
   usra.2d v13, v2, #26
-  and.16b v0, v14, v8
   adds x22, x23, x22
   cinc x4, x4, hs
-  and.16b v1, v11, v8
+  and.16b v0, v14, v8
   mul x23, x0, x5
+  and.16b v1, v11, v8
+  umulh x24, x0, x5
   and.16b v2, v12, v8
   and.16b v11, v13, v8
-  umulh x24, x0, x5
-  shl.2d v12, v5, #14
   adds x20, x23, x20
   cinc x23, x24, hs
+  shl.2d v12, v5, #14
+  mul x24, x1, x5
   shl.2d v13, v6, #26
   shl.2d v14, v7, #38
-  mul x24, x1, x5
-  ushr.2d v7, v7, #14
   umulh x25, x1, x5
-  shl.2d v15, v4, #2
-  usra.2d v12, v4, #50
+  ushr.2d v7, v7, #14
   adds x23, x24, x23
   cinc x24, x25, hs
-  usra.2d v13, v5, #38
+  shl.2d v15, v4, #2
   adds x21, x23, x21
   cinc x23, x24, hs
-  usra.2d v14, v6, #26
-  and.16b v4, v15, v8
+  usra.2d v12, v4, #50
+  usra.2d v13, v5, #38
   mul x24, x2, x5
-  and.16b v5, v12, v8
+  usra.2d v14, v6, #26
   umulh x25, x2, x5
-  and.16b v6, v13, v8
-  and.16b v12, v14, v8
+  and.16b v4, v15, v8
   adds x23, x24, x23
   cinc x24, x25, hs
-  mov x25, #13605374474286268416
+  and.16b v5, v12, v8
+  and.16b v6, v13, v8
   adds x22, x23, x22
   cinc x23, x24, hs
+  and.16b v12, v14, v8
+  mul x24, x3, x5
+  mov x25, #13605374474286268416
   dup.2d v13, x25
-  mov x24, #6440147467139809280
-  mul x25, x3, x5
-  dup.2d v14, x24
   umulh x5, x3, x5
-  mov x24, #3688448094816436224
-  adds x23, x25, x23
+  mov x25, #6440147467139809280
+  adds x23, x24, x23
   cinc x5, x5, hs
-  dup.2d v15, x24
-  mov x24, #9209861237972664320
+  dup.2d v14, x25
   adds x4, x23, x4
   cinc x5, x5, hs
-  dup.2d v16, x24
+  mov x23, #3688448094816436224
+  dup.2d v15, x23
   mul x23, x0, x6
+  mov x24, #9209861237972664320
+  umulh x25, x0, x6
+  dup.2d v16, x24
+  adds x21, x23, x21
+  cinc x23, x25, hs
   mov x24, #12218265789056155648
   dup.2d v17, x24
-  umulh x24, x0, x6
+  mul x24, x1, x6
   mov x25, #17739678932212383744
-  adds x21, x23, x21
-  cinc x23, x24, hs
+  umulh x26, x1, x6
   dup.2d v18, x25
-  mov x24, #2301339409586323456
-  mul x25, x1, x6
-  dup.2d v19, x24
-  umulh x24, x1, x6
-  mov x26, #7822752552742551552
-  dup.2d v20, x26
-  adds x23, x25, x23
-  cinc x24, x24, hs
-  mov x25, #5071053180419178496
+  mov x25, #2301339409586323456
+  adds x23, x24, x23
+  cinc x24, x26, hs
+  dup.2d v19, x25
   adds x22, x23, x22
   cinc x23, x24, hs
-  dup.2d v21, x25
-  mov x24, #16352570246982270976
+  mov x24, #7822752552742551552
   mul x25, x2, x6
-  dup.2d v22, x24
-  umulh x24, x2, x6
-  ucvtf.2d v0, v0
-  ucvtf.2d v1, v1
+  dup.2d v20, x24
+  mov x24, #5071053180419178496
+  umulh x26, x2, x6
+  dup.2d v21, x24
   adds x23, x25, x23
-  cinc x24, x24, hs
-  ucvtf.2d v2, v2
+  cinc x24, x26, hs
+  mov x25, #16352570246982270976
   adds x4, x23, x4
   cinc x23, x24, hs
-  ucvtf.2d v11, v11
-  ucvtf.2d v3, v3
+  dup.2d v22, x25
+  ucvtf.2d v0, v0
   mul x24, x3, x6
-  ucvtf.2d v4, v4
+  ucvtf.2d v1, v1
   umulh x6, x3, x6
-  ucvtf.2d v5, v5
-  ucvtf.2d v6, v6
+  ucvtf.2d v2, v2
+  ucvtf.2d v11, v11
   adds x23, x24, x23
   cinc x6, x6, hs
-  ucvtf.2d v12, v12
+  ucvtf.2d v3, v3
   adds x5, x23, x5
   cinc x6, x6, hs
-  ucvtf.2d v7, v7
-  mov.16b v23, v9
+  ucvtf.2d v4, v4
   mul x23, x0, x7
-  fmla.2d v23, v0, v4
+  ucvtf.2d v5, v5
+  ucvtf.2d v6, v6
   umulh x0, x0, x7
-  fsub.2d v24, v10, v23
-  fmla.2d v24, v0, v4
+  ucvtf.2d v12, v12
   adds x22, x23, x22
   cinc x0, x0, hs
-  add.2d v15, v15, v23
-  mul x23, x1, x7
-  add.2d v13, v13, v24
+  ucvtf.2d v7, v7
   mov.16b v23, v9
+  mul x23, x1, x7
+  fmla.2d v23, v0, v4
   umulh x1, x1, x7
-  fmla.2d v23, v0, v5
+  fsub.2d v24, v10, v23
   adds x0, x23, x0
   cinc x1, x1, hs
-  fsub.2d v24, v10, v23
+  fmla.2d v24, v0, v4
+  add.2d v15, v15, v23
   adds x0, x0, x4
   cinc x1, x1, hs
-  fmla.2d v24, v0, v5
-  add.2d v17, v17, v23
+  add.2d v13, v13, v24
   mul x4, x2, x7
-  add.2d v15, v15, v24
-  umulh x2, x2, x7
   mov.16b v23, v9
-  fmla.2d v23, v0, v6
+  umulh x2, x2, x7
+  fmla.2d v23, v0, v5
+  fsub.2d v24, v10, v23
   adds x1, x4, x1
   cinc x2, x2, hs
-  fsub.2d v24, v10, v23
+  fmla.2d v24, v0, v5
   adds x1, x1, x5
   cinc x2, x2, hs
-  fmla.2d v24, v0, v6
-  add.2d v19, v19, v23
+  add.2d v17, v17, v23
+  add.2d v15, v15, v24
   mul x4, x3, x7
-  add.2d v17, v17, v24
-  umulh x3, x3, x7
   mov.16b v23, v9
-  fmla.2d v23, v0, v12
+  umulh x3, x3, x7
+  fmla.2d v23, v0, v6
   adds x2, x4, x2
   cinc x3, x3, hs
   fsub.2d v24, v10, v23
+  fmla.2d v24, v0, v6
   adds x2, x2, x6
   cinc x3, x3, hs
-  fmla.2d v24, v0, v12
-  add.2d v21, v21, v23
+  add.2d v19, v19, v23
   mov x4, #48718
-  add.2d v19, v19, v24
+  add.2d v17, v17, v24
   movk x4, #4732, lsl 16
   mov.16b v23, v9
-  fmla.2d v23, v0, v7
+  fmla.2d v23, v0, v12
   movk x4, #45078, lsl 32
   fsub.2d v24, v10, v23
   movk x4, #39852, lsl 48
-  fmla.2d v24, v0, v7
-  add.2d v0, v22, v23
+  fmla.2d v24, v0, v12
+  add.2d v21, v21, v23
   mov x5, #16676
-  add.2d v21, v21, v24
+  add.2d v19, v19, v24
   movk x5, #12692, lsl 16
-  mov.16b v22, v9
-  fmla.2d v22, v1, v4
+  mov.16b v23, v9
   movk x5, #20986, lsl 32
-  fsub.2d v23, v10, v22
+  fmla.2d v23, v0, v7
+  fsub.2d v24, v10, v23
   movk x5, #2848, lsl 48
-  fmla.2d v23, v1, v4
-  add.2d v17, v17, v22
+  fmla.2d v24, v0, v7
   mov x6, #51052
-  add.2d v15, v15, v23
+  add.2d v0, v22, v23
   movk x6, #24721, lsl 16
+  add.2d v21, v21, v24
+  mov.16b v22, v9
+  movk x6, #61092, lsl 32
+  fmla.2d v22, v1, v4
+  movk x6, #45156, lsl 48
+  fsub.2d v23, v10, v22
+  fmla.2d v23, v1, v4
+  mov x7, #3197
+  add.2d v17, v17, v22
+  movk x7, #18936, lsl 16
+  add.2d v15, v15, v23
+  movk x7, #10922, lsl 32
   mov.16b v22, v9
   fmla.2d v22, v1, v5
-  movk x6, #61092, lsl 32
-  fsub.2d v23, v10, v22
-  movk x6, #45156, lsl 48
-  fmla.2d v23, v1, v5
-  add.2d v19, v19, v22
-  mov x7, #3197
-  add.2d v17, v17, v23
-  movk x7, #18936, lsl 16
-  mov.16b v22, v9
-  movk x7, #10922, lsl 32
-  fmla.2d v22, v1, v6
-  fsub.2d v23, v10, v22
   movk x7, #11014, lsl 48
-  fmla.2d v23, v1, v6
+  fsub.2d v23, v10, v22
   mul x23, x4, x17
-  add.2d v21, v21, v22
-  add.2d v19, v19, v23
+  fmla.2d v23, v1, v5
   umulh x4, x4, x17
-  mov.16b v22, v9
+  add.2d v19, v19, v22
+  add.2d v17, v17, v23
   adds x22, x23, x22
   cinc x4, x4, hs
-  fmla.2d v22, v1, v12
-  fsub.2d v23, v10, v22
+  mov.16b v22, v9
   mul x23, x5, x17
-  fmla.2d v23, v1, v12
+  fmla.2d v22, v1, v6
+  fsub.2d v23, v10, v22
   umulh x5, x5, x17
-  add.2d v0, v0, v22
-  add.2d v21, v21, v23
+  fmla.2d v23, v1, v6
   adds x4, x23, x4
   cinc x5, x5, hs
-  mov.16b v22, v9
+  add.2d v21, v21, v22
   adds x0, x4, x0
   cinc x4, x5, hs
-  fmla.2d v22, v1, v7
-  fsub.2d v23, v10, v22
+  add.2d v19, v19, v23
+  mov.16b v22, v9
   mul x5, x6, x17
-  fmla.2d v23, v1, v7
+  fmla.2d v22, v1, v12
   umulh x6, x6, x17
+  fsub.2d v23, v10, v22
+  fmla.2d v23, v1, v12
+  adds x4, x5, x4
+  cinc x5, x6, hs
+  add.2d v0, v0, v22
+  adds x1, x4, x1
+  cinc x4, x5, hs
+  add.2d v21, v21, v23
+  mul x5, x7, x17
+  mov.16b v22, v9
+  fmla.2d v22, v1, v7
+  umulh x6, x7, x17
+  fsub.2d v23, v10, v22
+  adds x4, x5, x4
+  cinc x5, x6, hs
+  fmla.2d v23, v1, v7
+  adds x2, x4, x2
+  cinc x4, x5, hs
   add.2d v1, v20, v22
   add.2d v0, v0, v23
-  adds x4, x5, x4
-  cinc x5, x6, hs
+  add x3, x3, x4
   mov.16b v20, v9
-  adds x1, x4, x1
-  cinc x4, x5, hs
+  mov x4, #56431
   fmla.2d v20, v2, v4
   fsub.2d v22, v10, v20
-  mul x5, x7, x17
-  fmla.2d v22, v2, v4
-  umulh x6, x7, x17
-  add.2d v19, v19, v20
-  add.2d v17, v17, v22
-  adds x4, x5, x4
-  cinc x5, x6, hs
-  mov.16b v20, v9
-  adds x2, x4, x2
-  cinc x4, x5, hs
-  fmla.2d v20, v2, v5
-  fsub.2d v22, v10, v20
-  add x3, x3, x4
-  fmla.2d v22, v2, v5
-  mov x4, #56431
-  add.2d v20, v21, v20
-  add.2d v19, v19, v22
   movk x4, #30457, lsl 16
-  mov.16b v21, v9
+  fmla.2d v22, v2, v4
   movk x4, #30012, lsl 32
-  fmla.2d v21, v2, v6
-  fsub.2d v22, v10, v21
+  add.2d v19, v19, v20
   movk x4, #6382, lsl 48
-  fmla.2d v22, v2, v6
+  add.2d v17, v17, v22
+  mov.16b v20, v9
   mov x5, #59151
+  fmla.2d v20, v2, v5
+  movk x5, #41769, lsl 16
+  fsub.2d v22, v10, v20
+  movk x5, #32276, lsl 32
+  fmla.2d v22, v2, v5
+  add.2d v20, v21, v20
+  movk x5, #21677, lsl 48
+  add.2d v19, v19, v22
+  mov x6, #34015
+  mov.16b v21, v9
+  fmla.2d v21, v2, v6
+  movk x6, #20342, lsl 16
+  fsub.2d v22, v10, v21
+  movk x6, #13935, lsl 32
+  fmla.2d v22, v2, v6
+  movk x6, #11030, lsl 48
   add.2d v0, v0, v21
   add.2d v20, v20, v22
-  movk x5, #41769, lsl 16
+  mov x7, #13689
   mov.16b v21, v9
-  movk x5, #32276, lsl 32
+  movk x7, #8159, lsl 16
   fmla.2d v21, v2, v12
-  movk x5, #21677, lsl 48
+  movk x7, #215, lsl 32
   fsub.2d v22, v10, v21
   fmla.2d v22, v2, v12
-  mov x6, #34015
+  movk x7, #4913, lsl 48
   add.2d v1, v1, v21
-  movk x6, #20342, lsl 16
+  mul x17, x4, x20
   add.2d v0, v0, v22
   mov.16b v21, v9
-  movk x6, #13935, lsl 32
-  fmla.2d v21, v2, v7
-  movk x6, #11030, lsl 48
-  fsub.2d v22, v10, v21
-  fmla.2d v22, v2, v7
-  mov x7, #13689
-  add.2d v2, v18, v21
-  movk x7, #8159, lsl 16
-  add.2d v1, v1, v22
-  mov.16b v18, v9
-  movk x7, #215, lsl 32
-  fmla.2d v18, v11, v4
-  movk x7, #4913, lsl 48
-  fsub.2d v21, v10, v18
-  fmla.2d v21, v11, v4
-  mul x17, x4, x20
-  add.2d v18, v20, v18
   umulh x4, x4, x20
-  add.2d v19, v19, v21
-  mov.16b v20, v9
+  fmla.2d v21, v2, v7
   adds x17, x17, x22
   cinc x4, x4, hs
-  fmla.2d v20, v11, v5
+  fsub.2d v22, v10, v21
   mul x22, x5, x20
-  fsub.2d v21, v10, v20
-  fmla.2d v21, v11, v5
+  fmla.2d v22, v2, v7
+  add.2d v2, v18, v21
   umulh x5, x5, x20
-  add.2d v0, v0, v20
+  add.2d v1, v1, v22
   adds x4, x22, x4
   cinc x5, x5, hs
-  add.2d v18, v18, v21
-  mov.16b v20, v9
+  mov.16b v18, v9
   adds x0, x4, x0
   cinc x4, x5, hs
-  fmla.2d v20, v11, v6
+  fmla.2d v18, v11, v4
+  fsub.2d v21, v10, v18
   mul x5, x6, x20
-  fsub.2d v21, v10, v20
-  fmla.2d v21, v11, v6
+  fmla.2d v21, v11, v4
   umulh x6, x6, x20
-  add.2d v1, v1, v20
+  add.2d v18, v20, v18
+  add.2d v19, v19, v21
   adds x4, x5, x4
   cinc x5, x6, hs
-  add.2d v0, v0, v21
   mov.16b v20, v9
   adds x1, x4, x1
   cinc x4, x5, hs
-  fmla.2d v20, v11, v12
+  fmla.2d v20, v11, v5
   mul x5, x7, x20
   fsub.2d v21, v10, v20
-  fmla.2d v21, v11, v12
+  fmla.2d v21, v11, v5
   umulh x6, x7, x20
-  add.2d v2, v2, v20
+  add.2d v0, v0, v20
   adds x4, x5, x4
   cinc x5, x6, hs
-  add.2d v1, v1, v21
+  add.2d v18, v18, v21
+  mov.16b v20, v9
   adds x2, x4, x2
   cinc x4, x5, hs
-  mov.16b v20, v9
-  fmla.2d v20, v11, v7
+  fmla.2d v20, v11, v6
   add x3, x3, x4
   fsub.2d v21, v10, v20
   mov x4, #61005
-  fmla.2d v21, v11, v7
-  add.2d v11, v16, v20
+  fmla.2d v21, v11, v6
+  add.2d v1, v1, v20
   movk x4, #58262, lsl 16
-  add.2d v2, v2, v21
+  add.2d v0, v0, v21
   movk x4, #32851, lsl 32
+  mov.16b v20, v9
+  movk x4, #11582, lsl 48
+  fmla.2d v20, v11, v12
+  fsub.2d v21, v10, v20
+  mov x5, #37581
+  fmla.2d v21, v11, v12
+  movk x5, #43836, lsl 16
+  add.2d v2, v2, v20
+  add.2d v1, v1, v21
+  movk x5, #36286, lsl 32
+  mov.16b v20, v9
+  movk x5, #51783, lsl 48
+  fmla.2d v20, v11, v7
+  mov x6, #10899
+  fsub.2d v21, v10, v20
+  fmla.2d v21, v11, v7
+  movk x6, #30709, lsl 16
+  add.2d v11, v16, v20
+  movk x6, #61551, lsl 32
+  add.2d v2, v2, v21
+  movk x6, #45784, lsl 48
   mov.16b v16, v9
   fmla.2d v16, v3, v4
-  movk x4, #11582, lsl 48
+  mov x7, #36612
   fsub.2d v20, v10, v16
-  mov x5, #37581
+  movk x7, #63402, lsl 16
   fmla.2d v20, v3, v4
   add.2d v0, v0, v16
-  movk x5, #43836, lsl 16
-  add.2d v4, v18, v20
-  movk x5, #36286, lsl 32
-  mov.16b v16, v9
-  fmla.2d v16, v3, v5
-  movk x5, #51783, lsl 48
-  fsub.2d v18, v10, v16
-  mov x6, #10899
-  fmla.2d v18, v3, v5
-  add.2d v1, v1, v16
-  movk x6, #30709, lsl 16
-  add.2d v0, v0, v18
-  movk x6, #61551, lsl 32
-  mov.16b v5, v9
-  fmla.2d v5, v3, v6
-  movk x6, #45784, lsl 48
-  fsub.2d v16, v10, v5
-  mov x7, #36612
-  fmla.2d v16, v3, v6
-  add.2d v2, v2, v5
-  movk x7, #63402, lsl 16
-  add.2d v1, v1, v16
   movk x7, #47623, lsl 32
-  mov.16b v5, v9
-  fmla.2d v5, v3, v12
+  add.2d v4, v18, v20
   movk x7, #9430, lsl 48
-  fsub.2d v6, v10, v5
+  mov.16b v16, v9
   mul x20, x4, x21
-  fmla.2d v6, v3, v12
-  add.2d v5, v11, v5
+  fmla.2d v16, v3, v5
+  fsub.2d v18, v10, v16
   umulh x4, x4, x21
-  add.2d v2, v2, v6
+  fmla.2d v18, v3, v5
   adds x17, x20, x17
   cinc x4, x4, hs
-  mov.16b v6, v9
-  fmla.2d v6, v3, v7
+  add.2d v1, v1, v16
   mul x20, x5, x21
-  fsub.2d v11, v10, v6
+  add.2d v0, v0, v18
+  mov.16b v5, v9
   umulh x5, x5, x21
-  fmla.2d v11, v3, v7
+  fmla.2d v5, v3, v6
   adds x4, x20, x4
   cinc x5, x5, hs
-  add.2d v3, v14, v6
-  add.2d v5, v5, v11
+  fsub.2d v16, v10, v5
+  fmla.2d v16, v3, v6
   adds x0, x4, x0
   cinc x4, x5, hs
-  usra.2d v15, v13, #52
+  add.2d v2, v2, v5
   mul x5, x6, x21
-  usra.2d v17, v15, #52
-  usra.2d v19, v17, #52
+  add.2d v1, v1, v16
   umulh x6, x6, x21
-  usra.2d v4, v19, #52
+  mov.16b v5, v9
+  fmla.2d v5, v3, v12
   adds x4, x5, x4
   cinc x5, x6, hs
-  and.16b v6, v13, v8
-  and.16b v7, v15, v8
+  fsub.2d v6, v10, v5
   adds x1, x4, x1
   cinc x4, x5, hs
-  and.16b v11, v17, v8
+  fmla.2d v6, v3, v12
   mul x5, x7, x21
-  and.16b v8, v19, v8
-  ucvtf.2d v6, v6
+  add.2d v5, v11, v5
+  add.2d v2, v2, v6
   umulh x6, x7, x21
-  mov x7, #37864
+  mov.16b v6, v9
   adds x4, x5, x4
   cinc x5, x6, hs
-  movk x7, #1815, lsl 16
-  movk x7, #28960, lsl 32
+  fmla.2d v6, v3, v7
+  fsub.2d v11, v10, v6
   adds x2, x4, x2
   cinc x4, x5, hs
-  movk x7, #17153, lsl 48
+  fmla.2d v11, v3, v7
   add x3, x3, x4
-  dup.2d v12, x7
-  mov.16b v13, v9
+  add.2d v3, v14, v6
   mov x4, #65535
-  fmla.2d v13, v6, v12
+  add.2d v5, v5, v11
+  usra.2d v15, v13, #52
   movk x4, #61439, lsl 16
-  fsub.2d v14, v10, v13
-  fmla.2d v14, v6, v12
+  usra.2d v17, v15, #52
   movk x4, #62867, lsl 32
-  add.2d v0, v0, v13
+  usra.2d v19, v17, #52
+  usra.2d v4, v19, #52
   movk x4, #49889, lsl 48
-  add.2d v4, v4, v14
-  mov x5, #46128
+  and.16b v6, v13, v8
   mul x4, x4, x17
-  movk x5, #29964, lsl 16
-  mov x6, #1
-  movk x5, #7587, lsl 32
-  movk x5, #17161, lsl 48
-  movk x6, #61440, lsl 16
-  dup.2d v12, x5
-  movk x6, #62867, lsl 32
+  and.16b v7, v15, v8
+  mov x5, #1
+  and.16b v11, v17, v8
+  and.16b v8, v19, v8
+  movk x5, #61440, lsl 16
+  ucvtf.2d v6, v6
+  movk x5, #62867, lsl 32
+  mov x6, #37864
+  movk x5, #17377, lsl 48
+  movk x6, #1815, lsl 16
+  movk x6, #28960, lsl 32
+  mov x7, #28817
+  movk x6, #17153, lsl 48
+  movk x7, #31161, lsl 16
+  dup.2d v12, x6
   mov.16b v13, v9
+  movk x7, #59464, lsl 32
   fmla.2d v13, v6, v12
-  movk x6, #17377, lsl 48
+  movk x7, #10291, lsl 48
   fsub.2d v14, v10, v13
-  mov x5, #28817
+  mov x6, #22621
+  fmla.2d v14, v6, v12
+  add.2d v0, v0, v13
+  movk x6, #33153, lsl 16
+  add.2d v4, v4, v14
+  movk x6, #17846, lsl 32
+  mov x20, #46128
+  movk x6, #47184, lsl 48
+  movk x20, #29964, lsl 16
+  movk x20, #7587, lsl 32
+  mov x21, #41001
+  movk x20, #17161, lsl 48
+  movk x21, #57649, lsl 16
+  dup.2d v12, x20
+  mov.16b v13, v9
+  movk x21, #20082, lsl 32
+  fmla.2d v13, v6, v12
+  movk x21, #12388, lsl 48
+  fsub.2d v14, v10, v13
+  mul x20, x5, x4
   fmla.2d v14, v6, v12
   add.2d v1, v1, v13
-  movk x5, #31161, lsl 16
-  add.2d v0, v0, v14
-  movk x5, #59464, lsl 32
-  mov x7, #52826
-  movk x7, #57790, lsl 16
-  movk x5, #10291, lsl 48
-  movk x7, #55431, lsl 32
-  mov x20, #22621
-  movk x7, #17196, lsl 48
-  movk x20, #33153, lsl 16
-  dup.2d v12, x7
-  mov.16b v13, v9
-  movk x20, #17846, lsl 32
-  fmla.2d v13, v6, v12
-  movk x20, #47184, lsl 48
-  fsub.2d v14, v10, v13
-  fmla.2d v14, v6, v12
-  mov x7, #41001
-  add.2d v2, v2, v13
-  movk x7, #57649, lsl 16
-  add.2d v1, v1, v14
-  mov x21, #31276
-  movk x7, #20082, lsl 32
-  movk x21, #21262, lsl 16
-  movk x7, #12388, lsl 48
-  movk x21, #2304, lsl 32
-  movk x21, #17182, lsl 48
-  mul x22, x6, x4
-  dup.2d v12, x21
-  umulh x6, x6, x4
-  mov.16b v13, v9
-  fmla.2d v13, v6, v12
-  cmn x22, x17
-  cinc x6, x6, hs
-  fsub.2d v14, v10, v13
-  mul x17, x5, x4
-  fmla.2d v14, v6, v12
-  add.2d v5, v5, v13
   umulh x5, x5, x4
-  add.2d v2, v2, v14
-  adds x6, x17, x6
+  add.2d v0, v0, v14
+  cmn x20, x17
   cinc x5, x5, hs
-  mov x17, #28672
-  movk x17, #24515, lsl 16
-  adds x0, x6, x0
-  cinc x5, x5, hs
-  movk x17, #54929, lsl 32
-  mul x6, x20, x4
-  movk x17, #17064, lsl 48
+  mov x17, #52826
+  mul x20, x7, x4
+  movk x17, #57790, lsl 16
+  movk x17, #55431, lsl 32
+  umulh x7, x7, x4
+  movk x17, #17196, lsl 48
+  adds x5, x20, x5
+  cinc x7, x7, hs
   dup.2d v12, x17
-  umulh x17, x20, x4
   mov.16b v13, v9
-  adds x5, x6, x5
-  cinc x6, x17, hs
+  adds x0, x5, x0
+  cinc x5, x7, hs
   fmla.2d v13, v6, v12
+  mul x7, x6, x4
   fsub.2d v14, v10, v13
+  umulh x6, x6, x4
+  fmla.2d v14, v6, v12
+  add.2d v2, v2, v13
+  adds x5, x7, x5
+  cinc x6, x6, hs
+  add.2d v1, v1, v14
   adds x1, x5, x1
   cinc x5, x6, hs
-  fmla.2d v14, v6, v12
-  mul x6, x7, x4
-  add.2d v3, v3, v13
-  add.2d v5, v5, v14
-  umulh x4, x7, x4
-  ucvtf.2d v6, v7
-  adds x5, x6, x5
+  mov x6, #31276
+  mul x7, x21, x4
+  movk x6, #21262, lsl 16
+  movk x6, #2304, lsl 32
+  umulh x4, x21, x4
+  movk x6, #17182, lsl 48
+  adds x5, x7, x5
   cinc x4, x4, hs
-  mov x6, #44768
-  movk x6, #51919, lsl 16
+  dup.2d v12, x6
+  mov.16b v13, v9
   adds x2, x5, x2
   cinc x4, x4, hs
-  movk x6, #6346, lsl 32
+  fmla.2d v13, v6, v12
   add x3, x3, x4
-  movk x6, #17133, lsl 48
+  fsub.2d v14, v10, v13
   mul x4, x8, x12
-  dup.2d v7, x6
-  mov.16b v12, v9
+  fmla.2d v14, v6, v12
+  add.2d v5, v5, v13
   umulh x5, x8, x12
-  fmla.2d v12, v6, v7
+  add.2d v2, v2, v14
   mul x6, x9, x12
-  fsub.2d v13, v10, v12
-  fmla.2d v13, v6, v7
-  umulh x7, x9, x12
-  add.2d v0, v0, v12
+  mov x7, #28672
+  movk x7, #24515, lsl 16
+  umulh x17, x9, x12
+  movk x7, #54929, lsl 32
   adds x5, x6, x5
-  cinc x6, x7, hs
-  add.2d v4, v4, v13
-  mov x7, #47492
+  cinc x6, x17, hs
+  movk x7, #17064, lsl 48
   mul x17, x10, x12
-  movk x7, #23630, lsl 16
-  umulh x20, x10, x12
-  movk x7, #49985, lsl 32
-  movk x7, #17168, lsl 48
+  dup.2d v12, x7
+  mov.16b v13, v9
+  umulh x7, x10, x12
+  fmla.2d v13, v6, v12
   adds x6, x17, x6
-  cinc x17, x20, hs
-  dup.2d v7, x7
-  mul x7, x11, x12
-  mov.16b v12, v9
-  fmla.2d v12, v6, v7
+  cinc x7, x7, hs
+  fsub.2d v14, v10, v13
+  mul x17, x11, x12
+  fmla.2d v14, v6, v12
+  add.2d v3, v3, v13
   umulh x12, x11, x12
-  fsub.2d v13, v10, v12
-  adds x7, x7, x17
+  add.2d v5, v5, v14
+  adds x7, x17, x7
   cinc x12, x12, hs
-  fmla.2d v13, v6, v7
-  add.2d v1, v1, v12
-  mul x17, x8, x13
-  add.2d v0, v0, v13
-  umulh x20, x8, x13
-  mov x21, #57936
-  movk x21, #54828, lsl 16
-  adds x5, x17, x5
-  cinc x17, x20, hs
-  movk x21, #18292, lsl 32
-  mul x20, x9, x13
-  movk x21, #17197, lsl 48
-  dup.2d v7, x21
-  umulh x21, x9, x13
-  mov.16b v12, v9
-  adds x17, x20, x17
+  ucvtf.2d v6, v7
+  mov x17, #44768
+  mul x20, x8, x13
+  movk x17, #51919, lsl 16
+  umulh x21, x8, x13
+  movk x17, #6346, lsl 32
+  adds x5, x20, x5
   cinc x20, x21, hs
+  movk x17, #17133, lsl 48
+  dup.2d v7, x17
+  mul x17, x9, x13
+  mov.16b v12, v9
+  umulh x21, x9, x13
   fmla.2d v12, v6, v7
+  adds x17, x17, x20
+  cinc x20, x21, hs
   fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
   adds x6, x17, x6
   cinc x17, x20, hs
-  fmla.2d v13, v6, v7
+  add.2d v0, v0, v12
   mul x20, x10, x13
+  add.2d v4, v4, v13
+  mov x21, #47492
+  umulh x22, x10, x13
+  movk x21, #23630, lsl 16
+  adds x17, x20, x17
+  cinc x20, x22, hs
+  movk x21, #49985, lsl 32
+  adds x7, x17, x7
+  cinc x17, x20, hs
+  movk x21, #17168, lsl 48
+  dup.2d v7, x21
+  mul x20, x11, x13
+  mov.16b v12, v9
+  umulh x13, x11, x13
+  fmla.2d v12, v6, v7
+  adds x17, x20, x17
+  cinc x13, x13, hs
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
+  adds x12, x17, x12
+  cinc x13, x13, hs
+  add.2d v1, v1, v12
+  mul x17, x8, x14
+  add.2d v0, v0, v13
+  mov x20, #57936
+  umulh x21, x8, x14
+  movk x20, #54828, lsl 16
+  adds x6, x17, x6
+  cinc x17, x21, hs
+  movk x20, #18292, lsl 32
+  mul x21, x9, x14
+  movk x20, #17197, lsl 48
+  dup.2d v7, x20
+  umulh x20, x9, x14
+  mov.16b v12, v9
+  adds x17, x21, x17
+  cinc x20, x20, hs
+  fmla.2d v12, v6, v7
+  adds x7, x17, x7
+  cinc x17, x20, hs
+  fsub.2d v13, v10, v12
+  fmla.2d v13, v6, v7
+  mul x20, x10, x14
   add.2d v2, v2, v12
+  umulh x21, x10, x14
   add.2d v1, v1, v13
-  umulh x21, x10, x13
   mov x22, #17708
   adds x17, x20, x17
   cinc x20, x21, hs
   movk x22, #43915, lsl 16
+  adds x12, x17, x12
+  cinc x17, x20, hs
   movk x22, #64348, lsl 32
-  adds x7, x17, x7
-  cinc x17, x20, hs
-  movk x22, #17188, lsl 48
-  mul x20, x11, x13
-  dup.2d v7, x22
-  umulh x13, x11, x13
-  mov.16b v12, v9
-  fmla.2d v12, v6, v7
-  adds x17, x20, x17
-  cinc x13, x13, hs
-  fsub.2d v13, v10, v12
-  adds x12, x17, x12
-  cinc x13, x13, hs
-  fmla.2d v13, v6, v7
-  add.2d v5, v5, v12
-  mul x17, x8, x14
-  add.2d v2, v2, v13
-  umulh x20, x8, x14
-  mov x21, #29184
-  movk x21, #20789, lsl 16
-  adds x6, x17, x6
-  cinc x17, x20, hs
-  movk x21, #19197, lsl 32
-  mul x20, x9, x14
-  movk x21, #17083, lsl 48
-  dup.2d v7, x21
-  umulh x21, x9, x14
-  mov.16b v12, v9
-  adds x17, x20, x17
-  cinc x20, x21, hs
-  fmla.2d v12, v6, v7
-  fsub.2d v13, v10, v12
-  adds x7, x17, x7
-  cinc x17, x20, hs
-  fmla.2d v13, v6, v7
-  mul x20, x10, x14
-  add.2d v3, v3, v12
-  add.2d v5, v5, v13
-  umulh x21, x10, x14
-  ucvtf.2d v6, v11
-  adds x17, x20, x17
-  cinc x20, x21, hs
-  mov x21, #58856
-  movk x21, #14953, lsl 16
-  adds x12, x17, x12
-  cinc x17, x20, hs
-  movk x21, #15155, lsl 32
   mul x20, x11, x14
-  movk x21, #17181, lsl 48
-  dup.2d v7, x21
+  movk x22, #17188, lsl 48
+  dup.2d v7, x22
   umulh x14, x11, x14
-  mov.16b v11, v9
+  mov.16b v12, v9
   adds x17, x20, x17
   cinc x14, x14, hs
-  fmla.2d v11, v6, v7
-  fsub.2d v12, v10, v11
+  fmla.2d v12, v6, v7
+  fsub.2d v13, v10, v12
   adds x13, x17, x13
   cinc x14, x14, hs
-  fmla.2d v12, v6, v7
+  fmla.2d v13, v6, v7
   mul x17, x8, x15
-  add.2d v0, v0, v11
-  add.2d v4, v4, v12
+  add.2d v5, v5, v12
   umulh x8, x8, x15
-  mov x20, #35392
+  add.2d v2, v2, v13
+  mov x20, #29184
   adds x7, x17, x7
   cinc x8, x8, hs
-  movk x20, #12477, lsl 16
-  movk x20, #56780, lsl 32
+  movk x20, #20789, lsl 16
   mul x17, x9, x15
-  movk x20, #17142, lsl 48
+  movk x20, #19197, lsl 32
   umulh x9, x9, x15
+  movk x20, #17083, lsl 48
   dup.2d v7, x20
-  mov.16b v11, v9
   adds x8, x17, x8
   cinc x9, x9, hs
-  fmla.2d v11, v6, v7
+  mov.16b v12, v9
   adds x8, x8, x12
   cinc x9, x9, hs
-  fsub.2d v12, v10, v11
-  mul x12, x10, x15
   fmla.2d v12, v6, v7
-  add.2d v1, v1, v11
+  fsub.2d v13, v10, v12
+  mul x12, x10, x15
+  fmla.2d v13, v6, v7
   umulh x10, x10, x15
-  add.2d v0, v0, v12
+  add.2d v3, v3, v12
   adds x9, x12, x9
   cinc x10, x10, hs
-  mov x12, #9848
-  movk x12, #54501, lsl 16
+  add.2d v5, v5, v13
+  ucvtf.2d v6, v11
   adds x9, x9, x13
   cinc x10, x10, hs
-  movk x12, #31540, lsl 32
+  mov x12, #58856
   mul x13, x11, x15
-  movk x12, #17170, lsl 48
-  dup.2d v7, x12
+  movk x12, #14953, lsl 16
   umulh x11, x11, x15
-  mov.16b v11, v9
+  movk x12, #15155, lsl 32
+  movk x12, #17181, lsl 48
   adds x10, x13, x10
   cinc x11, x11, hs
-  fmla.2d v11, v6, v7
-  fsub.2d v12, v10, v11
+  dup.2d v7, x12
   adds x10, x10, x14
   cinc x11, x11, hs
-  fmla.2d v12, v6, v7
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
   mov x12, #48718
+  fsub.2d v12, v10, v11
+  movk x12, #4732, lsl 16
+  fmla.2d v12, v6, v7
+  movk x12, #45078, lsl 32
+  add.2d v0, v0, v11
+  add.2d v4, v4, v12
+  movk x12, #39852, lsl 48
+  mov x13, #35392
+  mov x14, #16676
+  movk x13, #12477, lsl 16
+  movk x14, #12692, lsl 16
+  movk x13, #56780, lsl 32
+  movk x13, #17142, lsl 48
+  movk x14, #20986, lsl 32
+  dup.2d v7, x13
+  movk x14, #2848, lsl 48
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
+  mov x13, #51052
+  fsub.2d v12, v10, v11
+  movk x13, #24721, lsl 16
+  fmla.2d v12, v6, v7
+  movk x13, #61092, lsl 32
+  add.2d v1, v1, v11
+  add.2d v0, v0, v12
+  movk x13, #45156, lsl 48
+  mov x15, #9848
+  mov x17, #3197
+  movk x15, #54501, lsl 16
+  movk x17, #18936, lsl 16
+  movk x15, #31540, lsl 32
+  movk x15, #17170, lsl 48
+  movk x17, #10922, lsl 32
+  dup.2d v7, x15
+  movk x17, #11014, lsl 48
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
+  mul x15, x12, x4
+  fsub.2d v12, v10, v11
+  umulh x12, x12, x4
+  fmla.2d v12, v6, v7
+  adds x7, x15, x7
+  cinc x12, x12, hs
   add.2d v2, v2, v11
   add.2d v1, v1, v12
-  movk x12, #4732, lsl 16
-  mov x13, #9584
-  movk x12, #45078, lsl 32
-  movk x13, #63883, lsl 16
-  movk x13, #18253, lsl 32
-  movk x12, #39852, lsl 48
-  movk x13, #17190, lsl 48
-  mov x14, #16676
-  dup.2d v7, x13
-  mov.16b v11, v9
-  movk x14, #12692, lsl 16
-  fmla.2d v11, v6, v7
-  movk x14, #20986, lsl 32
-  fsub.2d v12, v10, v11
-  fmla.2d v12, v6, v7
-  movk x14, #2848, lsl 48
-  add.2d v5, v5, v11
-  mov x13, #51052
-  add.2d v2, v2, v12
-  mov x15, #51712
-  movk x13, #24721, lsl 16
-  movk x15, #16093, lsl 16
-  movk x13, #61092, lsl 32
-  movk x15, #30633, lsl 32
-  movk x15, #17068, lsl 48
-  movk x13, #45156, lsl 48
-  dup.2d v7, x15
-  mov x15, #3197
-  mov.16b v11, v9
-  fmla.2d v11, v6, v7
-  movk x15, #18936, lsl 16
-  fsub.2d v12, v10, v11
-  movk x15, #10922, lsl 32
-  fmla.2d v12, v6, v7
-  movk x15, #11014, lsl 48
-  add.2d v3, v3, v11
-  add.2d v5, v5, v12
-  mul x17, x12, x4
-  ucvtf.2d v6, v8
-  umulh x12, x12, x4
-  mov x20, #34724
-  movk x20, #40393, lsl 16
-  adds x7, x17, x7
-  cinc x12, x12, hs
-  movk x20, #23752, lsl 32
-  mul x17, x14, x4
-  movk x20, #17184, lsl 48
-  dup.2d v7, x20
+  mul x15, x14, x4
+  mov x20, #9584
   umulh x14, x14, x4
-  mov.16b v8, v9
-  adds x12, x17, x12
+  movk x20, #63883, lsl 16
+  movk x20, #18253, lsl 32
+  adds x12, x15, x12
   cinc x14, x14, hs
-  fmla.2d v8, v6, v7
-  fsub.2d v11, v10, v8
+  movk x20, #17190, lsl 48
   adds x8, x12, x8
   cinc x12, x14, hs
-  fmla.2d v11, v6, v7
+  dup.2d v7, x20
   mul x14, x13, x4
-  add.2d v0, v0, v8
-  add.2d v4, v4, v11
+  mov.16b v11, v9
+  fmla.2d v11, v6, v7
   umulh x13, x13, x4
-  mov x17, #25532
+  fsub.2d v12, v10, v11
   adds x12, x14, x12
   cinc x13, x13, hs
-  movk x17, #31025, lsl 16
-  movk x17, #10002, lsl 32
+  fmla.2d v12, v6, v7
   adds x9, x12, x9
   cinc x12, x13, hs
-  movk x17, #17199, lsl 48
-  mul x13, x15, x4
-  dup.2d v7, x17
-  mov.16b v8, v9
-  umulh x4, x15, x4
-  fmla.2d v8, v6, v7
+  add.2d v5, v5, v11
+  add.2d v2, v2, v12
+  mul x13, x17, x4
+  mov x14, #51712
+  umulh x4, x17, x4
+  movk x14, #16093, lsl 16
+  movk x14, #30633, lsl 32
   adds x12, x13, x12
   cinc x4, x4, hs
-  fsub.2d v11, v10, v8
-  fmla.2d v11, v6, v7
+  movk x14, #17068, lsl 48
   adds x10, x12, x10
   cinc x4, x4, hs
-  add.2d v1, v1, v8
+  dup.2d v7, x14
   add x4, x11, x4
-  add.2d v0, v0, v11
-  mov x11, #18830
-  mov x12, #56431
-  movk x11, #2465, lsl 16
-  movk x12, #30457, lsl 16
-  movk x11, #36348, lsl 32
-  movk x11, #17194, lsl 48
-  movk x12, #30012, lsl 32
-  dup.2d v7, x11
-  movk x12, #6382, lsl 48
-  mov.16b v8, v9
-  fmla.2d v8, v6, v7
-  mov x11, #59151
-  fsub.2d v11, v10, v8
-  movk x11, #41769, lsl 16
+  mov.16b v11, v9
   fmla.2d v11, v6, v7
-  movk x11, #32276, lsl 32
-  add.2d v2, v2, v8
-  add.2d v1, v1, v11
-  movk x11, #21677, lsl 48
-  mov x13, #21566
-  mov x14, #34015
-  movk x13, #43708, lsl 16
-  movk x13, #57685, lsl 32
-  movk x14, #20342, lsl 16
-  movk x13, #17185, lsl 48
-  movk x14, #13935, lsl 32
+  mov x11, #56431
+  fsub.2d v12, v10, v11
+  movk x11, #30457, lsl 16
+  fmla.2d v12, v6, v7
+  movk x11, #30012, lsl 32
+  add.2d v3, v3, v11
+  add.2d v5, v5, v12
+  movk x11, #6382, lsl 48
+  ucvtf.2d v6, v8
+  mov x12, #59151
+  mov x13, #34724
+  movk x13, #40393, lsl 16
+  movk x12, #41769, lsl 16
+  movk x13, #23752, lsl 32
+  movk x12, #32276, lsl 32
+  movk x13, #17184, lsl 48
+  movk x12, #21677, lsl 48
   dup.2d v7, x13
   mov.16b v8, v9
-  movk x14, #11030, lsl 48
+  mov x13, #34015
   fmla.2d v8, v6, v7
-  mov x13, #13689
+  movk x13, #20342, lsl 16
   fsub.2d v11, v10, v8
-  fmla.2d v11, v6, v7
-  movk x13, #8159, lsl 16
-  add.2d v5, v5, v8
-  movk x13, #215, lsl 32
-  add.2d v2, v2, v11
-  mov x15, #3072
-  movk x13, #4913, lsl 48
-  movk x15, #8058, lsl 16
-  mul x17, x12, x5
-  movk x15, #46097, lsl 32
-  movk x15, #17047, lsl 48
-  umulh x12, x12, x5
-  dup.2d v7, x15
-  adds x7, x17, x7
-  cinc x12, x12, hs
-  mov.16b v8, v9
-  fmla.2d v8, v6, v7
-  mul x15, x11, x5
-  fsub.2d v11, v10, v8
-  umulh x11, x11, x5
-  fmla.2d v11, v6, v7
-  add.2d v3, v3, v8
-  adds x12, x15, x12
-  cinc x11, x11, hs
-  add.2d v5, v5, v11
-  adds x8, x12, x8
-  cinc x11, x11, hs
-  mov x12, #65535
-  movk x12, #61439, lsl 16
-  mul x15, x14, x5
-  movk x12, #62867, lsl 32
-  umulh x14, x14, x5
-  movk x12, #1, lsl 48
-  umov x17, v4.d[0]
-  adds x11, x15, x11
-  cinc x14, x14, hs
-  umov x15, v4.d[1]
-  adds x9, x11, x9
-  cinc x11, x14, hs
-  mul x14, x17, x12
-  mul x12, x15, x12
-  mul x15, x13, x5
-  and x14, x14, x16
-  umulh x5, x13, x5
-  and x12, x12, x16
-  ins v6.d[0], x14
-  ins v6.d[1], x12
-  adds x11, x15, x11
-  cinc x5, x5, hs
-  ucvtf.2d v6, v6
-  adds x10, x11, x10
-  cinc x5, x5, hs
-  mov x11, #16
-  add x4, x4, x5
-  movk x11, #22847, lsl 32
-  movk x11, #17151, lsl 48
-  mov x5, #61005
-  dup.2d v7, x11
-  movk x5, #58262, lsl 16
-  mov.16b v8, v9
-  fmla.2d v8, v6, v7
-  movk x5, #32851, lsl 32
-  fsub.2d v11, v10, v8
-  movk x5, #11582, lsl 48
+  movk x13, #13935, lsl 32
   fmla.2d v11, v6, v7
   add.2d v0, v0, v8
-  mov x11, #37581
+  movk x13, #11030, lsl 48
   add.2d v4, v4, v11
-  movk x11, #43836, lsl 16
-  mov x12, #20728
-  movk x12, #23588, lsl 16
-  movk x11, #36286, lsl 32
-  movk x12, #7790, lsl 32
-  movk x11, #51783, lsl 48
-  movk x12, #17170, lsl 48
-  dup.2d v7, x12
-  mov x12, #10899
+  mov x14, #13689
+  mov x15, #25532
+  movk x15, #31025, lsl 16
+  movk x14, #8159, lsl 16
+  movk x15, #10002, lsl 32
+  movk x14, #215, lsl 32
+  movk x15, #17199, lsl 48
+  movk x14, #4913, lsl 48
+  dup.2d v7, x15
   mov.16b v8, v9
-  movk x12, #30709, lsl 16
+  mul x15, x11, x5
   fmla.2d v8, v6, v7
+  umulh x11, x11, x5
   fsub.2d v11, v10, v8
-  movk x12, #61551, lsl 32
-  fmla.2d v11, v6, v7
-  movk x12, #45784, lsl 48
-  add.2d v1, v1, v8
-  add.2d v0, v0, v11
-  mov x13, #36612
-  mov x14, #16000
-  movk x13, #63402, lsl 16
-  movk x14, #53891, lsl 16
-  movk x14, #5509, lsl 32
-  movk x13, #47623, lsl 32
-  movk x14, #17144, lsl 48
-  movk x13, #9430, lsl 48
-  dup.2d v7, x14
-  mov.16b v8, v9
-  mul x14, x5, x6
-  fmla.2d v8, v6, v7
-  umulh x5, x5, x6
-  fsub.2d v11, v10, v8
-  fmla.2d v11, v6, v7
-  adds x7, x14, x7
-  cinc x5, x5, hs
-  add.2d v2, v2, v8
-  mul x14, x11, x6
-  add.2d v1, v1, v11
-  mov x15, #46800
-  umulh x11, x11, x6
-  movk x15, #2568, lsl 16
-  adds x5, x14, x5
+  adds x7, x15, x7
   cinc x11, x11, hs
-  movk x15, #1335, lsl 32
+  fmla.2d v11, v6, v7
+  add.2d v1, v1, v8
+  mul x15, x12, x5
+  add.2d v0, v0, v11
+  umulh x12, x12, x5
+  mov x17, #18830
+  movk x17, #2465, lsl 16
+  adds x11, x15, x11
+  cinc x12, x12, hs
+  movk x17, #36348, lsl 32
+  adds x8, x11, x8
+  cinc x11, x12, hs
+  movk x17, #17194, lsl 48
+  mul x12, x13, x5
+  dup.2d v7, x17
+  mov.16b v8, v9
+  umulh x13, x13, x5
+  fmla.2d v8, v6, v7
+  adds x11, x12, x11
+  cinc x12, x13, hs
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  adds x9, x11, x9
+  cinc x11, x12, hs
+  add.2d v2, v2, v8
+  mul x12, x14, x5
+  add.2d v1, v1, v11
+  umulh x5, x14, x5
+  mov x13, #21566
+  movk x13, #43708, lsl 16
+  adds x11, x12, x11
+  cinc x5, x5, hs
+  movk x13, #57685, lsl 32
+  adds x10, x11, x10
+  cinc x5, x5, hs
+  movk x13, #17185, lsl 48
+  add x4, x4, x5
+  dup.2d v7, x13
+  mov.16b v8, v9
+  mov x5, #61005
+  fmla.2d v8, v6, v7
+  movk x5, #58262, lsl 16
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  movk x5, #32851, lsl 32
+  add.2d v5, v5, v8
+  movk x5, #11582, lsl 48
+  add.2d v2, v2, v11
+  mov x11, #37581
+  mov x12, #3072
+  movk x12, #8058, lsl 16
+  movk x11, #43836, lsl 16
+  movk x12, #46097, lsl 32
+  movk x11, #36286, lsl 32
+  movk x12, #17047, lsl 48
+  movk x11, #51783, lsl 48
+  dup.2d v7, x12
+  mov.16b v8, v9
+  mov x12, #10899
+  fmla.2d v8, v6, v7
+  movk x12, #30709, lsl 16
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  movk x12, #61551, lsl 32
+  add.2d v3, v3, v8
+  movk x12, #45784, lsl 48
+  add.2d v5, v5, v11
+  mov x13, #36612
+  mov x14, #65535
+  movk x14, #61439, lsl 16
+  movk x13, #63402, lsl 16
+  movk x14, #62867, lsl 32
+  movk x13, #47623, lsl 32
+  movk x14, #1, lsl 48
+  movk x13, #9430, lsl 48
+  umov x15, v4.d[0]
+  umov x17, v4.d[1]
+  mul x20, x5, x6
+  mul x15, x15, x14
+  umulh x5, x5, x6
+  mul x14, x17, x14
+  and x15, x15, x16
+  adds x7, x20, x7
+  cinc x5, x5, hs
+  and x14, x14, x16
+  mul x16, x11, x6
+  ins v6.d[0], x15
+  ins v6.d[1], x14
+  umulh x11, x11, x6
+  ucvtf.2d v6, v6
+  mov x14, #16
+  adds x5, x16, x5
+  cinc x11, x11, hs
+  movk x14, #22847, lsl 32
   adds x5, x5, x8
   cinc x8, x11, hs
-  movk x15, #17188, lsl 48
-  dup.2d v7, x15
+  movk x14, #17151, lsl 48
   mul x11, x12, x6
+  dup.2d v7, x14
   mov.16b v8, v9
   umulh x12, x12, x6
   fmla.2d v8, v6, v7
-  fsub.2d v11, v10, v8
   adds x8, x11, x8
   cinc x11, x12, hs
+  fsub.2d v11, v10, v8
   fmla.2d v11, v6, v7
   adds x8, x8, x9
   cinc x9, x11, hs
-  add.2d v5, v5, v8
-  add.2d v2, v2, v11
+  add.2d v0, v0, v8
   mul x11, x13, x6
-  mov x12, #39040
+  add.2d v4, v4, v11
   umulh x6, x13, x6
-  movk x12, #14704, lsl 16
-  movk x12, #12839, lsl 32
+  mov x12, #20728
+  movk x12, #23588, lsl 16
   adds x9, x11, x9
   cinc x6, x6, hs
-  movk x12, #17096, lsl 48
+  movk x12, #7790, lsl 32
   adds x9, x9, x10
   cinc x6, x6, hs
+  movk x12, #17170, lsl 48
   dup.2d v7, x12
-  mov.16b v8, v9
   add x10, x4, x6
-  fmla.2d v8, v6, v7
+  mov.16b v8, v9
   mov x4, #65535
-  fsub.2d v9, v10, v8
-  fmla.2d v9, v6, v7
+  fmla.2d v8, v6, v7
   movk x4, #61439, lsl 16
-  add.2d v3, v3, v8
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
   movk x4, #62867, lsl 32
-  add.2d v5, v5, v9
-  mov x6, #140737488355328
+  add.2d v1, v1, v8
   movk x4, #49889, lsl 48
-  dup.2d v6, x6
+  add.2d v0, v0, v11
   mul x6, x4, x7
-  and.16b v6, v3, v6
-  cmeq.2d v6, v6, #0
-  mov x4, #1
-  mov x11, #2
-  movk x4, #61440, lsl 16
-  movk x11, #57344, lsl 16
-  movk x11, #60199, lsl 32
-  movk x4, #62867, lsl 32
-  movk x11, #3, lsl 48
-  movk x4, #17377, lsl 48
-  dup.2d v7, x11
-  bic.16b v7, v7, v6
-  mov x11, #28817
-  mov x12, #10364
-  movk x11, #31161, lsl 16
-  movk x12, #11794, lsl 16
-  movk x12, #3895, lsl 32
-  movk x11, #59464, lsl 32
-  movk x12, #9, lsl 48
-  movk x11, #10291, lsl 48
-  dup.2d v8, x12
-  mov x12, #22621
-  bic.16b v8, v8, v6
-  mov x13, #26576
-  movk x12, #33153, lsl 16
-  movk x13, #47696, lsl 16
-  movk x12, #17846, lsl 32
-  movk x13, #688, lsl 32
-  movk x13, #3, lsl 48
-  movk x12, #47184, lsl 48
-  dup.2d v9, x13
-  mov x13, #41001
-  bic.16b v9, v9, v6
-  mov x14, #46800
-  movk x13, #57649, lsl 16
-  movk x14, #2568, lsl 16
-  movk x13, #20082, lsl 32
-  movk x14, #1335, lsl 32
-  movk x14, #4, lsl 48
-  movk x13, #12388, lsl 48
-  dup.2d v10, x14
-  mul x14, x4, x6
-  bic.16b v10, v10, v6
-  mov x15, #49763
-  umulh x4, x4, x6
-  movk x15, #40165, lsl 16
-  cmn x14, x7
-  cinc x4, x4, hs
-  movk x15, #24776, lsl 32
-  dup.2d v11, x15
-  mul x7, x11, x6
-  bic.16b v6, v11, v6
+  mov x4, #16000
+  movk x4, #53891, lsl 16
+  mov x11, #1
+  movk x4, #5509, lsl 32
+  movk x11, #61440, lsl 16
+  movk x4, #17144, lsl 48
+  dup.2d v7, x4
+  movk x11, #62867, lsl 32
+  mov.16b v8, v9
+  movk x11, #17377, lsl 48
+  fmla.2d v8, v6, v7
+  mov x4, #28817
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v7
+  movk x4, #31161, lsl 16
+  add.2d v2, v2, v8
+  movk x4, #59464, lsl 32
+  add.2d v7, v1, v11
+  movk x4, #10291, lsl 48
+  mov x12, #46800
+  movk x12, #2568, lsl 16
+  mov x13, #22621
+  movk x12, #1335, lsl 32
+  movk x13, #33153, lsl 16
+  movk x12, #17188, lsl 48
+  dup.2d v1, x12
+  movk x13, #17846, lsl 32
+  mov.16b v8, v9
+  movk x13, #47184, lsl 48
+  fmla.2d v8, v6, v1
+  mov x12, #41001
+  fsub.2d v11, v10, v8
+  fmla.2d v11, v6, v1
+  movk x12, #57649, lsl 16
+  add.2d v1, v5, v8
+  movk x12, #20082, lsl 32
+  add.2d v5, v2, v11
+  movk x12, #12388, lsl 48
+  mov x14, #39040
+  movk x14, #14704, lsl 16
+  mul x15, x11, x6
+  movk x14, #12839, lsl 32
   umulh x11, x11, x6
-  sub.2d v0, v0, v7
+  movk x14, #17096, lsl 48
+  dup.2d v2, x14
+  cmn x15, x7
+  cinc x11, x11, hs
+  mov.16b v8, v9
+  mul x7, x4, x6
+  fmla.2d v8, v6, v2
+  umulh x4, x4, x6
+  fsub.2d v9, v10, v8
+  fmla.2d v9, v6, v2
+  adds x7, x7, x11
+  cinc x11, x4, hs
+  add.2d v6, v3, v8
+  adds x4, x7, x5
+  cinc x5, x11, hs
+  add.2d v8, v1, v9
+  mul x7, x13, x6
   ssra.2d v0, v4, #52
-  adds x4, x7, x4
-  cinc x7, x11, hs
-  sub.2d v4, v1, v8
-  adds x4, x4, x5
-  cinc x5, x7, hs
-  ssra.2d v4, v0, #52
-  sub.2d v7, v2, v9
-  mul x7, x12, x6
-  ssra.2d v7, v4, #52
-  umulh x11, x12, x6
-  sub.2d v5, v5, v10
+  ssra.2d v7, v0, #52
+  umulh x11, x13, x6
   ssra.2d v5, v7, #52
   adds x5, x7, x5
   cinc x7, x11, hs
-  sub.2d v6, v3, v6
+  ssra.2d v8, v5, #52
+  ssra.2d v6, v8, #52
   adds x5, x5, x8
   cinc x7, x7, hs
-  ssra.2d v6, v5, #52
-  ushr.2d v1, v4, #12
-  mul x8, x13, x6
-  ushr.2d v2, v7, #24
-  umulh x6, x13, x6
-  ushr.2d v3, v5, #36
-  sli.2d v0, v4, #52
+  ushr.2d v1, v7, #12
+  mul x8, x12, x6
+  ushr.2d v2, v5, #24
+  umulh x6, x12, x6
+  ushr.2d v3, v8, #36
+  sli.2d v0, v7, #52
   adds x7, x8, x7
   cinc x8, x6, hs
-  sli.2d v1, v7, #40
+  sli.2d v1, v5, #40
   adds x6, x7, x9
   cinc x7, x8, hs
-  sli.2d v2, v5, #28
+  sli.2d v2, v8, #28
   sli.2d v3, v6, #16
   add x7, x10, x7

--- a/block-multiplier/src/aarch64/montgomery_log_jump.s
+++ b/block-multiplier/src/aarch64/montgomery_log_jump.s
@@ -1,0 +1,257 @@
+// GENERATED FILE, DO NOT EDIT!
+// in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+// in("x4") b[0], in("x5") b[1], in("x6") b[2], in("x7") b[3],
+// lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3") out[3],
+// lateout("x4") _, lateout("x5") _, lateout("x6") _, lateout("x7") _, lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _,
+// lateout("lr") _
+  mul x8, x0, x4
+  umulh x9, x0, x4
+  mul x10, x1, x4
+  umulh x11, x1, x4
+  adds x9, x10, x9
+  cinc x10, x11, hs
+  mul x11, x2, x4
+  umulh x12, x2, x4
+  adds x10, x11, x10
+  cinc x11, x12, hs
+  mul x12, x3, x4
+  umulh x4, x3, x4
+  adds x11, x12, x11
+  cinc x4, x4, hs
+  mul x12, x0, x5
+  umulh x13, x0, x5
+  adds x9, x12, x9
+  cinc x12, x13, hs
+  mul x13, x1, x5
+  umulh x14, x1, x5
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  mul x13, x2, x5
+  umulh x14, x2, x5
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  adds x11, x12, x11
+  cinc x12, x13, hs
+  mul x13, x3, x5
+  umulh x5, x3, x5
+  adds x12, x13, x12
+  cinc x5, x5, hs
+  adds x4, x12, x4
+  cinc x5, x5, hs
+  mul x12, x0, x6
+  umulh x13, x0, x6
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  mul x13, x1, x6
+  umulh x14, x1, x6
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  adds x11, x12, x11
+  cinc x12, x13, hs
+  mul x13, x2, x6
+  umulh x14, x2, x6
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  adds x4, x12, x4
+  cinc x12, x13, hs
+  mul x13, x3, x6
+  umulh x6, x3, x6
+  adds x12, x13, x12
+  cinc x6, x6, hs
+  adds x5, x12, x5
+  cinc x6, x6, hs
+  mul x12, x0, x7
+  umulh x0, x0, x7
+  adds x11, x12, x11
+  cinc x0, x0, hs
+  mul x12, x1, x7
+  umulh x1, x1, x7
+  adds x0, x12, x0
+  cinc x1, x1, hs
+  adds x0, x0, x4
+  cinc x1, x1, hs
+  mul x4, x2, x7
+  umulh x2, x2, x7
+  adds x1, x4, x1
+  cinc x2, x2, hs
+  adds x1, x1, x5
+  cinc x2, x2, hs
+  mul x4, x3, x7
+  umulh x3, x3, x7
+  adds x2, x4, x2
+  cinc x3, x3, hs
+  adds x2, x2, x6
+  cinc x3, x3, hs
+  mov x4, #56431
+  movk x4, #30457, lsl 16
+  movk x4, #30012, lsl 32
+  movk x4, #6382, lsl 48
+  mov x5, #59151
+  movk x5, #41769, lsl 16
+  movk x5, #32276, lsl 32
+  movk x5, #21677, lsl 48
+  mov x6, #34015
+  movk x6, #20342, lsl 16
+  movk x6, #13935, lsl 32
+  movk x6, #11030, lsl 48
+  mov x7, #13689
+  movk x7, #8159, lsl 16
+  movk x7, #215, lsl 32
+  movk x7, #4913, lsl 48
+  mul x12, x4, x8
+  umulh x13, x4, x8
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  mul x13, x5, x8
+  umulh x14, x5, x8
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  adds x11, x12, x11
+  cinc x12, x13, hs
+  mul x13, x6, x8
+  umulh x14, x6, x8
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  adds x0, x12, x0
+  cinc x12, x13, hs
+  mul x13, x7, x8
+  umulh x8, x7, x8
+  adds x12, x13, x12
+  cinc x8, x8, hs
+  adds x1, x12, x1
+  cinc x8, x8, hs
+  adds x2, x2, x8
+  cinc x3, x3, hs
+  mul x8, x4, x9
+  umulh x4, x4, x9
+  adds x8, x8, x11
+  cinc x4, x4, hs
+  mul x11, x5, x9
+  umulh x5, x5, x9
+  adds x4, x11, x4
+  cinc x5, x5, hs
+  adds x0, x4, x0
+  cinc x4, x5, hs
+  mul x5, x6, x9
+  umulh x6, x6, x9
+  adds x4, x5, x4
+  cinc x5, x6, hs
+  adds x1, x4, x1
+  cinc x4, x5, hs
+  mul x5, x7, x9
+  umulh x6, x7, x9
+  adds x4, x5, x4
+  cinc x5, x6, hs
+  adds x2, x4, x2
+  cinc x4, x5, hs
+  add x3, x3, x4
+  mov x4, #61005
+  movk x4, #58262, lsl 16
+  movk x4, #32851, lsl 32
+  movk x4, #11582, lsl 48
+  mov x5, #37581
+  movk x5, #43836, lsl 16
+  movk x5, #36286, lsl 32
+  movk x5, #51783, lsl 48
+  mov x6, #10899
+  movk x6, #30709, lsl 16
+  movk x6, #61551, lsl 32
+  movk x6, #45784, lsl 48
+  mov x7, #36612
+  movk x7, #63402, lsl 16
+  movk x7, #47623, lsl 32
+  movk x7, #9430, lsl 48
+  mul x9, x4, x10
+  umulh x4, x4, x10
+  adds x8, x9, x8
+  cinc x4, x4, hs
+  mul x9, x5, x10
+  umulh x5, x5, x10
+  adds x4, x9, x4
+  cinc x5, x5, hs
+  adds x0, x4, x0
+  cinc x4, x5, hs
+  mul x5, x6, x10
+  umulh x6, x6, x10
+  adds x4, x5, x4
+  cinc x5, x6, hs
+  adds x1, x4, x1
+  cinc x4, x5, hs
+  mul x5, x7, x10
+  umulh x6, x7, x10
+  adds x4, x5, x4
+  cinc x5, x6, hs
+  adds x2, x4, x2
+  cinc x4, x5, hs
+  add x3, x3, x4
+  mov x4, #65535
+  movk x4, #61439, lsl 16
+  movk x4, #62867, lsl 32
+  movk x4, #49889, lsl 48
+  mul x4, x4, x8
+  mov x5, #1
+  movk x5, #61440, lsl 16
+  movk x5, #62867, lsl 32
+  movk x5, #17377, lsl 48
+  mov x6, #28817
+  movk x6, #31161, lsl 16
+  movk x6, #59464, lsl 32
+  movk x6, #10291, lsl 48
+  mov x7, #22621
+  movk x7, #33153, lsl 16
+  movk x7, #17846, lsl 32
+  movk x7, #47184, lsl 48
+  mov x9, #41001
+  movk x9, #57649, lsl 16
+  movk x9, #20082, lsl 32
+  movk x9, #12388, lsl 48
+  mul x10, x5, x4
+  umulh x5, x5, x4
+  cmn x10, x8
+  cinc x5, x5, hs
+  mul x8, x6, x4
+  umulh x6, x6, x4
+  adds x5, x8, x5
+  cinc x6, x6, hs
+  adds x0, x5, x0
+  cinc x5, x6, hs
+  mul x6, x7, x4
+  umulh x7, x7, x4
+  adds x5, x6, x5
+  cinc x6, x7, hs
+  adds x1, x5, x1
+  cinc x5, x6, hs
+  mul x6, x9, x4
+  umulh x4, x9, x4
+  adds x5, x6, x5
+  cinc x4, x4, hs
+  adds x2, x5, x2
+  cinc x4, x4, hs
+  add x3, x3, x4
+  mov x4, #2
+  movk x4, #57344, lsl 16
+  movk x4, #60199, lsl 32
+  movk x4, #34755, lsl 48
+  mov x5, #57634
+  movk x5, #62322, lsl 16
+  movk x5, #53392, lsl 32
+  movk x5, #20583, lsl 48
+  mov x6, #45242
+  movk x6, #770, lsl 16
+  movk x6, #35693, lsl 32
+  movk x6, #28832, lsl 48
+  mov x7, #16467
+  movk x7, #49763, lsl 16
+  movk x7, #40165, lsl 32
+  movk x7, #24776, lsl 48
+  subs x4, x0, x4
+  sbcs x5, x1, x5
+  sbcs x6, x2, x6
+  sbcs x7, x3, x7
+  tst x3, #9223372036854775808
+  csel x0, x4, x0, mi
+  csel x1, x5, x1, mi
+  csel x2, x6, x2, mi
+  csel x3, x7, x3, mi

--- a/block-multiplier/src/aarch64/montgomery_log_jump.s
+++ b/block-multiplier/src/aarch64/montgomery_log_jump.s
@@ -230,28 +230,3 @@
   adds x2, x5, x2
   cinc x4, x4, hs
   add x3, x3, x4
-  mov x4, #2
-  movk x4, #57344, lsl 16
-  movk x4, #60199, lsl 32
-  movk x4, #34755, lsl 48
-  mov x5, #57634
-  movk x5, #62322, lsl 16
-  movk x5, #53392, lsl 32
-  movk x5, #20583, lsl 48
-  mov x6, #45242
-  movk x6, #770, lsl 16
-  movk x6, #35693, lsl 32
-  movk x6, #28832, lsl 48
-  mov x7, #16467
-  movk x7, #49763, lsl 16
-  movk x7, #40165, lsl 32
-  movk x7, #24776, lsl 48
-  subs x4, x0, x4
-  sbcs x5, x1, x5
-  sbcs x6, x2, x6
-  sbcs x7, x3, x7
-  tst x3, #9223372036854775808
-  csel x0, x4, x0, mi
-  csel x1, x5, x1, mi
-  csel x2, x6, x2, mi
-  csel x3, x7, x3, mi

--- a/block-multiplier/src/aarch64/montgomery_square_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_square_interleaved_3.s
@@ -14,751 +14,726 @@
   umulh x7, x0, x0
   movk x6, #18032, lsl 48
   dup.2d v6, x6
-  mul x6, x0, x1
   shl.2d v7, v1, #14
+  mul x6, x0, x1
   shl.2d v8, v2, #26
   shl.2d v9, v3, #38
-  umulh x8, x0, x1
   ushr.2d v3, v3, #14
+  umulh x8, x0, x1
   shl.2d v10, v0, #2
-  adds x7, x6, x7
-  cinc x9, x8, hs
   usra.2d v7, v0, #50
   usra.2d v8, v1, #38
+  adds x7, x6, x7
+  cinc x9, x8, hs
   usra.2d v9, v2, #26
-  mul x10, x0, x2
   and.16b v0, v10, v4
   and.16b v1, v7, v4
+  mul x10, x0, x2
   and.16b v2, v8, v4
-  umulh x11, x0, x2
   and.16b v7, v9, v4
+  umulh x11, x0, x2
   mov x12, #13605374474286268416
-  adds x9, x10, x9
-  cinc x13, x11, hs
   dup.2d v8, x12
   mov x12, #6440147467139809280
+  adds x9, x10, x9
+  cinc x13, x11, hs
   dup.2d v9, x12
+  mov x12, #3688448094816436224
+  dup.2d v10, x12
   mul x12, x0, x3
-  mov x14, #3688448094816436224
-  dup.2d v10, x14
-  umulh x0, x0, x3
   mov x14, #9209861237972664320
   dup.2d v11, x14
   mov x14, #12218265789056155648
-  adds x13, x12, x13
-  cinc x15, x0, hs
+  umulh x0, x0, x3
   dup.2d v12, x14
   mov x14, #17739678932212383744
+  dup.2d v13, x14
+  adds x13, x12, x13
+  cinc x14, x0, hs
+  mov x15, #2301339409586323456
+  dup.2d v14, x15
+  mov x15, #7822752552742551552
   adds x6, x6, x7
   cinc x7, x8, hs
-  dup.2d v13, x14
-  mov x8, #2301339409586323456
-  dup.2d v14, x8
-  mul x8, x1, x1
-  mov x14, #7822752552742551552
-  dup.2d v15, x14
-  mov x14, #5071053180419178496
-  umulh x16, x1, x1
-  dup.2d v16, x14
-  mov x14, #16352570246982270976
-  adds x7, x8, x7
-  cinc x8, x16, hs
-  dup.2d v17, x14
+  dup.2d v15, x15
+  mov x8, #5071053180419178496
+  mul x15, x1, x1
+  dup.2d v16, x8
+  mov x8, #16352570246982270976
+  dup.2d v17, x8
+  umulh x8, x1, x1
   ucvtf.2d v0, v0
   ucvtf.2d v1, v1
-  adds x7, x7, x9
-  cinc x8, x8, hs
   ucvtf.2d v2, v2
+  adds x7, x15, x7
+  cinc x8, x8, hs
   ucvtf.2d v7, v7
-  mul x9, x1, x2
   ucvtf.2d v3, v3
   mov.16b v18, v5
+  adds x7, x7, x9
+  cinc x8, x8, hs
   fmla.2d v18, v0, v0
-  umulh x14, x1, x2
   fsub.2d v19, v6, v18
   fmla.2d v19, v0, v0
-  adds x8, x9, x8
-  cinc x16, x14, hs
+  mul x9, x1, x2
   add.2d v10, v10, v18
   add.2d v8, v8, v19
   mov.16b v18, v5
-  adds x8, x8, x13
-  cinc x13, x16, hs
+  umulh x15, x1, x2
   fmla.2d v18, v0, v1
   fsub.2d v19, v6, v18
+  adds x8, x9, x8
+  cinc x16, x15, hs
   fmla.2d v19, v0, v1
-  mul x16, x1, x3
   add.2d v18, v18, v18
   add.2d v19, v19, v19
-  umulh x1, x1, x3
+  adds x8, x8, x13
+  cinc x13, x16, hs
   add.2d v12, v12, v18
   add.2d v10, v10, v19
   mov.16b v18, v5
-  adds x13, x16, x13
-  cinc x17, x1, hs
+  mul x16, x1, x3
   fmla.2d v18, v0, v2
   fsub.2d v19, v6, v18
-  adds x13, x13, x15
-  cinc x15, x17, hs
   fmla.2d v19, v0, v2
+  umulh x1, x1, x3
   add.2d v18, v18, v18
   add.2d v19, v19, v19
-  adds x7, x10, x7
-  cinc x10, x11, hs
   add.2d v14, v14, v18
+  adds x13, x16, x13
+  cinc x17, x1, hs
   add.2d v12, v12, v19
-  adds x9, x9, x10
-  cinc x10, x14, hs
   mov.16b v18, v5
   fmla.2d v18, v0, v7
+  adds x13, x13, x14
+  cinc x14, x17, hs
   fsub.2d v19, v6, v18
-  adds x8, x9, x8
-  cinc x9, x10, hs
   fmla.2d v19, v0, v7
+  adds x7, x10, x7
+  cinc x10, x11, hs
   add.2d v18, v18, v18
   add.2d v19, v19, v19
-  mul x10, x2, x2
   add.2d v16, v16, v18
+  adds x9, x9, x10
+  cinc x10, x15, hs
   add.2d v14, v14, v19
-  umulh x11, x2, x2
   mov.16b v18, v5
   fmla.2d v18, v0, v3
+  adds x8, x9, x8
+  cinc x9, x10, hs
   fsub.2d v19, v6, v18
-  adds x9, x10, x9
-  cinc x10, x11, hs
   fmla.2d v19, v0, v3
   add.2d v0, v18, v18
-  adds x9, x9, x13
-  cinc x10, x10, hs
+  mul x10, x2, x2
   add.2d v18, v19, v19
   add.2d v0, v17, v0
   add.2d v16, v16, v18
-  mul x11, x2, x3
+  umulh x11, x2, x2
   mov.16b v17, v5
   fmla.2d v17, v1, v1
-  umulh x2, x2, x3
   fsub.2d v18, v6, v17
+  adds x9, x10, x9
+  cinc x10, x11, hs
   fmla.2d v18, v1, v1
   add.2d v14, v14, v17
-  adds x10, x11, x10
-  cinc x13, x2, hs
+  adds x9, x9, x13
+  cinc x10, x10, hs
   add.2d v12, v12, v18
   mov.16b v17, v5
   fmla.2d v17, v1, v2
-  adds x10, x10, x15
-  cinc x13, x13, hs
+  mul x11, x2, x3
   fsub.2d v18, v6, v17
   fmla.2d v18, v1, v2
-  adds x8, x12, x8
-  cinc x0, x0, hs
   add.2d v17, v17, v17
+  umulh x2, x2, x3
   add.2d v18, v18, v18
   add.2d v16, v16, v17
-  adds x0, x16, x0
-  cinc x1, x1, hs
   add.2d v14, v14, v18
+  adds x10, x11, x10
+  cinc x13, x2, hs
   mov.16b v17, v5
-  adds x0, x0, x9
-  cinc x1, x1, hs
   fmla.2d v17, v1, v7
   fsub.2d v18, v6, v17
+  adds x10, x10, x14
+  cinc x13, x13, hs
   fmla.2d v18, v1, v7
-  adds x1, x11, x1
-  cinc x2, x2, hs
   add.2d v17, v17, v17
   add.2d v18, v18, v18
-  adds x1, x1, x10
-  cinc x2, x2, hs
+  adds x8, x12, x8
+  cinc x0, x0, hs
   add.2d v0, v0, v17
   add.2d v16, v16, v18
+  adds x0, x16, x0
+  cinc x1, x1, hs
   mov.16b v17, v5
-  mul x9, x3, x3
   fmla.2d v17, v1, v3
   fsub.2d v18, v6, v17
+  adds x0, x0, x9
+  cinc x1, x1, hs
   fmla.2d v18, v1, v3
-  umulh x3, x3, x3
   add.2d v1, v17, v17
   add.2d v17, v18, v18
-  adds x2, x9, x2
-  cinc x3, x3, hs
+  adds x1, x11, x1
+  cinc x2, x2, hs
   add.2d v1, v15, v1
   add.2d v0, v0, v17
   mov.16b v15, v5
-  adds x2, x2, x13
-  cinc x3, x3, hs
+  adds x1, x1, x10
+  cinc x2, x2, hs
   fmla.2d v15, v2, v2
   fsub.2d v17, v6, v15
-  mov x9, #48718
   fmla.2d v17, v2, v2
+  mul x9, x3, x3
   add.2d v0, v0, v15
   add.2d v15, v16, v17
-  movk x9, #4732, lsl 16
   mov.16b v16, v5
+  umulh x3, x3, x3
   fmla.2d v16, v2, v7
-  movk x9, #45078, lsl 32
   fsub.2d v17, v6, v16
+  adds x2, x9, x2
+  cinc x3, x3, hs
   fmla.2d v17, v2, v7
   add.2d v16, v16, v16
-  movk x9, #39852, lsl 48
   add.2d v17, v17, v17
+  adds x2, x2, x13
+  cinc x3, x3, hs
   add.2d v1, v1, v16
   add.2d v0, v0, v17
-  mov x10, #16676
   mov.16b v16, v5
+  mov x9, #48718
   fmla.2d v16, v2, v3
-  movk x10, #12692, lsl 16
   fsub.2d v17, v6, v16
   fmla.2d v17, v2, v3
+  movk x9, #4732, lsl 16
   add.2d v2, v16, v16
-  movk x10, #20986, lsl 32
   add.2d v16, v17, v17
   add.2d v2, v13, v2
-  movk x10, #2848, lsl 48
+  movk x9, #45078, lsl 32
   add.2d v1, v1, v16
   mov.16b v13, v5
   fmla.2d v13, v7, v7
-  mov x11, #51052
+  movk x9, #39852, lsl 48
   fsub.2d v16, v6, v13
   fmla.2d v16, v7, v7
+  mov x10, #16676
   add.2d v2, v2, v13
-  movk x11, #24721, lsl 16
   add.2d v1, v1, v16
   mov.16b v13, v5
-  movk x11, #61092, lsl 32
+  movk x10, #12692, lsl 16
   fmla.2d v13, v7, v3
   fsub.2d v16, v6, v13
   fmla.2d v16, v7, v3
-  movk x11, #45156, lsl 48
+  movk x10, #20986, lsl 32
   add.2d v7, v13, v13
   add.2d v13, v16, v16
-  mov x12, #3197
   add.2d v7, v11, v7
+  movk x10, #2848, lsl 48
   add.2d v2, v2, v13
   mov.16b v11, v5
-  movk x12, #18936, lsl 16
   fmla.2d v11, v3, v3
+  mov x11, #51052
   fsub.2d v13, v6, v11
-  movk x12, #10922, lsl 32
   fmla.2d v13, v3, v3
   add.2d v3, v9, v11
+  movk x11, #24721, lsl 16
   add.2d v7, v7, v13
-  movk x12, #11014, lsl 48
   usra.2d v10, v8, #52
+  movk x11, #61092, lsl 32
   usra.2d v12, v10, #52
   usra.2d v14, v12, #52
-  mul x13, x9, x5
   usra.2d v15, v14, #52
+  movk x11, #45156, lsl 48
   and.16b v8, v8, v4
-  umulh x9, x9, x5
   and.16b v9, v10, v4
   and.16b v10, v12, v4
+  mov x12, #3197
   and.16b v4, v14, v4
-  adds x8, x13, x8
-  cinc x9, x9, hs
   ucvtf.2d v8, v8
   mov x13, #37864
-  mul x14, x10, x5
+  movk x12, #18936, lsl 16
   movk x13, #1815, lsl 16
   movk x13, #28960, lsl 32
   movk x13, #17153, lsl 48
-  umulh x10, x10, x5
+  movk x12, #10922, lsl 32
   dup.2d v11, x13
   mov.16b v12, v5
-  adds x9, x14, x9
-  cinc x10, x10, hs
   fmla.2d v12, v8, v11
+  movk x12, #11014, lsl 48
   fsub.2d v13, v6, v12
   fmla.2d v13, v8, v11
-  adds x0, x9, x0
-  cinc x9, x10, hs
   add.2d v0, v0, v12
+  mul x13, x9, x5
   add.2d v11, v15, v13
-  mov x10, #46128
-  mul x13, x11, x5
-  movk x10, #29964, lsl 16
-  movk x10, #7587, lsl 32
-  umulh x11, x11, x5
-  movk x10, #17161, lsl 48
-  dup.2d v12, x10
+  mov x14, #46128
+  umulh x9, x9, x5
+  movk x14, #29964, lsl 16
+  movk x14, #7587, lsl 32
+  movk x14, #17161, lsl 48
+  adds x8, x13, x8
+  cinc x9, x9, hs
+  dup.2d v12, x14
   mov.16b v13, v5
-  adds x9, x13, x9
-  cinc x10, x11, hs
   fmla.2d v13, v8, v12
+  mul x13, x10, x5
   fsub.2d v14, v6, v13
-  adds x1, x9, x1
-  cinc x9, x10, hs
   fmla.2d v14, v8, v12
   add.2d v1, v1, v13
+  umulh x10, x10, x5
   add.2d v0, v0, v14
-  mul x10, x12, x5
-  mov x11, #52826
-  movk x11, #57790, lsl 16
-  umulh x5, x12, x5
-  movk x11, #55431, lsl 32
-  movk x11, #17196, lsl 48
-  dup.2d v12, x11
-  adds x9, x10, x9
-  cinc x5, x5, hs
+  mov x14, #52826
+  movk x14, #57790, lsl 16
+  adds x9, x13, x9
+  cinc x10, x10, hs
+  movk x14, #55431, lsl 32
+  movk x14, #17196, lsl 48
+  dup.2d v12, x14
+  adds x0, x9, x0
+  cinc x9, x10, hs
   mov.16b v13, v5
   fmla.2d v13, v8, v12
+  mul x10, x11, x5
   fsub.2d v14, v6, v13
-  adds x2, x9, x2
-  cinc x5, x5, hs
   fmla.2d v14, v8, v12
   add.2d v2, v2, v13
-  add x3, x3, x5
+  umulh x11, x11, x5
   add.2d v1, v1, v14
-  mov x5, #31276
-  movk x5, #21262, lsl 16
-  mov x9, #56431
-  movk x5, #2304, lsl 32
-  movk x5, #17182, lsl 48
-  movk x9, #30457, lsl 16
-  dup.2d v12, x5
+  mov x13, #31276
+  movk x13, #21262, lsl 16
+  adds x9, x10, x9
+  cinc x10, x11, hs
+  movk x13, #2304, lsl 32
+  movk x13, #17182, lsl 48
+  dup.2d v12, x13
+  adds x1, x9, x1
+  cinc x9, x10, hs
   mov.16b v13, v5
   fmla.2d v13, v8, v12
-  movk x9, #30012, lsl 32
   fsub.2d v14, v6, v13
+  mul x10, x12, x5
   fmla.2d v14, v8, v12
-  movk x9, #6382, lsl 48
   add.2d v7, v7, v13
   add.2d v2, v2, v14
-  mov x5, #28672
-  mov x10, #59151
-  movk x5, #24515, lsl 16
-  movk x5, #54929, lsl 32
-  movk x5, #17064, lsl 48
-  movk x10, #41769, lsl 16
-  dup.2d v12, x5
+  umulh x5, x12, x5
+  mov x11, #28672
+  movk x11, #24515, lsl 16
+  adds x9, x10, x9
+  cinc x5, x5, hs
+  movk x11, #54929, lsl 32
+  movk x11, #17064, lsl 48
+  dup.2d v12, x11
+  adds x2, x9, x2
+  cinc x5, x5, hs
   mov.16b v13, v5
-  movk x10, #32276, lsl 32
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
+  add x3, x3, x5
   fmla.2d v14, v8, v12
-  movk x10, #21677, lsl 48
   add.2d v3, v3, v13
   add.2d v7, v7, v14
-  mov x5, #34015
+  mov x5, #56431
   ucvtf.2d v8, v9
-  mov x11, #44768
-  movk x11, #51919, lsl 16
-  movk x5, #20342, lsl 16
-  movk x11, #6346, lsl 32
-  movk x11, #17133, lsl 48
-  movk x5, #13935, lsl 32
-  dup.2d v9, x11
+  mov x9, #44768
+  movk x9, #51919, lsl 16
+  movk x5, #30457, lsl 16
+  movk x9, #6346, lsl 32
+  movk x9, #17133, lsl 48
+  dup.2d v9, x9
+  movk x5, #30012, lsl 32
   mov.16b v12, v5
   fmla.2d v12, v8, v9
-  movk x5, #11030, lsl 48
+  movk x5, #6382, lsl 48
   fsub.2d v13, v6, v12
   fmla.2d v13, v8, v9
   add.2d v0, v0, v12
-  mov x11, #13689
+  mov x9, #59151
   add.2d v9, v11, v13
-  mov x12, #47492
+  mov x10, #47492
+  movk x10, #23630, lsl 16
+  movk x9, #41769, lsl 16
+  movk x10, #49985, lsl 32
+  movk x10, #17168, lsl 48
+  dup.2d v11, x10
+  movk x9, #32276, lsl 32
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  movk x9, #21677, lsl 48
+  fmla.2d v13, v8, v11
+  add.2d v1, v1, v12
+  add.2d v0, v0, v13
+  mov x10, #34015
+  mov x11, #57936
+  movk x11, #54828, lsl 16
+  movk x10, #20342, lsl 16
+  movk x11, #18292, lsl 32
+  movk x11, #17197, lsl 48
+  dup.2d v11, x11
+  movk x10, #13935, lsl 32
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  movk x10, #11030, lsl 48
+  fmla.2d v13, v8, v11
+  add.2d v2, v2, v12
+  add.2d v1, v1, v13
+  mov x11, #13689
+  mov x12, #17708
+  movk x12, #43915, lsl 16
+  movk x12, #64348, lsl 32
   movk x11, #8159, lsl 16
-  movk x12, #23630, lsl 16
-  movk x12, #49985, lsl 32
-  movk x12, #17168, lsl 48
-  movk x11, #215, lsl 32
+  movk x12, #17188, lsl 48
   dup.2d v11, x12
   mov.16b v12, v5
+  movk x11, #215, lsl 32
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
   movk x11, #4913, lsl 48
+  fmla.2d v13, v8, v11
+  add.2d v7, v7, v12
+  add.2d v2, v2, v13
+  mul x12, x5, x6
+  mov x13, #29184
+  movk x13, #20789, lsl 16
+  movk x13, #19197, lsl 32
+  umulh x5, x5, x6
+  movk x13, #17083, lsl 48
+  dup.2d v11, x13
+  mov.16b v12, v5
+  adds x8, x12, x8
+  cinc x5, x5, hs
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
   fmla.2d v13, v8, v11
   mul x12, x9, x6
-  add.2d v1, v1, v12
-  add.2d v0, v0, v13
-  umulh x9, x9, x6
-  mov x13, #57936
-  movk x13, #54828, lsl 16
-  movk x13, #18292, lsl 32
-  adds x8, x12, x8
-  cinc x9, x9, hs
-  movk x13, #17197, lsl 48
-  dup.2d v11, x13
-  mov.16b v12, v5
-  mul x12, x10, x6
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
-  umulh x10, x10, x6
-  fmla.2d v13, v8, v11
-  add.2d v2, v2, v12
-  add.2d v1, v1, v13
-  adds x9, x12, x9
-  cinc x10, x10, hs
-  mov x12, #17708
-  movk x12, #43915, lsl 16
-  adds x0, x9, x0
-  cinc x9, x10, hs
-  movk x12, #64348, lsl 32
-  movk x12, #17188, lsl 48
-  dup.2d v11, x12
-  mul x10, x5, x6
-  mov.16b v12, v5
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
-  umulh x5, x5, x6
-  fmla.2d v13, v8, v11
-  add.2d v7, v7, v12
-  adds x9, x10, x9
-  cinc x5, x5, hs
-  add.2d v2, v2, v13
-  mov x10, #29184
-  movk x10, #20789, lsl 16
-  adds x1, x9, x1
-  cinc x5, x5, hs
-  movk x10, #19197, lsl 32
-  movk x10, #17083, lsl 48
-  mul x9, x11, x6
-  dup.2d v11, x10
-  mov.16b v12, v5
-  fmla.2d v12, v8, v11
-  umulh x6, x11, x6
-  fsub.2d v13, v6, v12
-  fmla.2d v13, v8, v11
-  adds x5, x9, x5
-  cinc x6, x6, hs
   add.2d v3, v3, v12
   add.2d v7, v7, v13
   ucvtf.2d v8, v10
+  umulh x9, x9, x6
+  mov x13, #58856
+  movk x13, #14953, lsl 16
+  adds x5, x12, x5
+  cinc x9, x9, hs
+  movk x13, #15155, lsl 32
+  movk x13, #17181, lsl 48
+  dup.2d v10, x13
+  adds x0, x5, x0
+  cinc x5, x9, hs
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  mul x9, x10, x6
+  fmla.2d v12, v8, v10
+  add.2d v0, v0, v11
+  add.2d v9, v9, v12
+  umulh x10, x10, x6
+  mov x12, #35392
+  movk x12, #12477, lsl 16
+  movk x12, #56780, lsl 32
+  adds x5, x9, x5
+  cinc x9, x10, hs
+  movk x12, #17142, lsl 48
+  dup.2d v10, x12
+  mov.16b v11, v5
+  adds x1, x5, x1
+  cinc x5, x9, hs
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  mul x9, x11, x6
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  add.2d v0, v0, v12
+  umulh x6, x11, x6
+  mov x10, #9848
+  movk x10, #54501, lsl 16
+  movk x10, #31540, lsl 32
+  adds x5, x9, x5
+  cinc x6, x6, hs
+  movk x10, #17170, lsl 48
+  dup.2d v10, x10
+  mov.16b v11, v5
   adds x2, x5, x2
   cinc x5, x6, hs
-  mov x6, #58856
-  movk x6, #14953, lsl 16
-  movk x6, #15155, lsl 32
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
   add x3, x3, x5
-  movk x6, #17181, lsl 48
-  dup.2d v10, x6
-  mov x5, #61005
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  movk x5, #58262, lsl 16
-  fmla.2d v12, v8, v10
-  add.2d v0, v0, v11
-  movk x5, #32851, lsl 32
-  add.2d v9, v9, v12
-  mov x6, #35392
-  movk x6, #12477, lsl 16
-  movk x5, #11582, lsl 48
-  movk x6, #56780, lsl 32
-  movk x6, #17142, lsl 48
-  mov x9, #37581
-  dup.2d v10, x6
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  movk x9, #43836, lsl 16
-  fsub.2d v12, v6, v11
-  fmla.2d v12, v8, v10
-  add.2d v1, v1, v11
-  movk x9, #36286, lsl 32
-  add.2d v0, v0, v12
-  mov x6, #9848
-  movk x9, #51783, lsl 48
-  movk x6, #54501, lsl 16
-  movk x6, #31540, lsl 32
-  movk x6, #17170, lsl 48
-  mov x10, #10899
-  dup.2d v10, x6
-  mov.16b v11, v5
-  movk x10, #30709, lsl 16
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  fmla.2d v12, v8, v10
-  movk x10, #61551, lsl 32
   add.2d v2, v2, v11
   add.2d v1, v1, v12
-  movk x10, #45784, lsl 48
-  mov x6, #9584
-  movk x6, #63883, lsl 16
-  movk x6, #18253, lsl 32
-  mov x11, #36612
-  movk x6, #17190, lsl 48
-  dup.2d v10, x6
+  mov x5, #9584
+  mov x6, #61005
+  movk x5, #63883, lsl 16
+  movk x5, #18253, lsl 32
+  movk x6, #58262, lsl 16
+  movk x5, #17190, lsl 48
+  dup.2d v10, x5
   mov.16b v11, v5
-  movk x11, #63402, lsl 16
+  movk x6, #32851, lsl 32
   fmla.2d v11, v8, v10
   fsub.2d v12, v6, v11
-  movk x11, #47623, lsl 32
   fmla.2d v12, v8, v10
+  movk x6, #11582, lsl 48
   add.2d v7, v7, v11
   add.2d v2, v2, v12
-  movk x11, #9430, lsl 48
-  mov x6, #51712
-  movk x6, #16093, lsl 16
-  mul x12, x5, x7
-  movk x6, #30633, lsl 32
-  movk x6, #17068, lsl 48
-  dup.2d v10, x6
-  umulh x5, x5, x7
+  mov x5, #51712
+  mov x9, #37581
+  movk x5, #16093, lsl 16
+  movk x5, #30633, lsl 32
+  movk x5, #17068, lsl 48
+  movk x9, #43836, lsl 16
+  dup.2d v10, x5
   mov.16b v11, v5
   fmla.2d v11, v8, v10
-  adds x6, x12, x8
-  cinc x5, x5, hs
+  movk x9, #36286, lsl 32
   fsub.2d v12, v6, v11
   fmla.2d v12, v8, v10
+  movk x9, #51783, lsl 48
   add.2d v3, v3, v11
-  mul x8, x9, x7
   add.2d v7, v7, v12
   ucvtf.2d v4, v4
-  mov x12, #34724
-  umulh x9, x9, x7
-  movk x12, #40393, lsl 16
-  movk x12, #23752, lsl 32
-  adds x5, x8, x5
-  cinc x8, x9, hs
-  movk x12, #17184, lsl 48
-  dup.2d v8, x12
+  mov x5, #10899
+  mov x10, #34724
+  movk x10, #40393, lsl 16
+  movk x10, #23752, lsl 32
+  movk x5, #30709, lsl 16
+  movk x10, #17184, lsl 48
+  dup.2d v8, x10
   mov.16b v10, v5
-  adds x0, x5, x0
-  cinc x5, x8, hs
+  movk x5, #61551, lsl 32
   fmla.2d v10, v4, v8
   fsub.2d v11, v6, v10
-  mul x8, x10, x7
   fmla.2d v11, v4, v8
+  movk x5, #45784, lsl 48
   add.2d v0, v0, v10
   add.2d v8, v9, v11
-  umulh x9, x10, x7
   mov x10, #25532
+  mov x11, #36612
   movk x10, #31025, lsl 16
-  adds x5, x8, x5
-  cinc x8, x9, hs
   movk x10, #10002, lsl 32
   movk x10, #17199, lsl 48
+  movk x11, #63402, lsl 16
   dup.2d v9, x10
-  adds x1, x5, x1
-  cinc x5, x8, hs
   mov.16b v10, v5
+  movk x11, #47623, lsl 32
   fmla.2d v10, v4, v9
   fsub.2d v11, v6, v10
-  mul x8, x11, x7
   fmla.2d v11, v4, v9
+  movk x11, #9430, lsl 48
   add.2d v1, v1, v10
-  umulh x7, x11, x7
   add.2d v0, v0, v11
-  mov x9, #18830
-  movk x9, #2465, lsl 16
-  adds x5, x8, x5
-  cinc x7, x7, hs
-  movk x9, #36348, lsl 32
-  movk x9, #17194, lsl 48
-  adds x2, x5, x2
-  cinc x5, x7, hs
-  dup.2d v9, x9
+  mov x10, #18830
+  mul x12, x6, x7
+  movk x10, #2465, lsl 16
+  movk x10, #36348, lsl 32
+  movk x10, #17194, lsl 48
+  umulh x6, x6, x7
+  dup.2d v9, x10
   mov.16b v10, v5
   fmla.2d v10, v4, v9
-  add x3, x3, x5
+  adds x8, x12, x8
+  cinc x6, x6, hs
   fsub.2d v11, v6, v10
   fmla.2d v11, v4, v9
-  mov x5, #65535
   add.2d v2, v2, v10
+  mul x10, x9, x7
   add.2d v1, v1, v11
-  mov x7, #21566
-  movk x5, #61439, lsl 16
-  movk x7, #43708, lsl 16
-  movk x7, #57685, lsl 32
-  movk x7, #17185, lsl 48
-  movk x5, #62867, lsl 32
-  dup.2d v9, x7
+  mov x12, #21566
+  umulh x9, x9, x7
+  movk x12, #43708, lsl 16
+  movk x12, #57685, lsl 32
+  movk x12, #17185, lsl 48
+  adds x6, x10, x6
+  cinc x9, x9, hs
+  dup.2d v9, x12
   mov.16b v10, v5
-  movk x5, #49889, lsl 48
   fmla.2d v10, v4, v9
+  adds x0, x6, x0
+  cinc x6, x9, hs
   fsub.2d v11, v6, v10
   fmla.2d v11, v4, v9
-  mul x5, x5, x6
   add.2d v7, v7, v10
+  mul x9, x5, x7
   add.2d v2, v2, v11
-  mov x7, #1
-  mov x8, #3072
-  movk x8, #8058, lsl 16
-  movk x8, #46097, lsl 32
-  movk x7, #61440, lsl 16
-  movk x8, #17047, lsl 48
-  dup.2d v9, x8
+  mov x10, #3072
+  movk x10, #8058, lsl 16
+  umulh x5, x5, x7
+  movk x10, #46097, lsl 32
+  movk x10, #17047, lsl 48
+  dup.2d v9, x10
+  adds x6, x9, x6
+  cinc x5, x5, hs
   mov.16b v10, v5
-  movk x7, #62867, lsl 32
   fmla.2d v10, v4, v9
+  adds x1, x6, x1
+  cinc x5, x5, hs
   fsub.2d v11, v6, v10
-  movk x7, #17377, lsl 48
   fmla.2d v11, v4, v9
   add.2d v3, v3, v10
+  mul x6, x11, x7
   add.2d v4, v7, v11
-  mov x8, #28817
   mov x9, #65535
   movk x9, #61439, lsl 16
-  movk x8, #31161, lsl 16
+  umulh x7, x11, x7
   movk x9, #62867, lsl 32
   movk x9, #1, lsl 48
   umov x10, v8.d[0]
-  movk x8, #59464, lsl 32
-  umov x11, v8.d[1]
+  adds x5, x6, x5
+  cinc x6, x7, hs
+  umov x7, v8.d[1]
   mul x10, x10, x9
-  movk x8, #10291, lsl 48
-  mul x9, x11, x9
-  and x10, x10, x4
-  and x4, x9, x4
-  mov x9, #22621
-  ins v7.d[0], x10
+  mul x7, x7, x9
+  adds x2, x5, x2
+  cinc x5, x6, hs
+  and x6, x10, x4
+  and x4, x7, x4
+  ins v7.d[0], x6
   ins v7.d[1], x4
+  add x3, x3, x5
   ucvtf.2d v7, v7
   mov x4, #16
-  movk x9, #33153, lsl 16
+  mov x5, #65535
   movk x4, #22847, lsl 32
   movk x4, #17151, lsl 48
-  movk x9, #17846, lsl 32
   dup.2d v9, x4
+  movk x5, #61439, lsl 16
   mov.16b v10, v5
   fmla.2d v10, v7, v9
-  movk x9, #47184, lsl 48
   fsub.2d v11, v6, v10
+  movk x5, #62867, lsl 32
   fmla.2d v11, v7, v9
-  mov x4, #41001
   add.2d v0, v0, v10
   add.2d v8, v8, v11
-  mov x10, #20728
-  movk x4, #57649, lsl 16
-  movk x10, #23588, lsl 16
-  movk x10, #7790, lsl 32
-  movk x4, #20082, lsl 32
-  movk x10, #17170, lsl 48
-  dup.2d v9, x10
+  movk x5, #49889, lsl 48
+  mov x4, #20728
+  movk x4, #23588, lsl 16
+  movk x4, #7790, lsl 32
+  mul x5, x5, x8
+  movk x4, #17170, lsl 48
+  dup.2d v9, x4
   mov.16b v10, v5
-  movk x4, #12388, lsl 48
+  mov x4, #1
   fmla.2d v10, v7, v9
   fsub.2d v11, v6, v10
+  movk x4, #61440, lsl 16
   fmla.2d v11, v7, v9
-  mul x10, x7, x5
   add.2d v1, v1, v10
   add.2d v0, v0, v11
-  umulh x7, x7, x5
-  mov x11, #16000
-  movk x11, #53891, lsl 16
-  movk x11, #5509, lsl 32
-  cmn x10, x6
-  cinc x7, x7, hs
-  movk x11, #17144, lsl 48
-  dup.2d v9, x11
-  mul x6, x8, x5
+  movk x4, #62867, lsl 32
+  mov x6, #16000
+  movk x6, #53891, lsl 16
+  movk x6, #5509, lsl 32
+  movk x4, #17377, lsl 48
+  movk x6, #17144, lsl 48
+  dup.2d v9, x6
   mov.16b v10, v5
+  mov x6, #28817
   fmla.2d v10, v7, v9
   fsub.2d v11, v6, v10
-  umulh x8, x8, x5
   fmla.2d v11, v7, v9
+  movk x6, #31161, lsl 16
   add.2d v2, v2, v10
-  adds x6, x6, x7
-  cinc x7, x8, hs
   add.2d v1, v1, v11
-  mov x8, #46800
-  movk x8, #2568, lsl 16
-  adds x0, x6, x0
-  cinc x6, x7, hs
-  movk x8, #1335, lsl 32
-  movk x8, #17188, lsl 48
-  dup.2d v9, x8
-  mul x7, x9, x5
+  mov x7, #46800
+  movk x6, #59464, lsl 32
+  movk x7, #2568, lsl 16
+  movk x7, #1335, lsl 32
+  movk x6, #10291, lsl 48
+  movk x7, #17188, lsl 48
+  dup.2d v9, x7
   mov.16b v10, v5
+  mov x7, #22621
   fmla.2d v10, v7, v9
-  umulh x8, x9, x5
   fsub.2d v11, v6, v10
   fmla.2d v11, v7, v9
+  movk x7, #33153, lsl 16
   add.2d v4, v4, v10
-  adds x6, x7, x6
-  cinc x7, x8, hs
   add.2d v2, v2, v11
-  mov x8, #39040
-  adds x1, x6, x1
-  cinc x6, x7, hs
-  movk x8, #14704, lsl 16
-  movk x8, #12839, lsl 32
-  movk x8, #17096, lsl 48
-  mul x7, x4, x5
-  dup.2d v9, x8
+  mov x9, #39040
+  movk x7, #17846, lsl 32
+  movk x9, #14704, lsl 16
+  movk x9, #12839, lsl 32
+  movk x9, #17096, lsl 48
+  movk x7, #47184, lsl 48
+  dup.2d v9, x9
   mov.16b v5, v5
-  umulh x4, x4, x5
   fmla.2d v5, v7, v9
+  mov x9, #41001
   fsub.2d v6, v6, v5
   fmla.2d v6, v7, v9
-  adds x5, x7, x6
-  cinc x4, x4, hs
+  movk x9, #57649, lsl 16
   add.2d v3, v3, v5
   add.2d v4, v4, v6
-  mov x6, #140737488355328
-  adds x2, x5, x2
-  cinc x4, x4, hs
-  dup.2d v5, x6
+  mov x10, #140737488355328
+  movk x9, #20082, lsl 32
+  dup.2d v5, x10
   and.16b v5, v3, v5
-  add x3, x3, x4
   cmeq.2d v5, v5, #0
-  mov x4, #2
-  movk x4, #57344, lsl 16
-  mov x5, #2
-  movk x4, #60199, lsl 32
-  movk x4, #3, lsl 48
-  movk x5, #57344, lsl 16
-  dup.2d v6, x4
+  movk x9, #12388, lsl 48
+  mov x10, #2
+  movk x10, #57344, lsl 16
+  movk x10, #60199, lsl 32
+  mul x11, x4, x5
+  movk x10, #3, lsl 48
+  dup.2d v6, x10
   bic.16b v6, v6, v5
-  mov x4, #10364
-  movk x5, #60199, lsl 32
-  movk x4, #11794, lsl 16
-  movk x4, #3895, lsl 32
-  movk x5, #34755, lsl 48
-  movk x4, #9, lsl 48
-  dup.2d v7, x4
+  umulh x4, x4, x5
+  mov x10, #10364
+  movk x10, #11794, lsl 16
+  movk x10, #3895, lsl 32
+  cmn x11, x8
+  cinc x4, x4, hs
+  movk x10, #9, lsl 48
+  dup.2d v7, x10
+  mul x8, x6, x5
   bic.16b v7, v7, v5
-  mov x4, #57634
-  mov x6, #26576
-  movk x6, #47696, lsl 16
-  movk x6, #688, lsl 32
-  movk x4, #62322, lsl 16
-  movk x6, #3, lsl 48
-  dup.2d v9, x6
-  movk x4, #53392, lsl 32
+  mov x10, #26576
+  movk x10, #47696, lsl 16
+  umulh x6, x6, x5
+  movk x10, #688, lsl 32
+  movk x10, #3, lsl 48
+  dup.2d v9, x10
+  adds x4, x8, x4
+  cinc x6, x6, hs
   bic.16b v9, v9, v5
-  mov x6, #46800
-  movk x6, #2568, lsl 16
-  movk x4, #20583, lsl 48
-  movk x6, #1335, lsl 32
-  movk x6, #4, lsl 48
-  mov x7, #45242
-  dup.2d v10, x6
+  mov x8, #46800
+  movk x8, #2568, lsl 16
+  adds x0, x4, x0
+  cinc x4, x6, hs
+  movk x8, #1335, lsl 32
+  movk x8, #4, lsl 48
+  dup.2d v10, x8
+  mul x6, x7, x5
   bic.16b v10, v10, v5
-  mov x6, #49763
-  movk x7, #770, lsl 16
-  movk x6, #40165, lsl 16
-  movk x6, #24776, lsl 32
-  movk x7, #35693, lsl 32
-  dup.2d v11, x6
+  mov x8, #49763
+  movk x8, #40165, lsl 16
+  umulh x7, x7, x5
+  movk x8, #24776, lsl 32
+  dup.2d v11, x8
+  adds x4, x6, x4
+  cinc x6, x7, hs
   bic.16b v5, v11, v5
   sub.2d v0, v0, v6
-  movk x7, #28832, lsl 48
   ssra.2d v0, v8, #52
+  adds x1, x4, x1
+  cinc x4, x6, hs
   sub.2d v6, v1, v7
   ssra.2d v6, v0, #52
-  mov x6, #16467
   sub.2d v7, v2, v9
+  mul x6, x9, x5
   ssra.2d v7, v6, #52
-  movk x6, #49763, lsl 16
   sub.2d v4, v4, v10
   ssra.2d v4, v7, #52
+  umulh x5, x9, x5
   sub.2d v5, v3, v5
-  movk x6, #40165, lsl 32
   ssra.2d v5, v4, #52
   ushr.2d v1, v6, #12
-  movk x6, #24776, lsl 48
+  adds x4, x6, x4
+  cinc x5, x5, hs
   ushr.2d v2, v7, #24
   ushr.2d v3, v4, #36
   sli.2d v0, v6, #52
-  subs x5, x0, x5
-  sbcs x4, x1, x4
-  sbcs x7, x2, x7
-  sbcs x6, x3, x6
+  adds x2, x4, x2
+  cinc x4, x5, hs
   sli.2d v1, v7, #40
   sli.2d v2, v4, #28
   sli.2d v3, v5, #16
-  tst x3, #9223372036854775808
-  csel x0, x5, x0, mi
-  csel x1, x4, x1, mi
-  csel x2, x7, x2, mi
-  csel x3, x6, x3, mi
+  add x3, x3, x4

--- a/block-multiplier/src/aarch64/montgomery_square_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_square_interleaved_3.s
@@ -14,726 +14,688 @@
   umulh x7, x0, x0
   movk x6, #18032, lsl 48
   dup.2d v6, x6
-  shl.2d v7, v1, #14
   mul x6, x0, x1
+  shl.2d v7, v1, #14
   shl.2d v8, v2, #26
   shl.2d v9, v3, #38
-  ushr.2d v3, v3, #14
   umulh x8, x0, x1
+  ushr.2d v3, v3, #14
   shl.2d v10, v0, #2
   usra.2d v7, v0, #50
-  usra.2d v8, v1, #38
   adds x7, x6, x7
   cinc x9, x8, hs
+  usra.2d v8, v1, #38
   usra.2d v9, v2, #26
+  mul x10, x0, x2
   and.16b v0, v10, v4
   and.16b v1, v7, v4
-  mul x10, x0, x2
   and.16b v2, v8, v4
-  and.16b v7, v9, v4
   umulh x11, x0, x2
+  and.16b v7, v9, v4
   mov x12, #13605374474286268416
-  dup.2d v8, x12
-  mov x12, #6440147467139809280
   adds x9, x10, x9
   cinc x13, x11, hs
+  dup.2d v8, x12
+  mov x12, #6440147467139809280
   dup.2d v9, x12
-  mov x12, #3688448094816436224
-  dup.2d v10, x12
   mul x12, x0, x3
+  mov x14, #3688448094816436224
+  dup.2d v10, x14
   mov x14, #9209861237972664320
+  umulh x0, x0, x3
   dup.2d v11, x14
   mov x14, #12218265789056155648
-  umulh x0, x0, x3
+  adds x13, x12, x13
+  cinc x15, x0, hs
   dup.2d v12, x14
   mov x14, #17739678932212383744
   dup.2d v13, x14
-  adds x13, x12, x13
-  cinc x14, x0, hs
-  mov x15, #2301339409586323456
-  dup.2d v14, x15
-  mov x15, #7822752552742551552
   adds x6, x6, x7
   cinc x7, x8, hs
-  dup.2d v15, x15
+  mov x8, #2301339409586323456
+  dup.2d v14, x8
+  mov x8, #7822752552742551552
+  mul x14, x1, x1
+  dup.2d v15, x8
   mov x8, #5071053180419178496
-  mul x15, x1, x1
+  umulh x16, x1, x1
   dup.2d v16, x8
   mov x8, #16352570246982270976
   dup.2d v17, x8
-  umulh x8, x1, x1
+  adds x7, x14, x7
+  cinc x8, x16, hs
   ucvtf.2d v0, v0
   ucvtf.2d v1, v1
-  ucvtf.2d v2, v2
-  adds x7, x15, x7
-  cinc x8, x8, hs
-  ucvtf.2d v7, v7
-  ucvtf.2d v3, v3
-  mov.16b v18, v5
   adds x7, x7, x9
   cinc x8, x8, hs
+  ucvtf.2d v2, v2
+  ucvtf.2d v7, v7
+  ucvtf.2d v3, v3
+  mul x9, x1, x2
+  mov.16b v18, v5
   fmla.2d v18, v0, v0
   fsub.2d v19, v6, v18
+  umulh x14, x1, x2
   fmla.2d v19, v0, v0
-  mul x9, x1, x2
   add.2d v10, v10, v18
+  adds x8, x9, x8
+  cinc x16, x14, hs
   add.2d v8, v8, v19
   mov.16b v18, v5
-  umulh x15, x1, x2
   fmla.2d v18, v0, v1
-  fsub.2d v19, v6, v18
-  adds x8, x9, x8
-  cinc x16, x15, hs
-  fmla.2d v19, v0, v1
-  add.2d v18, v18, v18
-  add.2d v19, v19, v19
   adds x8, x8, x13
   cinc x13, x16, hs
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v1
+  add.2d v18, v18, v18
+  mul x16, x1, x3
+  add.2d v19, v19, v19
   add.2d v12, v12, v18
+  umulh x1, x1, x3
   add.2d v10, v10, v19
   mov.16b v18, v5
-  mul x16, x1, x3
   fmla.2d v18, v0, v2
+  adds x13, x16, x13
+  cinc x17, x1, hs
   fsub.2d v19, v6, v18
   fmla.2d v19, v0, v2
-  umulh x1, x1, x3
+  adds x13, x13, x15
+  cinc x15, x17, hs
   add.2d v18, v18, v18
   add.2d v19, v19, v19
   add.2d v14, v14, v18
-  adds x13, x16, x13
-  cinc x17, x1, hs
+  adds x7, x10, x7
+  cinc x10, x11, hs
   add.2d v12, v12, v19
   mov.16b v18, v5
   fmla.2d v18, v0, v7
-  adds x13, x13, x14
-  cinc x14, x17, hs
+  adds x9, x9, x10
+  cinc x10, x14, hs
   fsub.2d v19, v6, v18
   fmla.2d v19, v0, v7
-  adds x7, x10, x7
-  cinc x10, x11, hs
+  adds x8, x9, x8
+  cinc x9, x10, hs
   add.2d v18, v18, v18
   add.2d v19, v19, v19
   add.2d v16, v16, v18
-  adds x9, x9, x10
-  cinc x10, x15, hs
+  mul x10, x2, x2
   add.2d v14, v14, v19
   mov.16b v18, v5
   fmla.2d v18, v0, v3
-  adds x8, x9, x8
-  cinc x9, x10, hs
+  umulh x11, x2, x2
   fsub.2d v19, v6, v18
   fmla.2d v19, v0, v3
-  add.2d v0, v18, v18
-  mul x10, x2, x2
-  add.2d v18, v19, v19
-  add.2d v0, v17, v0
-  add.2d v16, v16, v18
-  umulh x11, x2, x2
-  mov.16b v17, v5
-  fmla.2d v17, v1, v1
-  fsub.2d v18, v6, v17
   adds x9, x10, x9
   cinc x10, x11, hs
-  fmla.2d v18, v1, v1
-  add.2d v14, v14, v17
+  add.2d v0, v18, v18
+  add.2d v18, v19, v19
+  add.2d v0, v17, v0
   adds x9, x9, x13
   cinc x10, x10, hs
+  add.2d v16, v16, v18
+  mov.16b v17, v5
+  mul x11, x2, x3
+  fmla.2d v17, v1, v1
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v1
+  umulh x2, x2, x3
+  add.2d v14, v14, v17
   add.2d v12, v12, v18
   mov.16b v17, v5
-  fmla.2d v17, v1, v2
-  mul x11, x2, x3
-  fsub.2d v18, v6, v17
-  fmla.2d v18, v1, v2
-  add.2d v17, v17, v17
-  umulh x2, x2, x3
-  add.2d v18, v18, v18
-  add.2d v16, v16, v17
-  add.2d v14, v14, v18
   adds x10, x11, x10
   cinc x13, x2, hs
-  mov.16b v17, v5
-  fmla.2d v17, v1, v7
+  fmla.2d v17, v1, v2
   fsub.2d v18, v6, v17
-  adds x10, x10, x14
+  adds x10, x10, x15
   cinc x13, x13, hs
-  fmla.2d v18, v1, v7
+  fmla.2d v18, v1, v2
   add.2d v17, v17, v17
   add.2d v18, v18, v18
   adds x8, x12, x8
   cinc x0, x0, hs
-  add.2d v0, v0, v17
-  add.2d v16, v16, v18
+  add.2d v16, v16, v17
+  add.2d v14, v14, v18
   adds x0, x16, x0
   cinc x1, x1, hs
   mov.16b v17, v5
-  fmla.2d v17, v1, v3
+  fmla.2d v17, v1, v7
   fsub.2d v18, v6, v17
   adds x0, x0, x9
   cinc x1, x1, hs
+  fmla.2d v18, v1, v7
+  add.2d v17, v17, v17
+  add.2d v18, v18, v18
+  adds x1, x11, x1
+  cinc x2, x2, hs
+  add.2d v0, v0, v17
+  add.2d v16, v16, v18
+  adds x1, x1, x10
+  cinc x2, x2, hs
+  mov.16b v17, v5
+  fmla.2d v17, v1, v3
+  fsub.2d v18, v6, v17
+  mul x9, x3, x3
   fmla.2d v18, v1, v3
   add.2d v1, v17, v17
   add.2d v17, v18, v18
-  adds x1, x11, x1
-  cinc x2, x2, hs
+  umulh x3, x3, x3
   add.2d v1, v15, v1
   add.2d v0, v0, v17
-  mov.16b v15, v5
-  adds x1, x1, x10
-  cinc x2, x2, hs
-  fmla.2d v15, v2, v2
-  fsub.2d v17, v6, v15
-  fmla.2d v17, v2, v2
-  mul x9, x3, x3
-  add.2d v0, v0, v15
-  add.2d v15, v16, v17
-  mov.16b v16, v5
-  umulh x3, x3, x3
-  fmla.2d v16, v2, v7
-  fsub.2d v17, v6, v16
   adds x2, x9, x2
   cinc x3, x3, hs
-  fmla.2d v17, v2, v7
-  add.2d v16, v16, v16
-  add.2d v17, v17, v17
+  mov.16b v15, v5
+  fmla.2d v15, v2, v2
+  fsub.2d v17, v6, v15
   adds x2, x2, x13
   cinc x3, x3, hs
+  fmla.2d v17, v2, v2
+  add.2d v0, v0, v15
+  mov x9, #48718
+  add.2d v15, v16, v17
+  mov.16b v16, v5
+  fmla.2d v16, v2, v7
+  movk x9, #4732, lsl 16
+  fsub.2d v17, v6, v16
+  fmla.2d v17, v2, v7
+  add.2d v16, v16, v16
+  movk x9, #45078, lsl 32
+  add.2d v17, v17, v17
   add.2d v1, v1, v16
+  movk x9, #39852, lsl 48
   add.2d v0, v0, v17
   mov.16b v16, v5
-  mov x9, #48718
   fmla.2d v16, v2, v3
+  mov x10, #16676
   fsub.2d v17, v6, v16
   fmla.2d v17, v2, v3
-  movk x9, #4732, lsl 16
   add.2d v2, v16, v16
+  movk x10, #12692, lsl 16
   add.2d v16, v17, v17
   add.2d v2, v13, v2
-  movk x9, #45078, lsl 32
+  movk x10, #20986, lsl 32
   add.2d v1, v1, v16
   mov.16b v13, v5
   fmla.2d v13, v7, v7
-  movk x9, #39852, lsl 48
+  movk x10, #2848, lsl 48
   fsub.2d v16, v6, v13
   fmla.2d v16, v7, v7
-  mov x10, #16676
+  mov x11, #51052
   add.2d v2, v2, v13
   add.2d v1, v1, v16
   mov.16b v13, v5
-  movk x10, #12692, lsl 16
+  movk x11, #24721, lsl 16
   fmla.2d v13, v7, v3
   fsub.2d v16, v6, v13
   fmla.2d v16, v7, v3
-  movk x10, #20986, lsl 32
+  movk x11, #61092, lsl 32
   add.2d v7, v13, v13
   add.2d v13, v16, v16
+  movk x11, #45156, lsl 48
   add.2d v7, v11, v7
-  movk x10, #2848, lsl 48
   add.2d v2, v2, v13
   mov.16b v11, v5
+  mov x12, #3197
   fmla.2d v11, v3, v3
-  mov x11, #51052
   fsub.2d v13, v6, v11
   fmla.2d v13, v3, v3
+  movk x12, #18936, lsl 16
   add.2d v3, v9, v11
-  movk x11, #24721, lsl 16
   add.2d v7, v7, v13
+  movk x12, #10922, lsl 32
   usra.2d v10, v8, #52
-  movk x11, #61092, lsl 32
   usra.2d v12, v10, #52
   usra.2d v14, v12, #52
+  movk x12, #11014, lsl 48
   usra.2d v15, v14, #52
-  movk x11, #45156, lsl 48
   and.16b v8, v8, v4
+  mul x13, x9, x5
   and.16b v9, v10, v4
   and.16b v10, v12, v4
-  mov x12, #3197
   and.16b v4, v14, v4
+  umulh x9, x9, x5
   ucvtf.2d v8, v8
-  mov x13, #37864
-  movk x12, #18936, lsl 16
-  movk x13, #1815, lsl 16
-  movk x13, #28960, lsl 32
-  movk x13, #17153, lsl 48
-  movk x12, #10922, lsl 32
-  dup.2d v11, x13
+  mov x14, #37864
+  movk x14, #1815, lsl 16
+  adds x8, x13, x8
+  cinc x9, x9, hs
+  movk x14, #28960, lsl 32
+  movk x14, #17153, lsl 48
+  mul x13, x10, x5
+  dup.2d v11, x14
   mov.16b v12, v5
   fmla.2d v12, v8, v11
-  movk x12, #11014, lsl 48
+  umulh x10, x10, x5
   fsub.2d v13, v6, v12
   fmla.2d v13, v8, v11
   add.2d v0, v0, v12
-  mul x13, x9, x5
-  add.2d v11, v15, v13
-  mov x14, #46128
-  umulh x9, x9, x5
-  movk x14, #29964, lsl 16
-  movk x14, #7587, lsl 32
-  movk x14, #17161, lsl 48
-  adds x8, x13, x8
-  cinc x9, x9, hs
-  dup.2d v12, x14
-  mov.16b v13, v5
-  fmla.2d v13, v8, v12
-  mul x13, x10, x5
-  fsub.2d v14, v6, v13
-  fmla.2d v14, v8, v12
-  add.2d v1, v1, v13
-  umulh x10, x10, x5
-  add.2d v0, v0, v14
-  mov x14, #52826
-  movk x14, #57790, lsl 16
   adds x9, x13, x9
   cinc x10, x10, hs
-  movk x14, #55431, lsl 32
-  movk x14, #17196, lsl 48
-  dup.2d v12, x14
+  add.2d v11, v15, v13
+  mov x13, #46128
   adds x0, x9, x0
   cinc x9, x10, hs
-  mov.16b v13, v5
-  fmla.2d v13, v8, v12
+  movk x13, #29964, lsl 16
+  movk x13, #7587, lsl 32
+  movk x13, #17161, lsl 48
   mul x10, x11, x5
+  dup.2d v12, x13
+  mov.16b v13, v5
+  umulh x11, x11, x5
+  fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
   fmla.2d v14, v8, v12
-  add.2d v2, v2, v13
-  umulh x11, x11, x5
-  add.2d v1, v1, v14
-  mov x13, #31276
-  movk x13, #21262, lsl 16
   adds x9, x10, x9
   cinc x10, x11, hs
-  movk x13, #2304, lsl 32
-  movk x13, #17182, lsl 48
-  dup.2d v12, x13
+  add.2d v1, v1, v13
+  add.2d v0, v0, v14
+  mov x11, #52826
   adds x1, x9, x1
   cinc x9, x10, hs
+  movk x11, #57790, lsl 16
+  movk x11, #55431, lsl 32
+  mul x10, x12, x5
+  movk x11, #17196, lsl 48
+  dup.2d v12, x11
+  mov.16b v13, v5
+  umulh x5, x12, x5
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  adds x9, x10, x9
+  cinc x5, x5, hs
+  fmla.2d v14, v8, v12
+  add.2d v2, v2, v13
+  add.2d v1, v1, v14
+  adds x2, x9, x2
+  cinc x5, x5, hs
+  mov x9, #31276
+  movk x9, #21262, lsl 16
+  movk x9, #2304, lsl 32
+  add x3, x3, x5
+  movk x9, #17182, lsl 48
+  dup.2d v12, x9
+  mov x5, #56431
   mov.16b v13, v5
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
-  mul x10, x12, x5
+  movk x5, #30457, lsl 16
   fmla.2d v14, v8, v12
   add.2d v7, v7, v13
   add.2d v2, v2, v14
-  umulh x5, x12, x5
-  mov x11, #28672
-  movk x11, #24515, lsl 16
-  adds x9, x10, x9
-  cinc x5, x5, hs
-  movk x11, #54929, lsl 32
-  movk x11, #17064, lsl 48
-  dup.2d v12, x11
-  adds x2, x9, x2
-  cinc x5, x5, hs
+  movk x5, #30012, lsl 32
+  mov x9, #28672
+  movk x9, #24515, lsl 16
+  movk x5, #6382, lsl 48
+  movk x9, #54929, lsl 32
+  movk x9, #17064, lsl 48
+  dup.2d v12, x9
+  mov x9, #59151
   mov.16b v13, v5
   fmla.2d v13, v8, v12
+  movk x9, #41769, lsl 16
   fsub.2d v14, v6, v13
-  add x3, x3, x5
   fmla.2d v14, v8, v12
   add.2d v3, v3, v13
+  movk x9, #32276, lsl 32
   add.2d v7, v7, v14
-  mov x5, #56431
   ucvtf.2d v8, v9
-  mov x9, #44768
-  movk x9, #51919, lsl 16
-  movk x5, #30457, lsl 16
-  movk x9, #6346, lsl 32
-  movk x9, #17133, lsl 48
-  dup.2d v9, x9
-  movk x5, #30012, lsl 32
+  mov x10, #44768
+  movk x9, #21677, lsl 48
+  movk x10, #51919, lsl 16
+  movk x10, #6346, lsl 32
+  mov x11, #34015
+  movk x10, #17133, lsl 48
+  dup.2d v9, x10
   mov.16b v12, v5
+  movk x11, #20342, lsl 16
   fmla.2d v12, v8, v9
-  movk x5, #6382, lsl 48
   fsub.2d v13, v6, v12
   fmla.2d v13, v8, v9
+  movk x11, #13935, lsl 32
   add.2d v0, v0, v12
-  mov x9, #59151
   add.2d v9, v11, v13
+  movk x11, #11030, lsl 48
   mov x10, #47492
   movk x10, #23630, lsl 16
-  movk x9, #41769, lsl 16
   movk x10, #49985, lsl 32
+  mov x12, #13689
   movk x10, #17168, lsl 48
   dup.2d v11, x10
-  movk x9, #32276, lsl 32
+  movk x12, #8159, lsl 16
   mov.16b v12, v5
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
-  movk x9, #21677, lsl 48
+  movk x12, #215, lsl 32
   fmla.2d v13, v8, v11
   add.2d v1, v1, v12
   add.2d v0, v0, v13
-  mov x10, #34015
-  mov x11, #57936
-  movk x11, #54828, lsl 16
-  movk x10, #20342, lsl 16
-  movk x11, #18292, lsl 32
-  movk x11, #17197, lsl 48
-  dup.2d v11, x11
-  movk x10, #13935, lsl 32
+  movk x12, #4913, lsl 48
+  mov x10, #57936
+  movk x10, #54828, lsl 16
+  mul x13, x5, x6
+  movk x10, #18292, lsl 32
+  movk x10, #17197, lsl 48
+  dup.2d v11, x10
+  umulh x5, x5, x6
   mov.16b v12, v5
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
-  movk x10, #11030, lsl 48
+  adds x8, x13, x8
+  cinc x5, x5, hs
   fmla.2d v13, v8, v11
   add.2d v2, v2, v12
+  mul x10, x9, x6
   add.2d v1, v1, v13
-  mov x11, #13689
-  mov x12, #17708
-  movk x12, #43915, lsl 16
-  movk x12, #64348, lsl 32
-  movk x11, #8159, lsl 16
-  movk x12, #17188, lsl 48
-  dup.2d v11, x12
-  mov.16b v12, v5
-  movk x11, #215, lsl 32
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
-  movk x11, #4913, lsl 48
-  fmla.2d v13, v8, v11
-  add.2d v7, v7, v12
-  add.2d v2, v2, v13
-  mul x12, x5, x6
-  mov x13, #29184
-  movk x13, #20789, lsl 16
-  movk x13, #19197, lsl 32
-  umulh x5, x5, x6
-  movk x13, #17083, lsl 48
+  mov x13, #17708
+  movk x13, #43915, lsl 16
+  umulh x9, x9, x6
+  movk x13, #64348, lsl 32
+  movk x13, #17188, lsl 48
+  adds x5, x10, x5
+  cinc x9, x9, hs
   dup.2d v11, x13
   mov.16b v12, v5
-  adds x8, x12, x8
-  cinc x5, x5, hs
   fmla.2d v12, v8, v11
+  adds x0, x5, x0
+  cinc x5, x9, hs
   fsub.2d v13, v6, v12
   fmla.2d v13, v8, v11
-  mul x12, x9, x6
+  add.2d v7, v7, v12
+  mul x9, x11, x6
+  add.2d v2, v2, v13
+  mov x10, #29184
+  umulh x11, x11, x6
+  movk x10, #20789, lsl 16
+  movk x10, #19197, lsl 32
+  movk x10, #17083, lsl 48
+  adds x5, x9, x5
+  cinc x9, x11, hs
+  dup.2d v11, x10
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  adds x1, x5, x1
+  cinc x5, x9, hs
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v11
+  mul x9, x12, x6
   add.2d v3, v3, v12
   add.2d v7, v7, v13
   ucvtf.2d v8, v10
-  umulh x9, x9, x6
-  mov x13, #58856
-  movk x13, #14953, lsl 16
-  adds x5, x12, x5
-  cinc x9, x9, hs
-  movk x13, #15155, lsl 32
-  movk x13, #17181, lsl 48
-  dup.2d v10, x13
-  adds x0, x5, x0
-  cinc x5, x9, hs
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  mul x9, x10, x6
-  fmla.2d v12, v8, v10
-  add.2d v0, v0, v11
-  add.2d v9, v9, v12
-  umulh x10, x10, x6
-  mov x12, #35392
-  movk x12, #12477, lsl 16
-  movk x12, #56780, lsl 32
-  adds x5, x9, x5
-  cinc x9, x10, hs
-  movk x12, #17142, lsl 48
-  dup.2d v10, x12
-  mov.16b v11, v5
-  adds x1, x5, x1
-  cinc x5, x9, hs
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  mul x9, x11, x6
-  fmla.2d v12, v8, v10
-  add.2d v1, v1, v11
-  add.2d v0, v0, v12
-  umulh x6, x11, x6
-  mov x10, #9848
-  movk x10, #54501, lsl 16
-  movk x10, #31540, lsl 32
+  umulh x6, x12, x6
+  mov x10, #58856
+  movk x10, #14953, lsl 16
   adds x5, x9, x5
   cinc x6, x6, hs
-  movk x10, #17170, lsl 48
+  movk x10, #15155, lsl 32
+  movk x10, #17181, lsl 48
   dup.2d v10, x10
-  mov.16b v11, v5
   adds x2, x5, x2
   cinc x5, x6, hs
+  mov.16b v11, v5
   fmla.2d v11, v8, v10
   fsub.2d v12, v6, v11
-  fmla.2d v12, v8, v10
   add x3, x3, x5
+  fmla.2d v12, v8, v10
+  add.2d v0, v0, v11
+  mov x5, #61005
+  add.2d v9, v9, v12
+  mov x6, #35392
+  movk x6, #12477, lsl 16
+  movk x5, #58262, lsl 16
+  movk x6, #56780, lsl 32
+  movk x6, #17142, lsl 48
+  movk x5, #32851, lsl 32
+  dup.2d v10, x6
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  movk x5, #11582, lsl 48
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  mov x6, #37581
+  add.2d v0, v0, v12
+  mov x9, #9848
+  movk x6, #43836, lsl 16
+  movk x9, #54501, lsl 16
+  movk x9, #31540, lsl 32
+  movk x9, #17170, lsl 48
+  movk x6, #36286, lsl 32
+  dup.2d v10, x9
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  movk x6, #51783, lsl 48
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  mov x9, #10899
   add.2d v2, v2, v11
   add.2d v1, v1, v12
-  mov x5, #9584
-  mov x6, #61005
-  movk x5, #63883, lsl 16
-  movk x5, #18253, lsl 32
-  movk x6, #58262, lsl 16
-  movk x5, #17190, lsl 48
-  dup.2d v10, x5
+  mov x10, #9584
+  movk x9, #30709, lsl 16
+  movk x10, #63883, lsl 16
+  movk x10, #18253, lsl 32
+  movk x9, #61551, lsl 32
+  movk x10, #17190, lsl 48
+  dup.2d v10, x10
   mov.16b v11, v5
-  movk x6, #32851, lsl 32
+  movk x9, #45784, lsl 48
   fmla.2d v11, v8, v10
   fsub.2d v12, v6, v11
   fmla.2d v12, v8, v10
-  movk x6, #11582, lsl 48
+  mov x10, #36612
   add.2d v7, v7, v11
   add.2d v2, v2, v12
-  mov x5, #51712
-  mov x9, #37581
-  movk x5, #16093, lsl 16
-  movk x5, #30633, lsl 32
-  movk x5, #17068, lsl 48
-  movk x9, #43836, lsl 16
-  dup.2d v10, x5
+  movk x10, #63402, lsl 16
+  mov x11, #51712
+  movk x11, #16093, lsl 16
+  movk x11, #30633, lsl 32
+  movk x10, #47623, lsl 32
+  movk x11, #17068, lsl 48
+  dup.2d v10, x11
   mov.16b v11, v5
+  movk x10, #9430, lsl 48
   fmla.2d v11, v8, v10
-  movk x9, #36286, lsl 32
   fsub.2d v12, v6, v11
+  mul x11, x5, x7
   fmla.2d v12, v8, v10
-  movk x9, #51783, lsl 48
   add.2d v3, v3, v11
   add.2d v7, v7, v12
+  umulh x5, x5, x7
   ucvtf.2d v4, v4
-  mov x5, #10899
-  mov x10, #34724
-  movk x10, #40393, lsl 16
-  movk x10, #23752, lsl 32
-  movk x5, #30709, lsl 16
-  movk x10, #17184, lsl 48
-  dup.2d v8, x10
+  mov x12, #34724
+  adds x8, x11, x8
+  cinc x5, x5, hs
+  movk x12, #40393, lsl 16
+  movk x12, #23752, lsl 32
+  movk x12, #17184, lsl 48
+  mul x11, x6, x7
+  dup.2d v8, x12
   mov.16b v10, v5
-  movk x5, #61551, lsl 32
   fmla.2d v10, v4, v8
+  umulh x6, x6, x7
   fsub.2d v11, v6, v10
   fmla.2d v11, v4, v8
-  movk x5, #45784, lsl 48
+  adds x5, x11, x5
+  cinc x6, x6, hs
   add.2d v0, v0, v10
   add.2d v8, v9, v11
-  mov x10, #25532
-  mov x11, #36612
-  movk x10, #31025, lsl 16
-  movk x10, #10002, lsl 32
-  movk x10, #17199, lsl 48
-  movk x11, #63402, lsl 16
-  dup.2d v9, x10
+  mov x11, #25532
+  adds x0, x5, x0
+  cinc x5, x6, hs
+  movk x11, #31025, lsl 16
+  movk x11, #10002, lsl 32
+  movk x11, #17199, lsl 48
+  mul x6, x9, x7
+  dup.2d v9, x11
   mov.16b v10, v5
-  movk x11, #47623, lsl 32
+  umulh x9, x9, x7
   fmla.2d v10, v4, v9
   fsub.2d v11, v6, v10
   fmla.2d v11, v4, v9
-  movk x11, #9430, lsl 48
+  adds x5, x6, x5
+  cinc x6, x9, hs
   add.2d v1, v1, v10
   add.2d v0, v0, v11
-  mov x10, #18830
-  mul x12, x6, x7
-  movk x10, #2465, lsl 16
-  movk x10, #36348, lsl 32
-  movk x10, #17194, lsl 48
-  umulh x6, x6, x7
-  dup.2d v9, x10
+  adds x1, x5, x1
+  cinc x5, x6, hs
+  mov x6, #18830
+  movk x6, #2465, lsl 16
+  movk x6, #36348, lsl 32
+  mul x9, x10, x7
+  movk x6, #17194, lsl 48
+  dup.2d v9, x6
   mov.16b v10, v5
+  umulh x6, x10, x7
   fmla.2d v10, v4, v9
-  adds x8, x12, x8
-  cinc x6, x6, hs
   fsub.2d v11, v6, v10
+  adds x5, x9, x5
+  cinc x6, x6, hs
   fmla.2d v11, v4, v9
   add.2d v2, v2, v10
-  mul x10, x9, x7
   add.2d v1, v1, v11
-  mov x12, #21566
-  umulh x9, x9, x7
-  movk x12, #43708, lsl 16
-  movk x12, #57685, lsl 32
-  movk x12, #17185, lsl 48
-  adds x6, x10, x6
-  cinc x9, x9, hs
-  dup.2d v9, x12
+  adds x2, x5, x2
+  cinc x5, x6, hs
+  mov x6, #21566
+  movk x6, #43708, lsl 16
+  movk x6, #57685, lsl 32
+  add x3, x3, x5
+  movk x6, #17185, lsl 48
+  dup.2d v9, x6
+  mov x5, #65535
   mov.16b v10, v5
   fmla.2d v10, v4, v9
-  adds x0, x6, x0
-  cinc x6, x9, hs
   fsub.2d v11, v6, v10
+  movk x5, #61439, lsl 16
   fmla.2d v11, v4, v9
   add.2d v7, v7, v10
-  mul x9, x5, x7
+  movk x5, #62867, lsl 32
   add.2d v2, v2, v11
-  mov x10, #3072
-  movk x10, #8058, lsl 16
-  umulh x5, x5, x7
-  movk x10, #46097, lsl 32
-  movk x10, #17047, lsl 48
-  dup.2d v9, x10
-  adds x6, x9, x6
-  cinc x5, x5, hs
+  mov x6, #3072
+  movk x6, #8058, lsl 16
+  movk x5, #49889, lsl 48
+  movk x6, #46097, lsl 32
+  movk x6, #17047, lsl 48
+  dup.2d v9, x6
+  mul x5, x5, x8
   mov.16b v10, v5
   fmla.2d v10, v4, v9
-  adds x1, x6, x1
-  cinc x5, x5, hs
+  mov x6, #1
   fsub.2d v11, v6, v10
   fmla.2d v11, v4, v9
   add.2d v3, v3, v10
-  mul x6, x11, x7
+  movk x6, #61440, lsl 16
   add.2d v4, v7, v11
-  mov x9, #65535
-  movk x9, #61439, lsl 16
-  umulh x7, x11, x7
-  movk x9, #62867, lsl 32
-  movk x9, #1, lsl 48
-  umov x10, v8.d[0]
-  adds x5, x6, x5
-  cinc x6, x7, hs
-  umov x7, v8.d[1]
-  mul x10, x10, x9
-  mul x7, x7, x9
-  adds x2, x5, x2
-  cinc x5, x6, hs
-  and x6, x10, x4
+  mov x7, #65535
+  movk x6, #62867, lsl 32
+  movk x7, #61439, lsl 16
+  movk x7, #62867, lsl 32
+  movk x7, #1, lsl 48
+  movk x6, #17377, lsl 48
+  umov x9, v8.d[0]
+  umov x10, v8.d[1]
+  mul x9, x9, x7
+  mov x11, #28817
+  mul x7, x10, x7
+  and x9, x9, x4
+  movk x11, #31161, lsl 16
   and x4, x7, x4
-  ins v7.d[0], x6
+  ins v7.d[0], x9
   ins v7.d[1], x4
-  add x3, x3, x5
   ucvtf.2d v7, v7
+  movk x11, #59464, lsl 32
   mov x4, #16
-  mov x5, #65535
   movk x4, #22847, lsl 32
   movk x4, #17151, lsl 48
+  movk x11, #10291, lsl 48
   dup.2d v9, x4
-  movk x5, #61439, lsl 16
   mov.16b v10, v5
+  mov x4, #22621
   fmla.2d v10, v7, v9
   fsub.2d v11, v6, v10
-  movk x5, #62867, lsl 32
   fmla.2d v11, v7, v9
+  movk x4, #33153, lsl 16
   add.2d v0, v0, v10
   add.2d v8, v8, v11
-  movk x5, #49889, lsl 48
-  mov x4, #20728
-  movk x4, #23588, lsl 16
-  movk x4, #7790, lsl 32
-  mul x5, x5, x8
-  movk x4, #17170, lsl 48
-  dup.2d v9, x4
+  movk x4, #17846, lsl 32
+  mov x7, #20728
+  movk x7, #23588, lsl 16
+  movk x7, #7790, lsl 32
+  movk x4, #47184, lsl 48
+  movk x7, #17170, lsl 48
+  dup.2d v9, x7
   mov.16b v10, v5
-  mov x4, #1
+  mov x7, #41001
   fmla.2d v10, v7, v9
   fsub.2d v11, v6, v10
-  movk x4, #61440, lsl 16
+  movk x7, #57649, lsl 16
   fmla.2d v11, v7, v9
   add.2d v1, v1, v10
   add.2d v0, v0, v11
-  movk x4, #62867, lsl 32
-  mov x6, #16000
-  movk x6, #53891, lsl 16
-  movk x6, #5509, lsl 32
-  movk x4, #17377, lsl 48
-  movk x6, #17144, lsl 48
-  dup.2d v9, x6
-  mov.16b v10, v5
-  mov x6, #28817
-  fmla.2d v10, v7, v9
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v7, v9
-  movk x6, #31161, lsl 16
-  add.2d v2, v2, v10
-  add.2d v1, v1, v11
-  mov x7, #46800
-  movk x6, #59464, lsl 32
-  movk x7, #2568, lsl 16
-  movk x7, #1335, lsl 32
-  movk x6, #10291, lsl 48
-  movk x7, #17188, lsl 48
-  dup.2d v9, x7
-  mov.16b v10, v5
-  mov x7, #22621
-  fmla.2d v10, v7, v9
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v7, v9
-  movk x7, #33153, lsl 16
-  add.2d v4, v4, v10
-  add.2d v2, v2, v11
-  mov x9, #39040
-  movk x7, #17846, lsl 32
-  movk x9, #14704, lsl 16
-  movk x9, #12839, lsl 32
-  movk x9, #17096, lsl 48
-  movk x7, #47184, lsl 48
+  movk x7, #20082, lsl 32
+  mov x9, #16000
+  movk x9, #53891, lsl 16
+  movk x9, #5509, lsl 32
+  movk x7, #12388, lsl 48
+  movk x9, #17144, lsl 48
   dup.2d v9, x9
-  mov.16b v5, v5
-  fmla.2d v5, v7, v9
-  mov x9, #41001
-  fsub.2d v6, v6, v5
-  fmla.2d v6, v7, v9
-  movk x9, #57649, lsl 16
-  add.2d v3, v3, v5
-  add.2d v4, v4, v6
-  mov x10, #140737488355328
-  movk x9, #20082, lsl 32
-  dup.2d v5, x10
-  and.16b v5, v3, v5
-  cmeq.2d v5, v5, #0
-  movk x9, #12388, lsl 48
-  mov x10, #2
-  movk x10, #57344, lsl 16
-  movk x10, #60199, lsl 32
-  mul x11, x4, x5
-  movk x10, #3, lsl 48
-  dup.2d v6, x10
-  bic.16b v6, v6, v5
-  umulh x4, x4, x5
-  mov x10, #10364
-  movk x10, #11794, lsl 16
-  movk x10, #3895, lsl 32
-  cmn x11, x8
-  cinc x4, x4, hs
-  movk x10, #9, lsl 48
-  dup.2d v7, x10
-  mul x8, x6, x5
-  bic.16b v7, v7, v5
-  mov x10, #26576
-  movk x10, #47696, lsl 16
+  mul x9, x6, x5
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  fsub.2d v11, v6, v10
   umulh x6, x6, x5
-  movk x10, #688, lsl 32
-  movk x10, #3, lsl 48
-  dup.2d v9, x10
-  adds x4, x8, x4
+  fmla.2d v11, v7, v9
+  add.2d v2, v2, v10
+  cmn x9, x8
   cinc x6, x6, hs
-  bic.16b v9, v9, v5
+  add.2d v9, v1, v11
   mov x8, #46800
   movk x8, #2568, lsl 16
-  adds x0, x4, x0
-  cinc x4, x6, hs
+  mul x9, x11, x5
   movk x8, #1335, lsl 32
-  movk x8, #4, lsl 48
-  dup.2d v10, x8
-  mul x6, x7, x5
-  bic.16b v10, v10, v5
-  mov x8, #49763
-  movk x8, #40165, lsl 16
-  umulh x7, x7, x5
-  movk x8, #24776, lsl 32
-  dup.2d v11, x8
-  adds x4, x6, x4
-  cinc x6, x7, hs
-  bic.16b v5, v11, v5
-  sub.2d v0, v0, v6
+  movk x8, #17188, lsl 48
+  dup.2d v1, x8
+  umulh x8, x11, x5
+  mov.16b v10, v5
+  fmla.2d v10, v7, v1
+  adds x6, x9, x6
+  cinc x8, x8, hs
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v1
+  add.2d v1, v4, v10
+  adds x0, x6, x0
+  cinc x6, x8, hs
+  add.2d v4, v2, v11
+  mov x8, #39040
+  movk x8, #14704, lsl 16
+  mul x9, x4, x5
+  movk x8, #12839, lsl 32
+  movk x8, #17096, lsl 48
+  umulh x4, x4, x5
+  dup.2d v2, x8
+  mov.16b v5, v5
+  fmla.2d v5, v7, v2
+  adds x6, x9, x6
+  cinc x4, x4, hs
+  fsub.2d v6, v6, v5
+  fmla.2d v6, v7, v2
+  adds x1, x6, x1
+  cinc x4, x4, hs
+  add.2d v5, v3, v5
+  add.2d v6, v1, v6
   ssra.2d v0, v8, #52
-  adds x1, x4, x1
-  cinc x4, x6, hs
-  sub.2d v6, v1, v7
-  ssra.2d v6, v0, #52
-  sub.2d v7, v2, v9
-  mul x6, x9, x5
-  ssra.2d v7, v6, #52
-  sub.2d v4, v4, v10
-  ssra.2d v4, v7, #52
-  umulh x5, x9, x5
-  sub.2d v5, v3, v5
-  ssra.2d v5, v4, #52
-  ushr.2d v1, v6, #12
+  mul x6, x7, x5
+  ssra.2d v9, v0, #52
+  ssra.2d v4, v9, #52
+  ssra.2d v6, v4, #52
+  umulh x5, x7, x5
+  ssra.2d v5, v6, #52
+  ushr.2d v1, v9, #12
   adds x4, x6, x4
   cinc x5, x5, hs
-  ushr.2d v2, v7, #24
-  ushr.2d v3, v4, #36
-  sli.2d v0, v6, #52
+  ushr.2d v2, v4, #24
+  ushr.2d v3, v6, #36
+  sli.2d v0, v9, #52
   adds x2, x4, x2
   cinc x4, x5, hs
-  sli.2d v1, v7, #40
-  sli.2d v2, v4, #28
+  sli.2d v1, v4, #40
+  sli.2d v2, v6, #28
   sli.2d v3, v5, #16
   add x3, x3, x4

--- a/block-multiplier/src/aarch64/montgomery_square_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_square_interleaved_4.s
@@ -12,725 +12,711 @@
   dup.2d v4, x8
   umulh x10, x0, x0
   mov x11, #5075556780046548992
-  mul x12, x0, x1
   dup.2d v5, x11
-  mov x11, #1
+  mul x11, x0, x1
+  mov x12, #1
   umulh x13, x0, x1
-  movk x11, #18032, lsl 48
-  adds x10, x12, x10
-  cinc x14, x13, hs
-  dup.2d v6, x11
-  mul x11, x0, x2
+  movk x12, #18032, lsl 48
+  dup.2d v6, x12
+  adds x10, x11, x10
+  cinc x12, x13, hs
   shl.2d v7, v1, #14
+  mul x14, x0, x2
   shl.2d v8, v2, #26
   umulh x15, x0, x2
   shl.2d v9, v3, #38
-  adds x14, x11, x14
-  cinc x16, x15, hs
   ushr.2d v3, v3, #14
-  mul x17, x0, x3
+  adds x12, x14, x12
+  cinc x16, x15, hs
   shl.2d v10, v0, #2
-  umulh x0, x0, x3
+  mul x17, x0, x3
   usra.2d v7, v0, #50
   usra.2d v8, v1, #38
+  umulh x0, x0, x3
+  usra.2d v9, v2, #26
   adds x16, x17, x16
   cinc x20, x0, hs
-  usra.2d v9, v2, #26
-  adds x10, x12, x10
-  cinc x12, x13, hs
   and.16b v0, v10, v4
-  mul x13, x1, x1
   and.16b v1, v7, v4
+  adds x10, x11, x10
+  cinc x11, x13, hs
   and.16b v2, v8, v4
-  umulh x21, x1, x1
+  mul x13, x1, x1
   and.16b v7, v9, v4
-  adds x12, x13, x12
+  umulh x21, x1, x1
+  mov x22, #13605374474286268416
+  dup.2d v8, x22
+  adds x11, x13, x11
   cinc x13, x21, hs
-  mov x21, #13605374474286268416
-  adds x12, x12, x14
-  cinc x13, x13, hs
-  dup.2d v8, x21
-  mul x14, x1, x2
   mov x21, #6440147467139809280
-  dup.2d v9, x21
-  umulh x21, x1, x2
-  mov x22, #3688448094816436224
-  adds x13, x14, x13
-  cinc x23, x21, hs
-  dup.2d v10, x22
-  adds x13, x13, x16
-  cinc x16, x23, hs
-  mov x22, #9209861237972664320
-  dup.2d v11, x22
-  mul x22, x1, x3
-  mov x23, #12218265789056155648
-  umulh x1, x1, x3
-  dup.2d v12, x23
-  adds x16, x22, x16
-  cinc x23, x1, hs
-  mov x24, #17739678932212383744
-  adds x16, x16, x20
-  cinc x20, x23, hs
-  dup.2d v13, x24
-  mov x23, #2301339409586323456
   adds x11, x11, x12
-  cinc x12, x15, hs
+  cinc x12, x13, hs
+  dup.2d v9, x21
+  mov x13, #3688448094816436224
+  mul x21, x1, x2
+  dup.2d v10, x13
+  umulh x13, x1, x2
+  mov x22, #9209861237972664320
+  adds x12, x21, x12
+  cinc x23, x13, hs
+  dup.2d v11, x22
+  mov x22, #12218265789056155648
+  adds x12, x12, x16
+  cinc x16, x23, hs
+  dup.2d v12, x22
+  mul x22, x1, x3
+  mov x23, #17739678932212383744
+  dup.2d v13, x23
+  umulh x1, x1, x3
+  mov x23, #2301339409586323456
+  adds x16, x22, x16
+  cinc x24, x1, hs
   dup.2d v14, x23
+  mov x23, #7822752552742551552
+  adds x16, x16, x20
+  cinc x20, x24, hs
+  dup.2d v15, x23
+  adds x11, x14, x11
+  cinc x14, x15, hs
+  mov x15, #5071053180419178496
+  adds x14, x21, x14
+  cinc x13, x13, hs
+  dup.2d v16, x15
+  mov x15, #16352570246982270976
   adds x12, x14, x12
-  cinc x14, x21, hs
-  mov x15, #7822752552742551552
-  adds x12, x12, x13
-  cinc x13, x14, hs
-  dup.2d v15, x15
-  mov x14, #5071053180419178496
-  mul x15, x2, x2
-  dup.2d v16, x14
-  umulh x14, x2, x2
-  mov x21, #16352570246982270976
-  adds x13, x15, x13
-  cinc x14, x14, hs
-  dup.2d v17, x21
-  adds x13, x13, x16
-  cinc x14, x14, hs
+  cinc x13, x13, hs
+  dup.2d v17, x15
+  mul x14, x2, x2
   ucvtf.2d v0, v0
   ucvtf.2d v1, v1
-  mul x15, x2, x3
+  umulh x15, x2, x2
   ucvtf.2d v2, v2
-  umulh x2, x2, x3
-  ucvtf.2d v7, v7
-  adds x14, x15, x14
-  cinc x16, x2, hs
-  ucvtf.2d v3, v3
-  mov.16b v18, v5
-  adds x14, x14, x20
-  cinc x16, x16, hs
-  fmla.2d v18, v0, v0
-  adds x12, x17, x12
-  cinc x0, x0, hs
-  fsub.2d v19, v6, v18
-  adds x0, x22, x0
-  cinc x1, x1, hs
-  fmla.2d v19, v0, v0
-  adds x0, x0, x13
-  cinc x1, x1, hs
-  add.2d v10, v10, v18
-  add.2d v8, v8, v19
-  adds x1, x15, x1
-  cinc x2, x2, hs
-  mov.16b v18, v5
-  adds x1, x1, x14
-  cinc x2, x2, hs
-  fmla.2d v18, v0, v1
-  mul x13, x3, x3
-  fsub.2d v19, v6, v18
-  fmla.2d v19, v0, v1
-  umulh x3, x3, x3
-  add.2d v18, v18, v18
-  adds x2, x13, x2
-  cinc x3, x3, hs
-  add.2d v19, v19, v19
-  adds x2, x2, x16
-  cinc x3, x3, hs
-  add.2d v12, v12, v18
-  mov x13, #48718
-  add.2d v10, v10, v19
-  mov.16b v18, v5
-  movk x13, #4732, lsl 16
-  fmla.2d v18, v0, v2
-  movk x13, #45078, lsl 32
-  fsub.2d v19, v6, v18
-  movk x13, #39852, lsl 48
-  fmla.2d v19, v0, v2
-  add.2d v18, v18, v18
-  mov x14, #16676
-  add.2d v19, v19, v19
-  movk x14, #12692, lsl 16
-  add.2d v14, v14, v18
-  movk x14, #20986, lsl 32
-  add.2d v12, v12, v19
-  movk x14, #2848, lsl 48
-  mov.16b v18, v5
-  fmla.2d v18, v0, v7
-  mov x15, #51052
-  fsub.2d v19, v6, v18
-  movk x15, #24721, lsl 16
-  fmla.2d v19, v0, v7
-  movk x15, #61092, lsl 32
-  add.2d v18, v18, v18
-  add.2d v19, v19, v19
-  movk x15, #45156, lsl 48
-  add.2d v16, v16, v18
-  mov x16, #3197
-  add.2d v14, v14, v19
-  movk x16, #18936, lsl 16
-  mov.16b v18, v5
-  movk x16, #10922, lsl 32
-  fmla.2d v18, v0, v3
-  fsub.2d v19, v6, v18
-  movk x16, #11014, lsl 48
-  fmla.2d v19, v0, v3
-  mul x17, x13, x9
-  add.2d v0, v18, v18
-  umulh x13, x13, x9
-  add.2d v18, v19, v19
-  add.2d v0, v17, v0
-  adds x12, x17, x12
-  cinc x13, x13, hs
-  add.2d v16, v16, v18
-  mul x17, x14, x9
-  mov.16b v17, v5
-  umulh x14, x14, x9
-  fmla.2d v17, v1, v1
-  adds x13, x17, x13
-  cinc x14, x14, hs
-  fsub.2d v18, v6, v17
-  fmla.2d v18, v1, v1
-  adds x0, x13, x0
-  cinc x13, x14, hs
-  add.2d v14, v14, v17
-  mul x14, x15, x9
-  add.2d v12, v12, v18
-  umulh x15, x15, x9
-  mov.16b v17, v5
-  fmla.2d v17, v1, v2
   adds x13, x14, x13
   cinc x14, x15, hs
+  ucvtf.2d v7, v7
+  adds x13, x13, x16
+  cinc x14, x14, hs
+  ucvtf.2d v3, v3
+  mov.16b v18, v5
+  mul x15, x2, x3
+  fmla.2d v18, v0, v0
+  umulh x2, x2, x3
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v0
+  adds x14, x15, x14
+  cinc x16, x2, hs
+  add.2d v10, v10, v18
+  adds x14, x14, x20
+  cinc x16, x16, hs
+  add.2d v8, v8, v19
+  mov.16b v18, v5
+  adds x12, x17, x12
+  cinc x0, x0, hs
+  fmla.2d v18, v0, v1
+  adds x0, x22, x0
+  cinc x1, x1, hs
+  fsub.2d v19, v6, v18
+  adds x0, x0, x13
+  cinc x1, x1, hs
+  fmla.2d v19, v0, v1
+  add.2d v18, v18, v18
+  adds x1, x15, x1
+  cinc x2, x2, hs
+  add.2d v19, v19, v19
+  adds x1, x1, x14
+  cinc x2, x2, hs
+  add.2d v12, v12, v18
+  add.2d v10, v10, v19
+  mul x13, x3, x3
+  mov.16b v18, v5
+  umulh x3, x3, x3
+  fmla.2d v18, v0, v2
+  adds x2, x13, x2
+  cinc x3, x3, hs
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v2
+  adds x2, x2, x16
+  cinc x3, x3, hs
+  add.2d v18, v18, v18
+  mov x13, #48718
+  add.2d v19, v19, v19
+  add.2d v14, v14, v18
+  movk x13, #4732, lsl 16
+  add.2d v12, v12, v19
+  movk x13, #45078, lsl 32
+  mov.16b v18, v5
+  fmla.2d v18, v0, v7
+  movk x13, #39852, lsl 48
+  fsub.2d v19, v6, v18
+  mov x14, #16676
+  fmla.2d v19, v0, v7
+  movk x14, #12692, lsl 16
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  movk x14, #20986, lsl 32
+  add.2d v16, v16, v18
+  movk x14, #2848, lsl 48
+  add.2d v14, v14, v19
+  mov.16b v18, v5
+  mov x15, #51052
+  fmla.2d v18, v0, v3
+  movk x15, #24721, lsl 16
+  fsub.2d v19, v6, v18
+  movk x15, #61092, lsl 32
+  fmla.2d v19, v0, v3
+  add.2d v0, v18, v18
+  movk x15, #45156, lsl 48
+  add.2d v18, v19, v19
+  mov x16, #3197
+  add.2d v0, v17, v0
+  add.2d v16, v16, v18
+  movk x16, #18936, lsl 16
+  mov.16b v17, v5
+  movk x16, #10922, lsl 32
+  fmla.2d v17, v1, v1
   fsub.2d v18, v6, v17
-  adds x1, x13, x1
-  cinc x13, x14, hs
+  movk x16, #11014, lsl 48
+  fmla.2d v18, v1, v1
+  mul x17, x13, x9
+  add.2d v14, v14, v17
+  umulh x13, x13, x9
+  add.2d v12, v12, v18
+  mov.16b v17, v5
+  adds x12, x17, x12
+  cinc x13, x13, hs
+  fmla.2d v17, v1, v2
+  mul x17, x14, x9
+  fsub.2d v18, v6, v17
   fmla.2d v18, v1, v2
-  mul x14, x16, x9
+  umulh x14, x14, x9
   add.2d v17, v17, v17
-  umulh x9, x16, x9
+  adds x13, x17, x13
+  cinc x14, x14, hs
   add.2d v18, v18, v18
   add.2d v16, v16, v17
-  adds x13, x14, x13
-  cinc x9, x9, hs
+  adds x0, x13, x0
+  cinc x13, x14, hs
   add.2d v14, v14, v18
-  adds x2, x13, x2
-  cinc x9, x9, hs
+  mul x14, x15, x9
   mov.16b v17, v5
-  add x3, x3, x9
+  umulh x15, x15, x9
   fmla.2d v17, v1, v7
   fsub.2d v18, v6, v17
-  mov x9, #56431
+  adds x13, x14, x13
+  cinc x14, x15, hs
   fmla.2d v18, v1, v7
-  movk x9, #30457, lsl 16
+  adds x1, x13, x1
+  cinc x13, x14, hs
   add.2d v17, v17, v17
-  movk x9, #30012, lsl 32
   add.2d v18, v18, v18
-  movk x9, #6382, lsl 48
+  mul x14, x16, x9
   add.2d v0, v0, v17
+  umulh x9, x16, x9
   add.2d v16, v16, v18
-  mov x13, #59151
+  adds x13, x14, x13
+  cinc x9, x9, hs
   mov.16b v17, v5
-  movk x13, #41769, lsl 16
   fmla.2d v17, v1, v3
-  movk x13, #32276, lsl 32
+  adds x2, x13, x2
+  cinc x9, x9, hs
   fsub.2d v18, v6, v17
+  add x3, x3, x9
   fmla.2d v18, v1, v3
-  movk x13, #21677, lsl 48
   add.2d v1, v17, v17
-  mov x14, #34015
+  mov x9, #56431
   add.2d v17, v18, v18
-  movk x14, #20342, lsl 16
+  movk x9, #30457, lsl 16
   add.2d v1, v15, v1
-  movk x14, #13935, lsl 32
   add.2d v0, v0, v17
+  movk x9, #30012, lsl 32
   mov.16b v15, v5
-  movk x14, #11030, lsl 48
+  movk x9, #6382, lsl 48
   fmla.2d v15, v2, v2
-  mov x15, #13689
+  mov x13, #59151
   fsub.2d v17, v6, v15
-  movk x15, #8159, lsl 16
   fmla.2d v17, v2, v2
+  movk x13, #41769, lsl 16
   add.2d v0, v0, v15
-  movk x15, #215, lsl 32
+  movk x13, #32276, lsl 32
   add.2d v15, v16, v17
-  movk x15, #4913, lsl 48
   mov.16b v16, v5
-  mul x16, x9, x10
+  movk x13, #21677, lsl 48
   fmla.2d v16, v2, v7
-  umulh x9, x9, x10
+  mov x14, #34015
   fsub.2d v17, v6, v16
+  movk x14, #20342, lsl 16
   fmla.2d v17, v2, v7
+  add.2d v16, v16, v16
+  movk x14, #13935, lsl 32
+  add.2d v17, v17, v17
+  movk x14, #11030, lsl 48
+  add.2d v1, v1, v16
+  add.2d v0, v0, v17
+  mov x15, #13689
+  mov.16b v16, v5
+  movk x15, #8159, lsl 16
+  fmla.2d v16, v2, v3
+  fsub.2d v17, v6, v16
+  movk x15, #215, lsl 32
+  fmla.2d v17, v2, v3
+  movk x15, #4913, lsl 48
+  add.2d v2, v16, v16
+  mul x16, x9, x10
+  add.2d v16, v17, v17
+  add.2d v2, v13, v2
+  umulh x9, x9, x10
+  add.2d v1, v1, v16
   adds x12, x16, x12
   cinc x9, x9, hs
-  add.2d v16, v16, v16
+  mov.16b v13, v5
+  fmla.2d v13, v7, v7
   mul x16, x13, x10
-  add.2d v17, v17, v17
+  fsub.2d v16, v6, v13
   umulh x13, x13, x10
-  add.2d v1, v1, v16
-  add.2d v0, v0, v17
+  fmla.2d v16, v7, v7
   adds x9, x16, x9
   cinc x13, x13, hs
-  mov.16b v16, v5
+  add.2d v2, v2, v13
+  add.2d v1, v1, v16
   adds x0, x9, x0
   cinc x9, x13, hs
-  fmla.2d v16, v2, v3
+  mov.16b v13, v5
   mul x13, x14, x10
-  fsub.2d v17, v6, v16
-  fmla.2d v17, v2, v3
+  fmla.2d v13, v7, v3
+  fsub.2d v16, v6, v13
   umulh x14, x14, x10
-  add.2d v2, v16, v16
+  fmla.2d v16, v7, v3
   adds x9, x13, x9
   cinc x13, x14, hs
-  add.2d v16, v17, v17
+  add.2d v7, v13, v13
+  add.2d v13, v16, v16
   adds x1, x9, x1
   cinc x9, x13, hs
-  add.2d v2, v13, v2
+  add.2d v7, v11, v7
   mul x13, x15, x10
-  add.2d v1, v1, v16
-  mov.16b v13, v5
+  add.2d v2, v2, v13
   umulh x10, x15, x10
-  fmla.2d v13, v7, v7
+  mov.16b v11, v5
+  fmla.2d v11, v3, v3
   adds x9, x13, x9
   cinc x10, x10, hs
-  fsub.2d v16, v6, v13
+  fsub.2d v13, v6, v11
   adds x2, x9, x2
   cinc x9, x10, hs
-  fmla.2d v16, v7, v7
-  add.2d v2, v2, v13
-  add x3, x3, x9
-  add.2d v1, v1, v16
-  mov x9, #61005
-  mov.16b v13, v5
-  movk x9, #58262, lsl 16
-  fmla.2d v13, v7, v3
-  movk x9, #32851, lsl 32
-  fsub.2d v16, v6, v13
-  fmla.2d v16, v7, v3
-  movk x9, #11582, lsl 48
-  add.2d v7, v13, v13
-  mov x10, #37581
-  add.2d v13, v16, v16
-  movk x10, #43836, lsl 16
-  add.2d v7, v11, v7
-  add.2d v2, v2, v13
-  movk x10, #36286, lsl 32
-  mov.16b v11, v5
-  movk x10, #51783, lsl 48
-  fmla.2d v11, v3, v3
-  mov x13, #10899
-  fsub.2d v13, v6, v11
-  movk x13, #30709, lsl 16
   fmla.2d v13, v3, v3
   add.2d v3, v9, v11
-  movk x13, #61551, lsl 32
+  add x3, x3, x9
   add.2d v7, v7, v13
-  movk x13, #45784, lsl 48
+  mov x9, #61005
   usra.2d v10, v8, #52
-  mov x14, #36612
+  movk x9, #58262, lsl 16
   usra.2d v12, v10, #52
   usra.2d v14, v12, #52
-  movk x14, #63402, lsl 16
+  movk x9, #32851, lsl 32
   usra.2d v15, v14, #52
-  movk x14, #47623, lsl 32
+  movk x9, #11582, lsl 48
   and.16b v8, v8, v4
-  movk x14, #9430, lsl 48
   and.16b v9, v10, v4
-  mul x15, x9, x11
+  mov x10, #37581
   and.16b v10, v12, v4
+  movk x10, #43836, lsl 16
   and.16b v4, v14, v4
-  umulh x9, x9, x11
   ucvtf.2d v8, v8
-  adds x12, x15, x12
-  cinc x9, x9, hs
-  mov x15, #37864
-  mul x16, x10, x11
-  movk x15, #1815, lsl 16
-  movk x15, #28960, lsl 32
-  umulh x10, x10, x11
-  movk x15, #17153, lsl 48
-  adds x9, x16, x9
-  cinc x10, x10, hs
-  dup.2d v11, x15
-  adds x0, x9, x0
-  cinc x9, x10, hs
+  movk x10, #36286, lsl 32
+  mov x13, #37864
+  movk x10, #51783, lsl 48
+  movk x13, #1815, lsl 16
+  mov x14, #10899
+  movk x13, #28960, lsl 32
+  movk x13, #17153, lsl 48
+  movk x14, #30709, lsl 16
+  dup.2d v11, x13
+  movk x14, #61551, lsl 32
   mov.16b v12, v5
-  mul x10, x13, x11
   fmla.2d v12, v8, v11
+  movk x14, #45784, lsl 48
   fsub.2d v13, v6, v12
-  umulh x13, x13, x11
+  mov x13, #36612
   fmla.2d v13, v8, v11
-  adds x9, x10, x9
-  cinc x10, x13, hs
   add.2d v0, v0, v12
-  adds x1, x9, x1
-  cinc x9, x10, hs
+  movk x13, #63402, lsl 16
   add.2d v11, v15, v13
-  mov x10, #46128
-  mul x13, x14, x11
-  movk x10, #29964, lsl 16
-  umulh x11, x14, x11
-  movk x10, #7587, lsl 32
-  adds x9, x13, x9
-  cinc x11, x11, hs
-  movk x10, #17161, lsl 48
-  adds x2, x9, x2
-  cinc x9, x11, hs
-  dup.2d v12, x10
+  movk x13, #47623, lsl 32
+  mov x15, #46128
+  movk x13, #9430, lsl 48
+  movk x15, #29964, lsl 16
+  movk x15, #7587, lsl 32
+  mul x16, x9, x11
+  movk x15, #17161, lsl 48
+  umulh x9, x9, x11
+  dup.2d v12, x15
   mov.16b v13, v5
-  add x3, x3, x9
+  adds x12, x16, x12
+  cinc x9, x9, hs
   fmla.2d v13, v8, v12
-  mov x9, #65535
+  mul x15, x10, x11
   fsub.2d v14, v6, v13
-  movk x9, #61439, lsl 16
+  umulh x10, x10, x11
   fmla.2d v14, v8, v12
   add.2d v1, v1, v13
-  movk x9, #62867, lsl 32
+  adds x9, x15, x9
+  cinc x10, x10, hs
   add.2d v0, v0, v14
-  movk x9, #49889, lsl 48
+  adds x0, x9, x0
+  cinc x9, x10, hs
   mov x10, #52826
-  mul x9, x9, x12
   movk x10, #57790, lsl 16
-  mov x11, #1
+  mul x15, x14, x11
   movk x10, #55431, lsl 32
+  umulh x14, x14, x11
   movk x10, #17196, lsl 48
-  movk x11, #61440, lsl 16
   dup.2d v12, x10
-  movk x11, #62867, lsl 32
+  adds x9, x15, x9
+  cinc x10, x14, hs
   mov.16b v13, v5
-  movk x11, #17377, lsl 48
+  adds x1, x9, x1
+  cinc x9, x10, hs
   fmla.2d v13, v8, v12
+  mul x10, x13, x11
   fsub.2d v14, v6, v13
-  mov x10, #28817
   fmla.2d v14, v8, v12
-  movk x10, #31161, lsl 16
+  umulh x11, x13, x11
   add.2d v2, v2, v13
-  movk x10, #59464, lsl 32
+  adds x9, x10, x9
+  cinc x10, x11, hs
   add.2d v1, v1, v14
-  movk x10, #10291, lsl 48
-  mov x13, #31276
-  movk x13, #21262, lsl 16
-  mov x14, #22621
-  movk x13, #2304, lsl 32
-  movk x14, #33153, lsl 16
-  movk x13, #17182, lsl 48
-  movk x14, #17846, lsl 32
-  dup.2d v12, x13
+  mov x11, #31276
+  adds x2, x9, x2
+  cinc x9, x10, hs
+  movk x11, #21262, lsl 16
+  add x3, x3, x9
+  movk x11, #2304, lsl 32
+  mov x9, #65535
+  movk x11, #17182, lsl 48
+  dup.2d v12, x11
+  movk x9, #61439, lsl 16
   mov.16b v13, v5
-  movk x14, #47184, lsl 48
+  movk x9, #62867, lsl 32
   fmla.2d v13, v8, v12
-  mov x13, #41001
   fsub.2d v14, v6, v13
-  movk x13, #57649, lsl 16
+  movk x9, #49889, lsl 48
   fmla.2d v14, v8, v12
-  movk x13, #20082, lsl 32
+  mul x9, x9, x12
   add.2d v7, v7, v13
   add.2d v2, v2, v14
-  movk x13, #12388, lsl 48
-  mov x15, #28672
-  mul x16, x11, x9
-  movk x15, #24515, lsl 16
-  umulh x11, x11, x9
-  movk x15, #54929, lsl 32
-  movk x15, #17064, lsl 48
-  cmn x16, x12
-  cinc x11, x11, hs
-  dup.2d v12, x15
-  mul x12, x10, x9
+  mov x10, #1
+  mov x11, #28672
+  movk x10, #61440, lsl 16
+  movk x11, #24515, lsl 16
+  movk x10, #62867, lsl 32
+  movk x11, #54929, lsl 32
+  movk x11, #17064, lsl 48
+  movk x10, #17377, lsl 48
+  dup.2d v12, x11
+  mov x11, #28817
   mov.16b v13, v5
-  umulh x10, x10, x9
   fmla.2d v13, v8, v12
-  adds x11, x12, x11
-  cinc x10, x10, hs
+  movk x11, #31161, lsl 16
   fsub.2d v14, v6, v13
+  movk x11, #59464, lsl 32
   fmla.2d v14, v8, v12
-  adds x0, x11, x0
-  cinc x10, x10, hs
+  movk x11, #10291, lsl 48
   add.2d v3, v3, v13
-  mul x11, x14, x9
   add.2d v7, v7, v14
-  umulh x12, x14, x9
+  mov x13, #22621
   ucvtf.2d v8, v9
+  movk x13, #33153, lsl 16
   mov x14, #44768
+  movk x14, #51919, lsl 16
+  movk x13, #17846, lsl 32
+  movk x14, #6346, lsl 32
+  movk x13, #47184, lsl 48
+  movk x14, #17133, lsl 48
+  dup.2d v9, x14
+  mov x14, #41001
+  mov.16b v12, v5
+  movk x14, #57649, lsl 16
+  fmla.2d v12, v8, v9
+  movk x14, #20082, lsl 32
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v9
+  movk x14, #12388, lsl 48
+  add.2d v0, v0, v12
+  mul x15, x10, x9
+  add.2d v9, v11, v13
+  mov x16, #47492
+  umulh x10, x10, x9
+  movk x16, #23630, lsl 16
+  cmn x15, x12
+  cinc x10, x10, hs
+  movk x16, #49985, lsl 32
+  mul x12, x11, x9
+  movk x16, #17168, lsl 48
+  dup.2d v11, x16
+  umulh x11, x11, x9
+  mov.16b v12, v5
+  adds x10, x12, x10
+  cinc x11, x11, hs
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  adds x0, x10, x0
+  cinc x10, x11, hs
+  fmla.2d v13, v8, v11
+  mul x11, x13, x9
+  add.2d v1, v1, v12
+  add.2d v0, v0, v13
+  umulh x12, x13, x9
+  mov x13, #57936
   adds x10, x11, x10
   cinc x11, x12, hs
-  movk x14, #51919, lsl 16
+  movk x13, #54828, lsl 16
   adds x1, x10, x1
   cinc x10, x11, hs
-  movk x14, #6346, lsl 32
-  mul x11, x13, x9
-  movk x14, #17133, lsl 48
-  umulh x9, x13, x9
-  dup.2d v9, x14
+  movk x13, #18292, lsl 32
+  movk x13, #17197, lsl 48
+  mul x11, x14, x9
+  dup.2d v11, x13
+  umulh x9, x14, x9
   mov.16b v12, v5
+  fmla.2d v12, v8, v11
   adds x10, x11, x10
   cinc x9, x9, hs
-  fmla.2d v12, v8, v9
+  fsub.2d v13, v6, v12
   adds x2, x10, x2
   cinc x9, x9, hs
-  fsub.2d v13, v6, v12
-  add x3, x3, x9
-  fmla.2d v13, v8, v9
-  add.2d v0, v0, v12
-  mov x9, #2
-  add.2d v9, v11, v13
-  movk x9, #57344, lsl 16
-  mov x10, #47492
-  movk x9, #60199, lsl 32
-  movk x10, #23630, lsl 16
-  movk x9, #34755, lsl 48
-  movk x10, #49985, lsl 32
-  movk x10, #17168, lsl 48
-  mov x11, #57634
-  dup.2d v11, x10
-  movk x11, #62322, lsl 16
-  mov.16b v12, v5
-  movk x11, #53392, lsl 32
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
-  movk x11, #20583, lsl 48
-  fmla.2d v13, v8, v11
-  mov x10, #45242
-  add.2d v1, v1, v12
-  movk x10, #770, lsl 16
-  add.2d v0, v0, v13
-  movk x10, #35693, lsl 32
-  mov x12, #57936
-  movk x12, #54828, lsl 16
-  movk x10, #28832, lsl 48
-  movk x12, #18292, lsl 32
-  mov x13, #16467
-  movk x12, #17197, lsl 48
-  movk x13, #49763, lsl 16
-  dup.2d v11, x12
-  mov.16b v12, v5
-  movk x13, #40165, lsl 32
-  fmla.2d v12, v8, v11
-  movk x13, #24776, lsl 48
-  fsub.2d v13, v6, v12
-  subs x9, x0, x9
-  sbcs x11, x1, x11
-  sbcs x10, x2, x10
-  sbcs x12, x3, x13
   fmla.2d v13, v8, v11
   add.2d v2, v2, v12
-  tst x3, #9223372036854775808
-  csel x0, x9, x0, mi
-  csel x1, x11, x1, mi
-  csel x2, x10, x2, mi
-  csel x3, x12, x3, mi
+  add x3, x3, x9
   add.2d v1, v1, v13
   mul x9, x4, x4
   mov x10, #17708
   umulh x11, x4, x4
   movk x10, #43915, lsl 16
-  mul x12, x4, x5
   movk x10, #64348, lsl 32
+  mul x12, x4, x5
   movk x10, #17188, lsl 48
   umulh x13, x4, x5
   dup.2d v11, x10
+  mov.16b v12, v5
   adds x10, x12, x11
   cinc x11, x13, hs
-  mov.16b v12, v5
-  mul x14, x4, x6
   fmla.2d v12, v8, v11
+  mul x14, x4, x6
   fsub.2d v13, v6, v12
   umulh x15, x4, x6
   fmla.2d v13, v8, v11
+  add.2d v7, v7, v12
   adds x11, x14, x11
   cinc x16, x15, hs
-  add.2d v7, v7, v12
-  mul x17, x4, x7
   add.2d v2, v2, v13
-  umulh x4, x4, x7
+  mul x17, x4, x7
   mov x20, #29184
   movk x20, #20789, lsl 16
+  umulh x4, x4, x7
+  movk x20, #19197, lsl 32
   adds x16, x17, x16
   cinc x21, x4, hs
-  movk x20, #19197, lsl 32
+  movk x20, #17083, lsl 48
+  dup.2d v11, x20
   adds x10, x12, x10
   cinc x12, x13, hs
-  movk x20, #17083, lsl 48
-  mul x13, x5, x5
-  dup.2d v11, x20
   mov.16b v12, v5
-  umulh x20, x5, x5
+  mul x13, x5, x5
   fmla.2d v12, v8, v11
+  umulh x20, x5, x5
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v11
   adds x12, x13, x12
   cinc x13, x20, hs
-  fsub.2d v13, v6, v12
+  add.2d v3, v3, v12
   adds x11, x12, x11
   cinc x12, x13, hs
-  fmla.2d v13, v8, v11
-  mul x13, x5, x6
-  add.2d v3, v3, v12
   add.2d v7, v7, v13
-  umulh x20, x5, x6
   ucvtf.2d v8, v10
+  mul x13, x5, x6
+  mov x20, #58856
+  umulh x22, x5, x6
+  movk x20, #14953, lsl 16
   adds x12, x13, x12
-  cinc x22, x20, hs
-  mov x23, #58856
+  cinc x23, x22, hs
+  movk x20, #15155, lsl 32
+  movk x20, #17181, lsl 48
   adds x12, x12, x16
-  cinc x16, x22, hs
-  movk x23, #14953, lsl 16
-  movk x23, #15155, lsl 32
-  mul x22, x5, x7
-  movk x23, #17181, lsl 48
-  umulh x5, x5, x7
-  dup.2d v10, x23
-  adds x16, x22, x16
-  cinc x23, x5, hs
+  cinc x16, x23, hs
+  dup.2d v10, x20
+  mul x20, x5, x7
   mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  umulh x5, x5, x7
+  fsub.2d v12, v6, v11
+  adds x16, x20, x16
+  cinc x23, x5, hs
+  fmla.2d v12, v8, v10
+  add.2d v0, v0, v11
   adds x16, x16, x21
   cinc x21, x23, hs
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
+  add.2d v9, v9, v12
   adds x11, x14, x11
   cinc x14, x15, hs
-  fmla.2d v12, v8, v10
+  mov x15, #35392
   adds x13, x13, x14
-  cinc x14, x20, hs
-  add.2d v0, v0, v11
+  cinc x14, x22, hs
+  movk x15, #12477, lsl 16
+  movk x15, #56780, lsl 32
   adds x12, x13, x12
   cinc x13, x14, hs
-  add.2d v9, v9, v12
-  mov x14, #35392
-  mul x15, x6, x6
-  movk x14, #12477, lsl 16
-  umulh x20, x6, x6
-  movk x14, #56780, lsl 32
-  adds x13, x15, x13
-  cinc x15, x20, hs
-  movk x14, #17142, lsl 48
-  adds x13, x13, x16
-  cinc x15, x15, hs
-  dup.2d v10, x14
+  movk x15, #17142, lsl 48
+  mul x14, x6, x6
+  dup.2d v10, x15
   mov.16b v11, v5
-  mul x14, x6, x7
+  umulh x15, x6, x6
   fmla.2d v11, v8, v10
-  umulh x6, x6, x7
-  fsub.2d v12, v6, v11
-  adds x15, x14, x15
-  cinc x16, x6, hs
-  fmla.2d v12, v8, v10
-  add.2d v1, v1, v11
-  adds x15, x15, x21
-  cinc x16, x16, hs
-  add.2d v0, v0, v12
-  adds x12, x17, x12
-  cinc x4, x4, hs
-  mov x17, #9848
-  adds x4, x22, x4
-  cinc x5, x5, hs
-  movk x17, #54501, lsl 16
-  adds x4, x4, x13
-  cinc x5, x5, hs
-  movk x17, #31540, lsl 32
-  movk x17, #17170, lsl 48
-  adds x5, x14, x5
-  cinc x6, x6, hs
-  dup.2d v10, x17
-  adds x5, x5, x15
-  cinc x6, x6, hs
-  mov.16b v11, v5
-  mul x13, x7, x7
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  umulh x7, x7, x7
-  fmla.2d v12, v8, v10
-  adds x6, x13, x6
-  cinc x7, x7, hs
-  add.2d v2, v2, v11
-  adds x6, x6, x16
-  cinc x7, x7, hs
-  add.2d v1, v1, v12
-  mov x13, #48718
-  mov x14, #9584
-  movk x14, #63883, lsl 16
-  movk x13, #4732, lsl 16
-  movk x14, #18253, lsl 32
-  movk x13, #45078, lsl 32
-  movk x14, #17190, lsl 48
-  movk x13, #39852, lsl 48
-  dup.2d v10, x14
-  mov.16b v11, v5
-  mov x14, #16676
-  fmla.2d v11, v8, v10
-  movk x14, #12692, lsl 16
-  fsub.2d v12, v6, v11
-  movk x14, #20986, lsl 32
-  fmla.2d v12, v8, v10
-  movk x14, #2848, lsl 48
-  add.2d v7, v7, v11
-  add.2d v2, v2, v12
-  mov x15, #51052
-  mov x16, #51712
-  movk x15, #24721, lsl 16
-  movk x16, #16093, lsl 16
-  movk x15, #61092, lsl 32
-  movk x16, #30633, lsl 32
-  movk x16, #17068, lsl 48
-  movk x15, #45156, lsl 48
-  dup.2d v10, x16
-  mov x16, #3197
-  mov.16b v11, v5
-  movk x16, #18936, lsl 16
-  fmla.2d v11, v8, v10
-  movk x16, #10922, lsl 32
-  fsub.2d v12, v6, v11
-  fmla.2d v12, v8, v10
-  movk x16, #11014, lsl 48
-  add.2d v3, v3, v11
-  mul x17, x13, x9
-  add.2d v7, v7, v12
-  umulh x13, x13, x9
-  ucvtf.2d v4, v4
-  mov x20, #34724
-  adds x12, x17, x12
-  cinc x13, x13, hs
-  movk x20, #40393, lsl 16
-  mul x17, x14, x9
-  movk x20, #23752, lsl 32
-  umulh x14, x14, x9
-  movk x20, #17184, lsl 48
-  adds x13, x17, x13
-  cinc x14, x14, hs
-  dup.2d v8, x20
-  mov.16b v10, v5
-  adds x4, x13, x4
-  cinc x13, x14, hs
-  fmla.2d v10, v4, v8
-  mul x14, x15, x9
-  fsub.2d v11, v6, v10
-  umulh x15, x15, x9
-  fmla.2d v11, v4, v8
-  add.2d v0, v0, v10
   adds x13, x14, x13
   cinc x14, x15, hs
-  add.2d v8, v9, v11
-  adds x5, x13, x5
-  cinc x13, x14, hs
-  mov x14, #25532
-  mul x15, x16, x9
-  movk x14, #31025, lsl 16
-  umulh x9, x16, x9
-  movk x14, #10002, lsl 32
-  movk x14, #17199, lsl 48
-  adds x13, x15, x13
-  cinc x9, x9, hs
-  dup.2d v9, x14
-  adds x6, x13, x6
-  cinc x9, x9, hs
+  fsub.2d v12, v6, v11
+  adds x13, x13, x16
+  cinc x14, x14, hs
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  mul x15, x6, x7
+  add.2d v0, v0, v12
+  umulh x6, x6, x7
+  mov x16, #9848
+  movk x16, #54501, lsl 16
+  adds x14, x15, x14
+  cinc x22, x6, hs
+  movk x16, #31540, lsl 32
+  adds x14, x14, x21
+  cinc x21, x22, hs
+  movk x16, #17170, lsl 48
+  dup.2d v10, x16
+  adds x12, x17, x12
+  cinc x4, x4, hs
+  mov.16b v11, v5
+  adds x4, x20, x4
+  cinc x5, x5, hs
+  fmla.2d v11, v8, v10
+  adds x4, x4, x13
+  cinc x5, x5, hs
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  adds x5, x15, x5
+  cinc x6, x6, hs
+  add.2d v2, v2, v11
+  adds x5, x5, x14
+  cinc x6, x6, hs
+  add.2d v1, v1, v12
+  mov x13, #9584
+  mul x14, x7, x7
+  movk x13, #63883, lsl 16
+  umulh x7, x7, x7
+  movk x13, #18253, lsl 32
+  adds x6, x14, x6
+  cinc x7, x7, hs
+  movk x13, #17190, lsl 48
+  dup.2d v10, x13
+  adds x6, x6, x21
+  cinc x7, x7, hs
+  mov.16b v11, v5
+  mov x13, #48718
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  movk x13, #4732, lsl 16
+  fmla.2d v12, v8, v10
+  movk x13, #45078, lsl 32
+  add.2d v7, v7, v11
+  add.2d v2, v2, v12
+  movk x13, #39852, lsl 48
+  mov x14, #51712
+  mov x15, #16676
+  movk x14, #16093, lsl 16
+  movk x15, #12692, lsl 16
+  movk x14, #30633, lsl 32
+  movk x14, #17068, lsl 48
+  movk x15, #20986, lsl 32
+  dup.2d v10, x14
+  movk x15, #2848, lsl 48
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  mov x14, #51052
+  fsub.2d v12, v6, v11
+  movk x14, #24721, lsl 16
+  fmla.2d v12, v8, v10
+  movk x14, #61092, lsl 32
+  add.2d v3, v3, v11
+  add.2d v7, v7, v12
+  movk x14, #45156, lsl 48
+  ucvtf.2d v4, v4
+  mov x16, #3197
+  mov x17, #34724
+  movk x17, #40393, lsl 16
+  movk x16, #18936, lsl 16
+  movk x17, #23752, lsl 32
+  movk x16, #10922, lsl 32
+  movk x17, #17184, lsl 48
+  dup.2d v8, x17
+  movk x16, #11014, lsl 48
   mov.16b v10, v5
-  add x7, x7, x9
+  mul x17, x13, x9
+  fmla.2d v10, v4, v8
+  umulh x13, x13, x9
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v8
+  adds x12, x17, x12
+  cinc x13, x13, hs
+  add.2d v0, v0, v10
+  mul x17, x15, x9
+  add.2d v8, v9, v11
+  mov x20, #25532
+  umulh x15, x15, x9
+  movk x20, #31025, lsl 16
+  adds x13, x17, x13
+  cinc x15, x15, hs
+  movk x20, #10002, lsl 32
+  movk x20, #17199, lsl 48
+  adds x4, x13, x4
+  cinc x13, x15, hs
+  dup.2d v9, x20
+  mul x15, x14, x9
+  mov.16b v10, v5
+  umulh x14, x14, x9
   fmla.2d v10, v4, v9
   fsub.2d v11, v6, v10
-  mov x9, #56431
+  adds x13, x15, x13
+  cinc x14, x14, hs
   fmla.2d v11, v4, v9
-  movk x9, #30457, lsl 16
+  adds x5, x13, x5
+  cinc x13, x14, hs
   add.2d v1, v1, v10
-  movk x9, #30012, lsl 32
   add.2d v0, v0, v11
+  mul x14, x16, x9
+  mov x15, #18830
+  umulh x9, x16, x9
+  movk x15, #2465, lsl 16
+  adds x13, x14, x13
+  cinc x9, x9, hs
+  movk x15, #36348, lsl 32
+  movk x15, #17194, lsl 48
+  adds x6, x13, x6
+  cinc x9, x9, hs
+  dup.2d v9, x15
+  add x7, x7, x9
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  mov x9, #56431
+  fsub.2d v11, v6, v10
+  movk x9, #30457, lsl 16
+  fmla.2d v11, v4, v9
+  add.2d v2, v2, v10
+  movk x9, #30012, lsl 32
+  add.2d v1, v1, v11
   movk x9, #6382, lsl 48
-  mov x13, #18830
-  movk x13, #2465, lsl 16
+  mov x13, #21566
   mov x14, #59151
-  movk x13, #36348, lsl 32
+  movk x13, #43708, lsl 16
+  movk x13, #57685, lsl 32
   movk x14, #41769, lsl 16
-  movk x13, #17194, lsl 48
+  movk x13, #17185, lsl 48
   movk x14, #32276, lsl 32
   dup.2d v9, x13
   mov.16b v10, v5
@@ -740,281 +726,245 @@
   fsub.2d v11, v6, v10
   movk x13, #20342, lsl 16
   fmla.2d v11, v4, v9
+  add.2d v7, v7, v10
   movk x13, #13935, lsl 32
-  add.2d v2, v2, v10
-  add.2d v1, v1, v11
+  add.2d v2, v2, v11
   movk x13, #11030, lsl 48
-  mov x15, #21566
+  mov x15, #3072
+  movk x15, #8058, lsl 16
   mov x16, #13689
-  movk x15, #43708, lsl 16
+  movk x15, #46097, lsl 32
   movk x16, #8159, lsl 16
-  movk x15, #57685, lsl 32
-  movk x15, #17185, lsl 48
-  movk x16, #215, lsl 32
+  movk x15, #17047, lsl 48
   dup.2d v9, x15
-  movk x16, #4913, lsl 48
+  movk x16, #215, lsl 32
   mov.16b v10, v5
-  mul x15, x9, x10
+  movk x16, #4913, lsl 48
   fmla.2d v10, v4, v9
-  umulh x9, x9, x10
+  mul x15, x9, x10
   fsub.2d v11, v6, v10
   fmla.2d v11, v4, v9
+  umulh x9, x9, x10
+  add.2d v3, v3, v10
   adds x12, x15, x12
   cinc x9, x9, hs
-  add.2d v7, v7, v10
-  mul x15, x14, x10
-  add.2d v2, v2, v11
+  add.2d v4, v7, v11
+  mov x15, #65535
+  mul x17, x14, x10
+  movk x15, #61439, lsl 16
   umulh x14, x14, x10
-  mov x17, #3072
-  movk x17, #8058, lsl 16
-  adds x9, x15, x9
+  movk x15, #62867, lsl 32
+  adds x9, x17, x9
   cinc x14, x14, hs
-  movk x17, #46097, lsl 32
+  movk x15, #1, lsl 48
+  umov x17, v8.d[0]
   adds x4, x9, x4
   cinc x9, x14, hs
-  movk x17, #17047, lsl 48
-  mul x14, x13, x10
-  dup.2d v9, x17
-  mov.16b v10, v5
+  umov x14, v8.d[1]
+  mul x20, x13, x10
+  mul x17, x17, x15
+  mul x14, x14, x15
   umulh x13, x13, x10
-  fmla.2d v10, v4, v9
-  adds x9, x14, x9
+  and x15, x17, x8
+  adds x9, x20, x9
   cinc x13, x13, hs
-  fsub.2d v11, v6, v10
-  adds x5, x9, x5
-  cinc x9, x13, hs
-  fmla.2d v11, v4, v9
-  mul x13, x16, x10
-  add.2d v3, v3, v10
-  add.2d v4, v7, v11
-  umulh x10, x16, x10
-  mov x14, #65535
-  adds x9, x13, x9
-  cinc x10, x10, hs
-  movk x14, #61439, lsl 16
-  adds x6, x9, x6
-  cinc x9, x10, hs
-  movk x14, #62867, lsl 32
-  movk x14, #1, lsl 48
-  add x7, x7, x9
-  umov x9, v8.d[0]
-  mov x10, #61005
-  umov x13, v8.d[1]
-  movk x10, #58262, lsl 16
-  mul x9, x9, x14
-  movk x10, #32851, lsl 32
-  mul x13, x13, x14
-  and x9, x9, x8
-  movk x10, #11582, lsl 48
-  and x8, x13, x8
-  mov x13, #37581
-  ins v7.d[0], x9
+  and x8, x14, x8
+  ins v7.d[0], x15
   ins v7.d[1], x8
-  movk x13, #43836, lsl 16
+  adds x5, x9, x5
+  cinc x8, x13, hs
   ucvtf.2d v7, v7
-  mov x8, #16
-  movk x13, #36286, lsl 32
-  movk x8, #22847, lsl 32
-  movk x13, #51783, lsl 48
-  movk x8, #17151, lsl 48
-  mov x9, #10899
-  dup.2d v9, x8
-  movk x9, #30709, lsl 16
+  mul x9, x16, x10
+  mov x13, #16
+  umulh x10, x16, x10
+  movk x13, #22847, lsl 32
+  movk x13, #17151, lsl 48
+  adds x8, x9, x8
+  cinc x9, x10, hs
+  dup.2d v9, x13
+  adds x6, x8, x6
+  cinc x8, x9, hs
   mov.16b v10, v5
   fmla.2d v10, v7, v9
-  movk x9, #61551, lsl 32
+  add x7, x7, x8
   fsub.2d v11, v6, v10
-  movk x9, #45784, lsl 48
+  mov x8, #61005
   fmla.2d v11, v7, v9
-  mov x8, #36612
+  movk x8, #58262, lsl 16
   add.2d v0, v0, v10
   add.2d v8, v8, v11
-  movk x8, #63402, lsl 16
-  mov x14, #20728
-  movk x8, #47623, lsl 32
-  movk x14, #23588, lsl 16
-  movk x8, #9430, lsl 48
-  movk x14, #7790, lsl 32
-  mul x15, x10, x11
-  movk x14, #17170, lsl 48
-  dup.2d v9, x14
-  umulh x10, x10, x11
-  mov.16b v10, v5
-  adds x12, x15, x12
-  cinc x10, x10, hs
-  fmla.2d v10, v7, v9
-  mul x14, x13, x11
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v7, v9
-  umulh x13, x13, x11
-  add.2d v1, v1, v10
-  adds x10, x14, x10
-  cinc x13, x13, hs
-  add.2d v0, v0, v11
-  adds x4, x10, x4
-  cinc x10, x13, hs
-  mov x13, #16000
-  mul x14, x9, x11
-  movk x13, #53891, lsl 16
-  movk x13, #5509, lsl 32
-  umulh x9, x9, x11
-  movk x13, #17144, lsl 48
-  adds x10, x14, x10
-  cinc x9, x9, hs
-  dup.2d v9, x13
-  adds x5, x10, x5
-  cinc x9, x9, hs
-  mov.16b v10, v5
-  fmla.2d v10, v7, v9
-  mul x10, x8, x11
-  fsub.2d v11, v6, v10
-  umulh x8, x8, x11
-  fmla.2d v11, v7, v9
-  adds x9, x10, x9
-  cinc x8, x8, hs
-  add.2d v2, v2, v10
-  adds x6, x9, x6
-  cinc x8, x8, hs
-  add.2d v1, v1, v11
-  mov x9, #46800
-  add x7, x7, x8
-  movk x9, #2568, lsl 16
-  mov x8, #65535
-  movk x9, #1335, lsl 32
-  movk x8, #61439, lsl 16
-  movk x9, #17188, lsl 48
+  movk x8, #32851, lsl 32
+  mov x9, #20728
+  movk x8, #11582, lsl 48
+  movk x9, #23588, lsl 16
+  movk x9, #7790, lsl 32
+  mov x10, #37581
+  movk x9, #17170, lsl 48
+  movk x10, #43836, lsl 16
   dup.2d v9, x9
-  movk x8, #62867, lsl 32
   mov.16b v10, v5
-  movk x8, #49889, lsl 48
+  movk x10, #36286, lsl 32
   fmla.2d v10, v7, v9
-  mul x8, x8, x12
+  movk x10, #51783, lsl 48
   fsub.2d v11, v6, v10
-  mov x9, #1
+  mov x9, #10899
   fmla.2d v11, v7, v9
-  add.2d v4, v4, v10
-  movk x9, #61440, lsl 16
-  add.2d v2, v2, v11
-  movk x9, #62867, lsl 32
-  mov x10, #39040
-  movk x9, #17377, lsl 48
-  movk x10, #14704, lsl 16
-  movk x10, #12839, lsl 32
-  mov x11, #28817
-  movk x10, #17096, lsl 48
-  movk x11, #31161, lsl 16
-  dup.2d v9, x10
-  movk x11, #59464, lsl 32
-  mov.16b v5, v5
-  movk x11, #10291, lsl 48
-  fmla.2d v5, v7, v9
-  fsub.2d v6, v6, v5
-  mov x10, #22621
-  fmla.2d v6, v7, v9
-  movk x10, #33153, lsl 16
-  add.2d v3, v3, v5
-  movk x10, #17846, lsl 32
-  add.2d v4, v4, v6
-  mov x13, #140737488355328
-  movk x10, #47184, lsl 48
-  dup.2d v5, x13
-  mov x13, #41001
-  and.16b v5, v3, v5
-  movk x13, #57649, lsl 16
-  cmeq.2d v5, v5, #0
-  movk x13, #20082, lsl 32
-  mov x14, #2
-  movk x14, #57344, lsl 16
-  movk x13, #12388, lsl 48
-  movk x14, #60199, lsl 32
-  mul x15, x9, x8
-  movk x14, #3, lsl 48
-  umulh x9, x9, x8
-  dup.2d v6, x14
-  bic.16b v6, v6, v5
-  cmn x15, x12
-  cinc x9, x9, hs
-  mov x12, #10364
-  mul x14, x11, x8
-  movk x12, #11794, lsl 16
-  umulh x11, x11, x8
-  movk x12, #3895, lsl 32
-  adds x9, x14, x9
-  cinc x11, x11, hs
-  movk x12, #9, lsl 48
-  dup.2d v7, x12
-  adds x4, x9, x4
-  cinc x9, x11, hs
-  bic.16b v7, v7, v5
-  mul x11, x10, x8
-  mov x12, #26576
-  umulh x10, x10, x8
-  movk x12, #47696, lsl 16
-  movk x12, #688, lsl 32
-  adds x9, x11, x9
+  add.2d v1, v1, v10
+  movk x9, #30709, lsl 16
+  add.2d v0, v0, v11
+  movk x9, #61551, lsl 32
+  mov x13, #16000
+  movk x13, #53891, lsl 16
+  movk x9, #45784, lsl 48
+  movk x13, #5509, lsl 32
+  mov x14, #36612
+  movk x13, #17144, lsl 48
+  dup.2d v9, x13
+  movk x14, #63402, lsl 16
+  mov.16b v10, v5
+  movk x14, #47623, lsl 32
+  fmla.2d v10, v7, v9
+  movk x14, #9430, lsl 48
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  mul x13, x8, x11
+  add.2d v2, v2, v10
+  umulh x8, x8, x11
+  add.2d v1, v1, v11
+  mov x15, #46800
+  adds x12, x13, x12
+  cinc x8, x8, hs
+  movk x15, #2568, lsl 16
+  mul x13, x10, x11
+  movk x15, #1335, lsl 32
+  umulh x10, x10, x11
+  movk x15, #17188, lsl 48
+  dup.2d v9, x15
+  adds x8, x13, x8
   cinc x10, x10, hs
-  movk x12, #3, lsl 48
-  adds x5, x9, x5
-  cinc x9, x10, hs
-  dup.2d v9, x12
-  mul x10, x13, x8
-  bic.16b v9, v9, v5
-  umulh x8, x13, x8
-  mov x11, #46800
-  movk x11, #2568, lsl 16
-  adds x9, x10, x9
-  cinc x8, x8, hs
-  movk x11, #1335, lsl 32
-  adds x6, x9, x6
-  cinc x8, x8, hs
-  movk x11, #4, lsl 48
+  mov.16b v10, v5
+  adds x4, x8, x4
+  cinc x8, x10, hs
+  fmla.2d v10, v7, v9
+  fsub.2d v11, v6, v10
+  mul x10, x9, x11
+  fmla.2d v11, v7, v9
+  umulh x9, x9, x11
+  add.2d v4, v4, v10
+  add.2d v2, v2, v11
+  adds x8, x10, x8
+  cinc x9, x9, hs
+  mov x10, #39040
+  adds x5, x8, x5
+  cinc x8, x9, hs
+  movk x10, #14704, lsl 16
+  mul x9, x14, x11
+  movk x10, #12839, lsl 32
+  movk x10, #17096, lsl 48
+  umulh x11, x14, x11
+  dup.2d v9, x10
+  adds x8, x9, x8
+  cinc x9, x11, hs
+  mov.16b v5, v5
+  fmla.2d v5, v7, v9
+  adds x6, x8, x6
+  cinc x8, x9, hs
+  fsub.2d v6, v6, v5
   add x7, x7, x8
-  dup.2d v10, x11
+  fmla.2d v6, v7, v9
+  mov x8, #65535
+  add.2d v3, v3, v5
+  add.2d v4, v4, v6
+  movk x8, #61439, lsl 16
+  mov x9, #140737488355328
+  movk x8, #62867, lsl 32
+  dup.2d v5, x9
+  and.16b v5, v3, v5
+  movk x8, #49889, lsl 48
+  cmeq.2d v5, v5, #0
+  mul x8, x8, x12
+  mov x9, #2
+  movk x9, #57344, lsl 16
+  mov x10, #1
+  movk x9, #60199, lsl 32
+  movk x10, #61440, lsl 16
+  movk x9, #3, lsl 48
+  movk x10, #62867, lsl 32
+  dup.2d v6, x9
+  bic.16b v6, v6, v5
+  movk x10, #17377, lsl 48
+  mov x9, #10364
+  mov x11, #28817
+  movk x9, #11794, lsl 16
+  movk x9, #3895, lsl 32
+  movk x11, #31161, lsl 16
+  movk x9, #9, lsl 48
+  movk x11, #59464, lsl 32
+  dup.2d v7, x9
+  movk x11, #10291, lsl 48
+  bic.16b v7, v7, v5
+  mov x9, #26576
+  mov x13, #22621
+  movk x9, #47696, lsl 16
+  movk x13, #33153, lsl 16
+  movk x9, #688, lsl 32
+  movk x9, #3, lsl 48
+  movk x13, #17846, lsl 32
+  dup.2d v9, x9
+  movk x13, #47184, lsl 48
+  bic.16b v9, v9, v5
+  mov x9, #46800
+  mov x14, #41001
+  movk x9, #2568, lsl 16
+  movk x14, #57649, lsl 16
+  movk x9, #1335, lsl 32
+  movk x14, #20082, lsl 32
+  movk x9, #4, lsl 48
+  dup.2d v10, x9
+  movk x14, #12388, lsl 48
   bic.16b v10, v10, v5
-  mov x8, #2
-  mov x9, #49763
-  movk x8, #57344, lsl 16
-  movk x9, #40165, lsl 16
-  movk x8, #60199, lsl 32
-  movk x9, #24776, lsl 32
-  movk x8, #34755, lsl 48
-  dup.2d v11, x9
+  mul x9, x10, x8
+  mov x15, #49763
+  movk x15, #40165, lsl 16
+  umulh x10, x10, x8
+  movk x15, #24776, lsl 32
+  cmn x9, x12
+  cinc x10, x10, hs
+  dup.2d v11, x15
+  mul x9, x11, x8
   bic.16b v5, v11, v5
-  mov x9, #57634
   sub.2d v0, v0, v6
-  movk x9, #62322, lsl 16
+  umulh x11, x11, x8
   ssra.2d v0, v8, #52
-  movk x9, #53392, lsl 32
+  adds x9, x9, x10
+  cinc x10, x11, hs
   sub.2d v6, v1, v7
   ssra.2d v6, v0, #52
-  movk x9, #20583, lsl 48
+  adds x4, x9, x4
+  cinc x9, x10, hs
   sub.2d v7, v2, v9
-  mov x10, #45242
+  mul x10, x13, x8
   ssra.2d v7, v6, #52
-  movk x10, #770, lsl 16
   sub.2d v4, v4, v10
-  movk x10, #35693, lsl 32
+  umulh x11, x13, x8
   ssra.2d v4, v7, #52
+  adds x9, x10, x9
+  cinc x10, x11, hs
   sub.2d v5, v3, v5
-  movk x10, #28832, lsl 48
+  adds x5, x9, x5
+  cinc x9, x10, hs
   ssra.2d v5, v4, #52
-  mov x11, #16467
   ushr.2d v1, v6, #12
-  movk x11, #49763, lsl 16
+  mul x10, x14, x8
   ushr.2d v2, v7, #24
+  umulh x8, x14, x8
   ushr.2d v3, v4, #36
-  movk x11, #40165, lsl 32
   sli.2d v0, v6, #52
-  movk x11, #24776, lsl 48
+  adds x9, x10, x9
+  cinc x8, x8, hs
   sli.2d v1, v7, #40
-  subs x8, x4, x8
-  sbcs x9, x5, x9
-  sbcs x10, x6, x10
-  sbcs x11, x7, x11
+  adds x6, x9, x6
+  cinc x8, x8, hs
   sli.2d v2, v4, #28
   sli.2d v3, v5, #16
-  tst x7, #9223372036854775808
-  csel x4, x8, x4, mi
-  csel x5, x9, x5, mi
-  csel x6, x10, x6, mi
-  csel x7, x11, x7, mi
+  add x7, x7, x8

--- a/block-multiplier/src/aarch64/montgomery_square_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_square_interleaved_4.s
@@ -12,959 +12,921 @@
   dup.2d v4, x8
   umulh x10, x0, x0
   mov x11, #5075556780046548992
+  mul x12, x0, x1
   dup.2d v5, x11
-  mul x11, x0, x1
-  mov x12, #1
+  mov x11, #1
   umulh x13, x0, x1
-  movk x12, #18032, lsl 48
-  dup.2d v6, x12
-  adds x10, x11, x10
-  cinc x12, x13, hs
+  movk x11, #18032, lsl 48
+  adds x10, x12, x10
+  cinc x14, x13, hs
+  dup.2d v6, x11
+  mul x11, x0, x2
   shl.2d v7, v1, #14
-  mul x14, x0, x2
   shl.2d v8, v2, #26
   umulh x15, x0, x2
   shl.2d v9, v3, #38
-  ushr.2d v3, v3, #14
-  adds x12, x14, x12
+  adds x14, x11, x14
   cinc x16, x15, hs
-  shl.2d v10, v0, #2
+  ushr.2d v3, v3, #14
   mul x17, x0, x3
+  shl.2d v10, v0, #2
   usra.2d v7, v0, #50
-  usra.2d v8, v1, #38
   umulh x0, x0, x3
-  usra.2d v9, v2, #26
+  usra.2d v8, v1, #38
   adds x16, x17, x16
   cinc x20, x0, hs
+  usra.2d v9, v2, #26
+  adds x10, x12, x10
+  cinc x12, x13, hs
   and.16b v0, v10, v4
   and.16b v1, v7, v4
-  adds x10, x11, x10
-  cinc x11, x13, hs
-  and.16b v2, v8, v4
   mul x13, x1, x1
-  and.16b v7, v9, v4
+  and.16b v2, v8, v4
   umulh x21, x1, x1
-  mov x22, #13605374474286268416
-  dup.2d v8, x22
-  adds x11, x13, x11
+  and.16b v7, v9, v4
+  adds x12, x13, x12
   cinc x13, x21, hs
-  mov x21, #6440147467139809280
-  adds x11, x11, x12
-  cinc x12, x13, hs
-  dup.2d v9, x21
-  mov x13, #3688448094816436224
+  mov x21, #13605374474286268416
+  adds x12, x12, x14
+  cinc x13, x13, hs
+  dup.2d v8, x21
+  mov x14, #6440147467139809280
   mul x21, x1, x2
-  dup.2d v10, x13
-  umulh x13, x1, x2
+  dup.2d v9, x14
+  umulh x14, x1, x2
+  mov x22, #3688448094816436224
+  adds x13, x21, x13
+  cinc x23, x14, hs
+  dup.2d v10, x22
   mov x22, #9209861237972664320
-  adds x12, x21, x12
-  cinc x23, x13, hs
-  dup.2d v11, x22
-  mov x22, #12218265789056155648
-  adds x12, x12, x16
+  adds x13, x13, x16
   cinc x16, x23, hs
-  dup.2d v12, x22
+  dup.2d v11, x22
   mul x22, x1, x3
-  mov x23, #17739678932212383744
-  dup.2d v13, x23
+  mov x23, #12218265789056155648
   umulh x1, x1, x3
-  mov x23, #2301339409586323456
+  dup.2d v12, x23
+  mov x23, #17739678932212383744
   adds x16, x22, x16
   cinc x24, x1, hs
-  dup.2d v14, x23
-  mov x23, #7822752552742551552
+  dup.2d v13, x23
   adds x16, x16, x20
   cinc x20, x24, hs
-  dup.2d v15, x23
-  adds x11, x14, x11
-  cinc x14, x15, hs
-  mov x15, #5071053180419178496
-  adds x14, x21, x14
-  cinc x13, x13, hs
-  dup.2d v16, x15
-  mov x15, #16352570246982270976
-  adds x12, x14, x12
-  cinc x13, x13, hs
-  dup.2d v17, x15
-  mul x14, x2, x2
+  mov x23, #2301339409586323456
+  adds x11, x11, x12
+  cinc x12, x15, hs
+  dup.2d v14, x23
+  mov x15, #7822752552742551552
+  adds x12, x21, x12
+  cinc x14, x14, hs
+  dup.2d v15, x15
+  adds x12, x12, x13
+  cinc x13, x14, hs
+  mov x14, #5071053180419178496
+  mul x15, x2, x2
+  dup.2d v16, x14
+  mov x14, #16352570246982270976
+  umulh x21, x2, x2
+  dup.2d v17, x14
+  adds x13, x15, x13
+  cinc x14, x21, hs
   ucvtf.2d v0, v0
-  ucvtf.2d v1, v1
-  umulh x15, x2, x2
-  ucvtf.2d v2, v2
-  adds x13, x14, x13
-  cinc x14, x15, hs
-  ucvtf.2d v7, v7
   adds x13, x13, x16
   cinc x14, x14, hs
-  ucvtf.2d v3, v3
-  mov.16b v18, v5
+  ucvtf.2d v1, v1
   mul x15, x2, x3
-  fmla.2d v18, v0, v0
+  ucvtf.2d v2, v2
+  ucvtf.2d v7, v7
   umulh x2, x2, x3
-  fsub.2d v19, v6, v18
-  fmla.2d v19, v0, v0
+  ucvtf.2d v3, v3
   adds x14, x15, x14
   cinc x16, x2, hs
-  add.2d v10, v10, v18
+  mov.16b v18, v5
   adds x14, x14, x20
   cinc x16, x16, hs
-  add.2d v8, v8, v19
-  mov.16b v18, v5
+  fmla.2d v18, v0, v0
+  fsub.2d v19, v6, v18
   adds x12, x17, x12
   cinc x0, x0, hs
-  fmla.2d v18, v0, v1
+  fmla.2d v19, v0, v0
   adds x0, x22, x0
   cinc x1, x1, hs
-  fsub.2d v19, v6, v18
+  add.2d v10, v10, v18
   adds x0, x0, x13
   cinc x1, x1, hs
-  fmla.2d v19, v0, v1
-  add.2d v18, v18, v18
+  add.2d v8, v8, v19
+  mov.16b v18, v5
   adds x1, x15, x1
   cinc x2, x2, hs
-  add.2d v19, v19, v19
+  fmla.2d v18, v0, v1
   adds x1, x1, x14
   cinc x2, x2, hs
-  add.2d v12, v12, v18
-  add.2d v10, v10, v19
+  fsub.2d v19, v6, v18
   mul x13, x3, x3
-  mov.16b v18, v5
+  fmla.2d v19, v0, v1
+  add.2d v18, v18, v18
   umulh x3, x3, x3
-  fmla.2d v18, v0, v2
+  add.2d v19, v19, v19
   adds x2, x13, x2
   cinc x3, x3, hs
-  fsub.2d v19, v6, v18
-  fmla.2d v19, v0, v2
+  add.2d v12, v12, v18
   adds x2, x2, x16
   cinc x3, x3, hs
-  add.2d v18, v18, v18
+  add.2d v10, v10, v19
   mov x13, #48718
-  add.2d v19, v19, v19
-  add.2d v14, v14, v18
+  mov.16b v18, v5
+  fmla.2d v18, v0, v2
   movk x13, #4732, lsl 16
-  add.2d v12, v12, v19
+  fsub.2d v19, v6, v18
   movk x13, #45078, lsl 32
+  fmla.2d v19, v0, v2
+  movk x13, #39852, lsl 48
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  mov x14, #16676
+  add.2d v14, v14, v18
+  movk x14, #12692, lsl 16
+  add.2d v12, v12, v19
+  movk x14, #20986, lsl 32
   mov.16b v18, v5
   fmla.2d v18, v0, v7
-  movk x13, #39852, lsl 48
+  movk x14, #2848, lsl 48
   fsub.2d v19, v6, v18
-  mov x14, #16676
+  mov x15, #51052
   fmla.2d v19, v0, v7
-  movk x14, #12692, lsl 16
+  movk x15, #24721, lsl 16
   add.2d v18, v18, v18
   add.2d v19, v19, v19
-  movk x14, #20986, lsl 32
-  add.2d v16, v16, v18
-  movk x14, #2848, lsl 48
-  add.2d v14, v14, v19
-  mov.16b v18, v5
-  mov x15, #51052
-  fmla.2d v18, v0, v3
-  movk x15, #24721, lsl 16
-  fsub.2d v19, v6, v18
   movk x15, #61092, lsl 32
-  fmla.2d v19, v0, v3
-  add.2d v0, v18, v18
-  movk x15, #45156, lsl 48
-  add.2d v18, v19, v19
-  mov x16, #3197
-  add.2d v0, v17, v0
   add.2d v16, v16, v18
+  movk x15, #45156, lsl 48
+  add.2d v14, v14, v19
+  mov x16, #3197
+  mov.16b v18, v5
+  fmla.2d v18, v0, v3
   movk x16, #18936, lsl 16
-  mov.16b v17, v5
+  fsub.2d v19, v6, v18
   movk x16, #10922, lsl 32
-  fmla.2d v17, v1, v1
-  fsub.2d v18, v6, v17
+  fmla.2d v19, v0, v3
   movk x16, #11014, lsl 48
-  fmla.2d v18, v1, v1
+  add.2d v0, v18, v18
   mul x17, x13, x9
-  add.2d v14, v14, v17
+  add.2d v18, v19, v19
+  add.2d v0, v17, v0
   umulh x13, x13, x9
-  add.2d v12, v12, v18
-  mov.16b v17, v5
+  add.2d v16, v16, v18
   adds x12, x17, x12
   cinc x13, x13, hs
-  fmla.2d v17, v1, v2
+  mov.16b v17, v5
   mul x17, x14, x9
+  fmla.2d v17, v1, v1
   fsub.2d v18, v6, v17
-  fmla.2d v18, v1, v2
   umulh x14, x14, x9
-  add.2d v17, v17, v17
+  fmla.2d v18, v1, v1
   adds x13, x17, x13
   cinc x14, x14, hs
-  add.2d v18, v18, v18
-  add.2d v16, v16, v17
+  add.2d v14, v14, v17
   adds x0, x13, x0
   cinc x13, x14, hs
-  add.2d v14, v14, v18
-  mul x14, x15, x9
+  add.2d v12, v12, v18
   mov.16b v17, v5
+  mul x14, x15, x9
+  fmla.2d v17, v1, v2
   umulh x15, x15, x9
-  fmla.2d v17, v1, v7
   fsub.2d v18, v6, v17
   adds x13, x14, x13
   cinc x14, x15, hs
-  fmla.2d v18, v1, v7
+  fmla.2d v18, v1, v2
+  add.2d v17, v17, v17
   adds x1, x13, x1
   cinc x13, x14, hs
-  add.2d v17, v17, v17
   add.2d v18, v18, v18
   mul x14, x16, x9
-  add.2d v0, v0, v17
+  add.2d v16, v16, v17
   umulh x9, x16, x9
-  add.2d v16, v16, v18
+  add.2d v14, v14, v18
   adds x13, x14, x13
   cinc x9, x9, hs
   mov.16b v17, v5
-  fmla.2d v17, v1, v3
+  fmla.2d v17, v1, v7
   adds x2, x13, x2
   cinc x9, x9, hs
   fsub.2d v18, v6, v17
   add x3, x3, x9
-  fmla.2d v18, v1, v3
-  add.2d v1, v17, v17
+  fmla.2d v18, v1, v7
   mov x9, #56431
-  add.2d v17, v18, v18
+  add.2d v17, v17, v17
+  add.2d v18, v18, v18
   movk x9, #30457, lsl 16
-  add.2d v1, v15, v1
   add.2d v0, v0, v17
   movk x9, #30012, lsl 32
-  mov.16b v15, v5
+  add.2d v16, v16, v18
   movk x9, #6382, lsl 48
-  fmla.2d v15, v2, v2
+  mov.16b v17, v5
+  fmla.2d v17, v1, v3
   mov x13, #59151
-  fsub.2d v17, v6, v15
-  fmla.2d v17, v2, v2
+  fsub.2d v18, v6, v17
   movk x13, #41769, lsl 16
-  add.2d v0, v0, v15
+  fmla.2d v18, v1, v3
   movk x13, #32276, lsl 32
+  add.2d v1, v17, v17
+  add.2d v17, v18, v18
+  movk x13, #21677, lsl 48
+  add.2d v1, v15, v1
+  mov x14, #34015
+  add.2d v0, v0, v17
+  movk x14, #20342, lsl 16
+  mov.16b v15, v5
+  fmla.2d v15, v2, v2
+  movk x14, #13935, lsl 32
+  fsub.2d v17, v6, v15
+  movk x14, #11030, lsl 48
+  fmla.2d v17, v2, v2
+  mov x15, #13689
+  add.2d v0, v0, v15
+  movk x15, #8159, lsl 16
   add.2d v15, v16, v17
   mov.16b v16, v5
-  movk x13, #21677, lsl 48
+  movk x15, #215, lsl 32
   fmla.2d v16, v2, v7
-  mov x14, #34015
+  movk x15, #4913, lsl 48
   fsub.2d v17, v6, v16
-  movk x14, #20342, lsl 16
+  mul x16, x9, x10
   fmla.2d v17, v2, v7
   add.2d v16, v16, v16
-  movk x14, #13935, lsl 32
-  add.2d v17, v17, v17
-  movk x14, #11030, lsl 48
-  add.2d v1, v1, v16
-  add.2d v0, v0, v17
-  mov x15, #13689
-  mov.16b v16, v5
-  movk x15, #8159, lsl 16
-  fmla.2d v16, v2, v3
-  fsub.2d v17, v6, v16
-  movk x15, #215, lsl 32
-  fmla.2d v17, v2, v3
-  movk x15, #4913, lsl 48
-  add.2d v2, v16, v16
-  mul x16, x9, x10
-  add.2d v16, v17, v17
-  add.2d v2, v13, v2
   umulh x9, x9, x10
-  add.2d v1, v1, v16
+  add.2d v17, v17, v17
   adds x12, x16, x12
   cinc x9, x9, hs
-  mov.16b v13, v5
-  fmla.2d v13, v7, v7
+  add.2d v1, v1, v16
   mul x16, x13, x10
-  fsub.2d v16, v6, v13
+  add.2d v0, v0, v17
+  mov.16b v16, v5
   umulh x13, x13, x10
-  fmla.2d v16, v7, v7
+  fmla.2d v16, v2, v3
   adds x9, x16, x9
   cinc x13, x13, hs
+  fsub.2d v17, v6, v16
+  adds x0, x9, x0
+  cinc x9, x13, hs
+  fmla.2d v17, v2, v3
+  add.2d v2, v16, v16
+  mul x13, x14, x10
+  add.2d v16, v17, v17
+  umulh x14, x14, x10
+  add.2d v2, v13, v2
+  adds x9, x13, x9
+  cinc x13, x14, hs
+  add.2d v1, v1, v16
+  mov.16b v13, v5
+  adds x1, x9, x1
+  cinc x9, x13, hs
+  fmla.2d v13, v7, v7
+  mul x13, x15, x10
+  fsub.2d v16, v6, v13
+  umulh x10, x15, x10
+  fmla.2d v16, v7, v7
+  adds x9, x13, x9
+  cinc x10, x10, hs
   add.2d v2, v2, v13
   add.2d v1, v1, v16
-  adds x0, x9, x0
-  cinc x9, x13, hs
-  mov.16b v13, v5
-  mul x13, x14, x10
-  fmla.2d v13, v7, v3
-  fsub.2d v16, v6, v13
-  umulh x14, x14, x10
-  fmla.2d v16, v7, v3
-  adds x9, x13, x9
-  cinc x13, x14, hs
-  add.2d v7, v13, v13
-  add.2d v13, v16, v16
-  adds x1, x9, x1
-  cinc x9, x13, hs
-  add.2d v7, v11, v7
-  mul x13, x15, x10
-  add.2d v2, v2, v13
-  umulh x10, x15, x10
-  mov.16b v11, v5
-  fmla.2d v11, v3, v3
-  adds x9, x13, x9
-  cinc x10, x10, hs
-  fsub.2d v13, v6, v11
   adds x2, x9, x2
   cinc x9, x10, hs
-  fmla.2d v13, v3, v3
-  add.2d v3, v9, v11
+  mov.16b v13, v5
   add x3, x3, x9
-  add.2d v7, v7, v13
+  fmla.2d v13, v7, v3
   mov x9, #61005
-  usra.2d v10, v8, #52
+  fsub.2d v16, v6, v13
+  fmla.2d v16, v7, v3
   movk x9, #58262, lsl 16
+  add.2d v7, v13, v13
+  movk x9, #32851, lsl 32
+  add.2d v13, v16, v16
+  movk x9, #11582, lsl 48
+  add.2d v7, v11, v7
+  add.2d v2, v2, v13
+  mov x10, #37581
+  mov.16b v11, v5
+  movk x10, #43836, lsl 16
+  fmla.2d v11, v3, v3
+  movk x10, #36286, lsl 32
+  fsub.2d v13, v6, v11
+  fmla.2d v13, v3, v3
+  movk x10, #51783, lsl 48
+  add.2d v3, v9, v11
+  mov x13, #10899
+  add.2d v7, v7, v13
+  movk x13, #30709, lsl 16
+  usra.2d v10, v8, #52
+  movk x13, #61551, lsl 32
   usra.2d v12, v10, #52
   usra.2d v14, v12, #52
-  movk x9, #32851, lsl 32
+  movk x13, #45784, lsl 48
   usra.2d v15, v14, #52
-  movk x9, #11582, lsl 48
+  mov x14, #36612
   and.16b v8, v8, v4
+  movk x14, #63402, lsl 16
   and.16b v9, v10, v4
-  mov x10, #37581
   and.16b v10, v12, v4
-  movk x10, #43836, lsl 16
+  movk x14, #47623, lsl 32
   and.16b v4, v14, v4
+  movk x14, #9430, lsl 48
   ucvtf.2d v8, v8
-  movk x10, #36286, lsl 32
-  mov x13, #37864
-  movk x10, #51783, lsl 48
-  movk x13, #1815, lsl 16
-  mov x14, #10899
-  movk x13, #28960, lsl 32
-  movk x13, #17153, lsl 48
-  movk x14, #30709, lsl 16
-  dup.2d v11, x13
-  movk x14, #61551, lsl 32
-  mov.16b v12, v5
-  fmla.2d v12, v8, v11
-  movk x14, #45784, lsl 48
-  fsub.2d v13, v6, v12
-  mov x13, #36612
-  fmla.2d v13, v8, v11
-  add.2d v0, v0, v12
-  movk x13, #63402, lsl 16
-  add.2d v11, v15, v13
-  movk x13, #47623, lsl 32
-  mov x15, #46128
-  movk x13, #9430, lsl 48
-  movk x15, #29964, lsl 16
-  movk x15, #7587, lsl 32
-  mul x16, x9, x11
-  movk x15, #17161, lsl 48
+  mul x15, x9, x11
+  mov x16, #37864
+  movk x16, #1815, lsl 16
   umulh x9, x9, x11
-  dup.2d v12, x15
-  mov.16b v13, v5
-  adds x12, x16, x12
-  cinc x9, x9, hs
-  fmla.2d v13, v8, v12
-  mul x15, x10, x11
-  fsub.2d v14, v6, v13
-  umulh x10, x10, x11
-  fmla.2d v14, v8, v12
-  add.2d v1, v1, v13
-  adds x9, x15, x9
-  cinc x10, x10, hs
-  add.2d v0, v0, v14
-  adds x0, x9, x0
-  cinc x9, x10, hs
-  mov x10, #52826
-  movk x10, #57790, lsl 16
-  mul x15, x14, x11
-  movk x10, #55431, lsl 32
-  umulh x14, x14, x11
-  movk x10, #17196, lsl 48
-  dup.2d v12, x10
-  adds x9, x15, x9
-  cinc x10, x14, hs
-  mov.16b v13, v5
-  adds x1, x9, x1
-  cinc x9, x10, hs
-  fmla.2d v13, v8, v12
-  mul x10, x13, x11
-  fsub.2d v14, v6, v13
-  fmla.2d v14, v8, v12
-  umulh x11, x13, x11
-  add.2d v2, v2, v13
-  adds x9, x10, x9
-  cinc x10, x11, hs
-  add.2d v1, v1, v14
-  mov x11, #31276
-  adds x2, x9, x2
-  cinc x9, x10, hs
-  movk x11, #21262, lsl 16
-  add x3, x3, x9
-  movk x11, #2304, lsl 32
-  mov x9, #65535
-  movk x11, #17182, lsl 48
-  dup.2d v12, x11
-  movk x9, #61439, lsl 16
-  mov.16b v13, v5
-  movk x9, #62867, lsl 32
-  fmla.2d v13, v8, v12
-  fsub.2d v14, v6, v13
-  movk x9, #49889, lsl 48
-  fmla.2d v14, v8, v12
-  mul x9, x9, x12
-  add.2d v7, v7, v13
-  add.2d v2, v2, v14
-  mov x10, #1
-  mov x11, #28672
-  movk x10, #61440, lsl 16
-  movk x11, #24515, lsl 16
-  movk x10, #62867, lsl 32
-  movk x11, #54929, lsl 32
-  movk x11, #17064, lsl 48
-  movk x10, #17377, lsl 48
-  dup.2d v12, x11
-  mov x11, #28817
-  mov.16b v13, v5
-  fmla.2d v13, v8, v12
-  movk x11, #31161, lsl 16
-  fsub.2d v14, v6, v13
-  movk x11, #59464, lsl 32
-  fmla.2d v14, v8, v12
-  movk x11, #10291, lsl 48
-  add.2d v3, v3, v13
-  add.2d v7, v7, v14
-  mov x13, #22621
-  ucvtf.2d v8, v9
-  movk x13, #33153, lsl 16
-  mov x14, #44768
-  movk x14, #51919, lsl 16
-  movk x13, #17846, lsl 32
-  movk x14, #6346, lsl 32
-  movk x13, #47184, lsl 48
-  movk x14, #17133, lsl 48
-  dup.2d v9, x14
-  mov x14, #41001
-  mov.16b v12, v5
-  movk x14, #57649, lsl 16
-  fmla.2d v12, v8, v9
-  movk x14, #20082, lsl 32
-  fsub.2d v13, v6, v12
-  fmla.2d v13, v8, v9
-  movk x14, #12388, lsl 48
-  add.2d v0, v0, v12
-  mul x15, x10, x9
-  add.2d v9, v11, v13
-  mov x16, #47492
-  umulh x10, x10, x9
-  movk x16, #23630, lsl 16
-  cmn x15, x12
-  cinc x10, x10, hs
-  movk x16, #49985, lsl 32
-  mul x12, x11, x9
-  movk x16, #17168, lsl 48
-  dup.2d v11, x16
-  umulh x11, x11, x9
-  mov.16b v12, v5
-  adds x10, x12, x10
-  cinc x11, x11, hs
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
-  adds x0, x10, x0
-  cinc x10, x11, hs
-  fmla.2d v13, v8, v11
-  mul x11, x13, x9
-  add.2d v1, v1, v12
-  add.2d v0, v0, v13
-  umulh x12, x13, x9
-  mov x13, #57936
-  adds x10, x11, x10
-  cinc x11, x12, hs
-  movk x13, #54828, lsl 16
-  adds x1, x10, x1
-  cinc x10, x11, hs
-  movk x13, #18292, lsl 32
-  movk x13, #17197, lsl 48
-  mul x11, x14, x9
-  dup.2d v11, x13
-  umulh x9, x14, x9
-  mov.16b v12, v5
-  fmla.2d v12, v8, v11
-  adds x10, x11, x10
-  cinc x9, x9, hs
-  fsub.2d v13, v6, v12
-  adds x2, x10, x2
-  cinc x9, x9, hs
-  fmla.2d v13, v8, v11
-  add.2d v2, v2, v12
-  add x3, x3, x9
-  add.2d v1, v1, v13
-  mul x9, x4, x4
-  mov x10, #17708
-  umulh x11, x4, x4
-  movk x10, #43915, lsl 16
-  movk x10, #64348, lsl 32
-  mul x12, x4, x5
-  movk x10, #17188, lsl 48
-  umulh x13, x4, x5
-  dup.2d v11, x10
-  mov.16b v12, v5
-  adds x10, x12, x11
-  cinc x11, x13, hs
-  fmla.2d v12, v8, v11
-  mul x14, x4, x6
-  fsub.2d v13, v6, v12
-  umulh x15, x4, x6
-  fmla.2d v13, v8, v11
-  add.2d v7, v7, v12
-  adds x11, x14, x11
-  cinc x16, x15, hs
-  add.2d v2, v2, v13
-  mul x17, x4, x7
-  mov x20, #29184
-  movk x20, #20789, lsl 16
-  umulh x4, x4, x7
-  movk x20, #19197, lsl 32
-  adds x16, x17, x16
-  cinc x21, x4, hs
-  movk x20, #17083, lsl 48
-  dup.2d v11, x20
-  adds x10, x12, x10
-  cinc x12, x13, hs
-  mov.16b v12, v5
-  mul x13, x5, x5
-  fmla.2d v12, v8, v11
-  umulh x20, x5, x5
-  fsub.2d v13, v6, v12
-  fmla.2d v13, v8, v11
-  adds x12, x13, x12
-  cinc x13, x20, hs
-  add.2d v3, v3, v12
-  adds x11, x12, x11
-  cinc x12, x13, hs
-  add.2d v7, v7, v13
-  ucvtf.2d v8, v10
-  mul x13, x5, x6
-  mov x20, #58856
-  umulh x22, x5, x6
-  movk x20, #14953, lsl 16
-  adds x12, x13, x12
-  cinc x23, x22, hs
-  movk x20, #15155, lsl 32
-  movk x20, #17181, lsl 48
-  adds x12, x12, x16
-  cinc x16, x23, hs
-  dup.2d v10, x20
-  mul x20, x5, x7
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  umulh x5, x5, x7
-  fsub.2d v12, v6, v11
-  adds x16, x20, x16
-  cinc x23, x5, hs
-  fmla.2d v12, v8, v10
-  add.2d v0, v0, v11
-  adds x16, x16, x21
-  cinc x21, x23, hs
-  add.2d v9, v9, v12
-  adds x11, x14, x11
-  cinc x14, x15, hs
-  mov x15, #35392
-  adds x13, x13, x14
-  cinc x14, x22, hs
-  movk x15, #12477, lsl 16
-  movk x15, #56780, lsl 32
-  adds x12, x13, x12
-  cinc x13, x14, hs
-  movk x15, #17142, lsl 48
-  mul x14, x6, x6
-  dup.2d v10, x15
-  mov.16b v11, v5
-  umulh x15, x6, x6
-  fmla.2d v11, v8, v10
-  adds x13, x14, x13
-  cinc x14, x15, hs
-  fsub.2d v12, v6, v11
-  adds x13, x13, x16
-  cinc x14, x14, hs
-  fmla.2d v12, v8, v10
-  add.2d v1, v1, v11
-  mul x15, x6, x7
-  add.2d v0, v0, v12
-  umulh x6, x6, x7
-  mov x16, #9848
-  movk x16, #54501, lsl 16
-  adds x14, x15, x14
-  cinc x22, x6, hs
-  movk x16, #31540, lsl 32
-  adds x14, x14, x21
-  cinc x21, x22, hs
-  movk x16, #17170, lsl 48
-  dup.2d v10, x16
-  adds x12, x17, x12
-  cinc x4, x4, hs
-  mov.16b v11, v5
-  adds x4, x20, x4
-  cinc x5, x5, hs
-  fmla.2d v11, v8, v10
-  adds x4, x4, x13
-  cinc x5, x5, hs
-  fsub.2d v12, v6, v11
-  fmla.2d v12, v8, v10
-  adds x5, x15, x5
-  cinc x6, x6, hs
-  add.2d v2, v2, v11
-  adds x5, x5, x14
-  cinc x6, x6, hs
-  add.2d v1, v1, v12
-  mov x13, #9584
-  mul x14, x7, x7
-  movk x13, #63883, lsl 16
-  umulh x7, x7, x7
-  movk x13, #18253, lsl 32
-  adds x6, x14, x6
-  cinc x7, x7, hs
-  movk x13, #17190, lsl 48
-  dup.2d v10, x13
-  adds x6, x6, x21
-  cinc x7, x7, hs
-  mov.16b v11, v5
-  mov x13, #48718
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  movk x13, #4732, lsl 16
-  fmla.2d v12, v8, v10
-  movk x13, #45078, lsl 32
-  add.2d v7, v7, v11
-  add.2d v2, v2, v12
-  movk x13, #39852, lsl 48
-  mov x14, #51712
-  mov x15, #16676
-  movk x14, #16093, lsl 16
-  movk x15, #12692, lsl 16
-  movk x14, #30633, lsl 32
-  movk x14, #17068, lsl 48
-  movk x15, #20986, lsl 32
-  dup.2d v10, x14
-  movk x15, #2848, lsl 48
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  mov x14, #51052
-  fsub.2d v12, v6, v11
-  movk x14, #24721, lsl 16
-  fmla.2d v12, v8, v10
-  movk x14, #61092, lsl 32
-  add.2d v3, v3, v11
-  add.2d v7, v7, v12
-  movk x14, #45156, lsl 48
-  ucvtf.2d v4, v4
-  mov x16, #3197
-  mov x17, #34724
-  movk x17, #40393, lsl 16
-  movk x16, #18936, lsl 16
-  movk x17, #23752, lsl 32
-  movk x16, #10922, lsl 32
-  movk x17, #17184, lsl 48
-  dup.2d v8, x17
-  movk x16, #11014, lsl 48
-  mov.16b v10, v5
-  mul x17, x13, x9
-  fmla.2d v10, v4, v8
-  umulh x13, x13, x9
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v4, v8
-  adds x12, x17, x12
-  cinc x13, x13, hs
-  add.2d v0, v0, v10
-  mul x17, x15, x9
-  add.2d v8, v9, v11
-  mov x20, #25532
-  umulh x15, x15, x9
-  movk x20, #31025, lsl 16
-  adds x13, x17, x13
-  cinc x15, x15, hs
-  movk x20, #10002, lsl 32
-  movk x20, #17199, lsl 48
-  adds x4, x13, x4
-  cinc x13, x15, hs
-  dup.2d v9, x20
-  mul x15, x14, x9
-  mov.16b v10, v5
-  umulh x14, x14, x9
-  fmla.2d v10, v4, v9
-  fsub.2d v11, v6, v10
-  adds x13, x15, x13
-  cinc x14, x14, hs
-  fmla.2d v11, v4, v9
-  adds x5, x13, x5
-  cinc x13, x14, hs
-  add.2d v1, v1, v10
-  add.2d v0, v0, v11
-  mul x14, x16, x9
-  mov x15, #18830
-  umulh x9, x16, x9
-  movk x15, #2465, lsl 16
-  adds x13, x14, x13
-  cinc x9, x9, hs
-  movk x15, #36348, lsl 32
-  movk x15, #17194, lsl 48
-  adds x6, x13, x6
-  cinc x9, x9, hs
-  dup.2d v9, x15
-  add x7, x7, x9
-  mov.16b v10, v5
-  fmla.2d v10, v4, v9
-  mov x9, #56431
-  fsub.2d v11, v6, v10
-  movk x9, #30457, lsl 16
-  fmla.2d v11, v4, v9
-  add.2d v2, v2, v10
-  movk x9, #30012, lsl 32
-  add.2d v1, v1, v11
-  movk x9, #6382, lsl 48
-  mov x13, #21566
-  mov x14, #59151
-  movk x13, #43708, lsl 16
-  movk x13, #57685, lsl 32
-  movk x14, #41769, lsl 16
-  movk x13, #17185, lsl 48
-  movk x14, #32276, lsl 32
-  dup.2d v9, x13
-  mov.16b v10, v5
-  movk x14, #21677, lsl 48
-  fmla.2d v10, v4, v9
-  mov x13, #34015
-  fsub.2d v11, v6, v10
-  movk x13, #20342, lsl 16
-  fmla.2d v11, v4, v9
-  add.2d v7, v7, v10
-  movk x13, #13935, lsl 32
-  add.2d v2, v2, v11
-  movk x13, #11030, lsl 48
-  mov x15, #3072
-  movk x15, #8058, lsl 16
-  mov x16, #13689
-  movk x15, #46097, lsl 32
-  movk x16, #8159, lsl 16
-  movk x15, #17047, lsl 48
-  dup.2d v9, x15
-  movk x16, #215, lsl 32
-  mov.16b v10, v5
-  movk x16, #4913, lsl 48
-  fmla.2d v10, v4, v9
-  mul x15, x9, x10
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v4, v9
-  umulh x9, x9, x10
-  add.2d v3, v3, v10
+  movk x16, #28960, lsl 32
   adds x12, x15, x12
   cinc x9, x9, hs
-  add.2d v4, v7, v11
-  mov x15, #65535
-  mul x17, x14, x10
-  movk x15, #61439, lsl 16
-  umulh x14, x14, x10
-  movk x15, #62867, lsl 32
-  adds x9, x17, x9
-  cinc x14, x14, hs
-  movk x15, #1, lsl 48
-  umov x17, v8.d[0]
-  adds x4, x9, x4
-  cinc x9, x14, hs
-  umov x14, v8.d[1]
-  mul x20, x13, x10
-  mul x17, x17, x15
-  mul x14, x14, x15
-  umulh x13, x13, x10
-  and x15, x17, x8
-  adds x9, x20, x9
-  cinc x13, x13, hs
-  and x8, x14, x8
-  ins v7.d[0], x15
-  ins v7.d[1], x8
-  adds x5, x9, x5
-  cinc x8, x13, hs
-  ucvtf.2d v7, v7
-  mul x9, x16, x10
-  mov x13, #16
-  umulh x10, x16, x10
-  movk x13, #22847, lsl 32
-  movk x13, #17151, lsl 48
-  adds x8, x9, x8
-  cinc x9, x10, hs
-  dup.2d v9, x13
-  adds x6, x8, x6
-  cinc x8, x9, hs
-  mov.16b v10, v5
-  fmla.2d v10, v7, v9
-  add x7, x7, x8
-  fsub.2d v11, v6, v10
-  mov x8, #61005
-  fmla.2d v11, v7, v9
-  movk x8, #58262, lsl 16
-  add.2d v0, v0, v10
-  add.2d v8, v8, v11
-  movk x8, #32851, lsl 32
-  mov x9, #20728
-  movk x8, #11582, lsl 48
-  movk x9, #23588, lsl 16
-  movk x9, #7790, lsl 32
-  mov x10, #37581
-  movk x9, #17170, lsl 48
-  movk x10, #43836, lsl 16
-  dup.2d v9, x9
-  mov.16b v10, v5
-  movk x10, #36286, lsl 32
-  fmla.2d v10, v7, v9
-  movk x10, #51783, lsl 48
-  fsub.2d v11, v6, v10
-  mov x9, #10899
-  fmla.2d v11, v7, v9
-  add.2d v1, v1, v10
-  movk x9, #30709, lsl 16
-  add.2d v0, v0, v11
-  movk x9, #61551, lsl 32
-  mov x13, #16000
-  movk x13, #53891, lsl 16
-  movk x9, #45784, lsl 48
-  movk x13, #5509, lsl 32
-  mov x14, #36612
-  movk x13, #17144, lsl 48
-  dup.2d v9, x13
-  movk x14, #63402, lsl 16
-  mov.16b v10, v5
-  movk x14, #47623, lsl 32
-  fmla.2d v10, v7, v9
-  movk x14, #9430, lsl 48
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v7, v9
-  mul x13, x8, x11
-  add.2d v2, v2, v10
-  umulh x8, x8, x11
-  add.2d v1, v1, v11
-  mov x15, #46800
-  adds x12, x13, x12
-  cinc x8, x8, hs
-  movk x15, #2568, lsl 16
-  mul x13, x10, x11
-  movk x15, #1335, lsl 32
+  movk x16, #17153, lsl 48
+  mul x15, x10, x11
+  dup.2d v11, x16
+  mov.16b v12, v5
   umulh x10, x10, x11
-  movk x15, #17188, lsl 48
-  dup.2d v9, x15
-  adds x8, x13, x8
+  fmla.2d v12, v8, v11
+  adds x9, x15, x9
+  cinc x10, x10, hs
+  fsub.2d v13, v6, v12
+  adds x0, x9, x0
+  cinc x9, x10, hs
+  fmla.2d v13, v8, v11
+  add.2d v0, v0, v12
+  mul x10, x13, x11
+  add.2d v11, v15, v13
+  umulh x13, x13, x11
+  mov x15, #46128
+  adds x9, x10, x9
+  cinc x10, x13, hs
+  movk x15, #29964, lsl 16
+  adds x1, x9, x1
+  cinc x9, x10, hs
+  movk x15, #7587, lsl 32
+  movk x15, #17161, lsl 48
+  mul x10, x14, x11
+  dup.2d v12, x15
+  umulh x11, x14, x11
+  mov.16b v13, v5
+  adds x9, x10, x9
+  cinc x10, x11, hs
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  adds x2, x9, x2
+  cinc x9, x10, hs
+  fmla.2d v14, v8, v12
+  add x3, x3, x9
+  add.2d v1, v1, v13
+  mov x9, #65535
+  add.2d v0, v0, v14
+  mov x10, #52826
+  movk x9, #61439, lsl 16
+  movk x10, #57790, lsl 16
+  movk x9, #62867, lsl 32
+  movk x10, #55431, lsl 32
+  movk x9, #49889, lsl 48
+  movk x10, #17196, lsl 48
+  dup.2d v12, x10
+  mul x9, x9, x12
+  mov.16b v13, v5
+  mov x10, #1
+  fmla.2d v13, v8, v12
+  movk x10, #61440, lsl 16
+  fsub.2d v14, v6, v13
+  movk x10, #62867, lsl 32
+  fmla.2d v14, v8, v12
+  add.2d v2, v2, v13
+  movk x10, #17377, lsl 48
+  add.2d v1, v1, v14
+  mov x11, #28817
+  mov x13, #31276
+  movk x11, #31161, lsl 16
+  movk x13, #21262, lsl 16
+  movk x13, #2304, lsl 32
+  movk x11, #59464, lsl 32
+  movk x13, #17182, lsl 48
+  movk x11, #10291, lsl 48
+  dup.2d v12, x13
+  mov x13, #22621
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  movk x13, #33153, lsl 16
+  fsub.2d v14, v6, v13
+  movk x13, #17846, lsl 32
+  fmla.2d v14, v8, v12
+  movk x13, #47184, lsl 48
+  add.2d v7, v7, v13
+  add.2d v2, v2, v14
+  mov x14, #41001
+  mov x15, #28672
+  movk x14, #57649, lsl 16
+  movk x15, #24515, lsl 16
+  movk x14, #20082, lsl 32
+  movk x15, #54929, lsl 32
+  movk x15, #17064, lsl 48
+  movk x14, #12388, lsl 48
+  dup.2d v12, x15
+  mul x15, x10, x9
+  mov.16b v13, v5
+  umulh x10, x10, x9
+  fmla.2d v13, v8, v12
+  cmn x15, x12
+  cinc x10, x10, hs
+  fsub.2d v14, v6, v13
+  fmla.2d v14, v8, v12
+  mul x12, x11, x9
+  add.2d v3, v3, v13
+  umulh x11, x11, x9
+  add.2d v7, v7, v14
+  adds x10, x12, x10
+  cinc x11, x11, hs
+  ucvtf.2d v8, v9
+  mov x12, #44768
+  adds x0, x10, x0
+  cinc x10, x11, hs
+  movk x12, #51919, lsl 16
+  mul x11, x13, x9
+  movk x12, #6346, lsl 32
+  umulh x13, x13, x9
+  movk x12, #17133, lsl 48
+  dup.2d v9, x12
+  adds x10, x11, x10
+  cinc x11, x13, hs
+  mov.16b v12, v5
+  adds x1, x10, x1
+  cinc x10, x11, hs
+  fmla.2d v12, v8, v9
+  mul x11, x14, x9
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v9
+  umulh x9, x14, x9
+  add.2d v0, v0, v12
+  adds x10, x11, x10
+  cinc x9, x9, hs
+  add.2d v9, v11, v13
+  adds x2, x10, x2
+  cinc x9, x9, hs
+  mov x10, #47492
+  movk x10, #23630, lsl 16
+  add x3, x3, x9
+  movk x10, #49985, lsl 32
+  mul x9, x4, x4
+  movk x10, #17168, lsl 48
+  umulh x11, x4, x4
+  dup.2d v11, x10
+  mul x10, x4, x5
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  umulh x12, x4, x5
+  fsub.2d v13, v6, v12
+  adds x11, x10, x11
+  cinc x13, x12, hs
+  fmla.2d v13, v8, v11
+  mul x14, x4, x6
+  add.2d v1, v1, v12
+  add.2d v0, v0, v13
+  umulh x15, x4, x6
+  mov x16, #57936
+  adds x13, x14, x13
+  cinc x17, x15, hs
+  movk x16, #54828, lsl 16
+  mul x20, x4, x7
+  movk x16, #18292, lsl 32
+  movk x16, #17197, lsl 48
+  umulh x4, x4, x7
+  dup.2d v11, x16
+  adds x16, x20, x17
+  cinc x17, x4, hs
+  mov.16b v12, v5
+  adds x10, x10, x11
+  cinc x11, x12, hs
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  mul x12, x5, x5
+  fmla.2d v13, v8, v11
+  umulh x21, x5, x5
+  add.2d v2, v2, v12
+  adds x11, x12, x11
+  cinc x12, x21, hs
+  add.2d v1, v1, v13
+  adds x11, x11, x13
+  cinc x12, x12, hs
+  mov x13, #17708
+  movk x13, #43915, lsl 16
+  mul x21, x5, x6
+  movk x13, #64348, lsl 32
+  umulh x22, x5, x6
+  movk x13, #17188, lsl 48
+  adds x12, x21, x12
+  cinc x23, x22, hs
+  dup.2d v11, x13
+  mov.16b v12, v5
+  adds x12, x12, x16
+  cinc x13, x23, hs
+  fmla.2d v12, v8, v11
+  mul x16, x5, x7
+  fsub.2d v13, v6, v12
+  umulh x5, x5, x7
+  fmla.2d v13, v8, v11
+  add.2d v7, v7, v12
+  adds x13, x16, x13
+  cinc x23, x5, hs
+  add.2d v2, v2, v13
+  adds x13, x13, x17
+  cinc x17, x23, hs
+  mov x23, #29184
+  adds x11, x14, x11
+  cinc x14, x15, hs
+  movk x23, #20789, lsl 16
+  movk x23, #19197, lsl 32
+  adds x14, x21, x14
+  cinc x15, x22, hs
+  movk x23, #17083, lsl 48
+  adds x12, x14, x12
+  cinc x14, x15, hs
+  dup.2d v11, x23
+  mul x15, x6, x6
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  umulh x21, x6, x6
+  fsub.2d v13, v6, v12
+  adds x14, x15, x14
+  cinc x15, x21, hs
+  fmla.2d v13, v8, v11
+  adds x13, x14, x13
+  cinc x14, x15, hs
+  add.2d v3, v3, v12
+  mul x15, x6, x7
+  add.2d v7, v7, v13
+  ucvtf.2d v8, v10
+  umulh x6, x6, x7
+  mov x21, #58856
+  adds x14, x15, x14
+  cinc x22, x6, hs
+  movk x21, #14953, lsl 16
+  adds x14, x14, x17
+  cinc x17, x22, hs
+  movk x21, #15155, lsl 32
+  movk x21, #17181, lsl 48
+  adds x12, x20, x12
+  cinc x4, x4, hs
+  dup.2d v10, x21
+  adds x4, x16, x4
+  cinc x5, x5, hs
+  mov.16b v11, v5
+  adds x4, x4, x13
+  cinc x5, x5, hs
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  adds x5, x15, x5
+  cinc x6, x6, hs
+  fmla.2d v12, v8, v10
+  adds x5, x5, x14
+  cinc x6, x6, hs
+  add.2d v0, v0, v11
+  mul x13, x7, x7
+  add.2d v9, v9, v12
+  mov x14, #35392
+  umulh x7, x7, x7
+  movk x14, #12477, lsl 16
+  adds x6, x13, x6
+  cinc x7, x7, hs
+  movk x14, #56780, lsl 32
+  adds x6, x6, x17
+  cinc x7, x7, hs
+  movk x14, #17142, lsl 48
+  mov x13, #48718
+  dup.2d v10, x14
+  mov.16b v11, v5
+  movk x13, #4732, lsl 16
+  fmla.2d v11, v8, v10
+  movk x13, #45078, lsl 32
+  fsub.2d v12, v6, v11
+  movk x13, #39852, lsl 48
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  mov x14, #16676
+  add.2d v0, v0, v12
+  movk x14, #12692, lsl 16
+  mov x15, #9848
+  movk x14, #20986, lsl 32
+  movk x15, #54501, lsl 16
+  movk x15, #31540, lsl 32
+  movk x14, #2848, lsl 48
+  movk x15, #17170, lsl 48
+  mov x16, #51052
+  dup.2d v10, x15
+  movk x16, #24721, lsl 16
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  movk x16, #61092, lsl 32
+  fsub.2d v12, v6, v11
+  movk x16, #45156, lsl 48
+  fmla.2d v12, v8, v10
+  mov x15, #3197
+  add.2d v2, v2, v11
+  add.2d v1, v1, v12
+  movk x15, #18936, lsl 16
+  mov x17, #9584
+  movk x15, #10922, lsl 32
+  movk x17, #63883, lsl 16
+  movk x15, #11014, lsl 48
+  movk x17, #18253, lsl 32
+  mul x20, x13, x9
+  movk x17, #17190, lsl 48
+  dup.2d v10, x17
+  umulh x13, x13, x9
+  mov.16b v11, v5
+  adds x12, x20, x12
+  cinc x13, x13, hs
+  fmla.2d v11, v8, v10
+  mul x17, x14, x9
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  umulh x14, x14, x9
+  add.2d v7, v7, v11
+  adds x13, x17, x13
+  cinc x14, x14, hs
+  add.2d v2, v2, v12
+  adds x4, x13, x4
+  cinc x13, x14, hs
+  mov x14, #51712
+  movk x14, #16093, lsl 16
+  mul x17, x16, x9
+  movk x14, #30633, lsl 32
+  umulh x16, x16, x9
+  movk x14, #17068, lsl 48
+  adds x13, x17, x13
+  cinc x16, x16, hs
+  dup.2d v10, x14
+  mov.16b v11, v5
+  adds x5, x13, x5
+  cinc x13, x16, hs
+  fmla.2d v11, v8, v10
+  mul x14, x15, x9
+  fsub.2d v12, v6, v11
+  umulh x9, x15, x9
+  fmla.2d v12, v8, v10
+  adds x13, x14, x13
+  cinc x9, x9, hs
+  add.2d v3, v3, v11
+  add.2d v7, v7, v12
+  adds x6, x13, x6
+  cinc x9, x9, hs
+  ucvtf.2d v4, v4
+  add x7, x7, x9
+  mov x9, #34724
+  mov x13, #56431
+  movk x9, #40393, lsl 16
+  movk x9, #23752, lsl 32
+  movk x13, #30457, lsl 16
+  movk x9, #17184, lsl 48
+  movk x13, #30012, lsl 32
+  dup.2d v8, x9
+  movk x13, #6382, lsl 48
+  mov.16b v10, v5
+  fmla.2d v10, v4, v8
+  mov x9, #59151
+  fsub.2d v11, v6, v10
+  movk x9, #41769, lsl 16
+  fmla.2d v11, v4, v8
+  movk x9, #32276, lsl 32
+  add.2d v0, v0, v10
+  add.2d v8, v9, v11
+  movk x9, #21677, lsl 48
+  mov x14, #25532
+  mov x15, #34015
+  movk x14, #31025, lsl 16
+  movk x15, #20342, lsl 16
+  movk x14, #10002, lsl 32
+  movk x14, #17199, lsl 48
+  movk x15, #13935, lsl 32
+  dup.2d v9, x14
+  movk x15, #11030, lsl 48
+  mov.16b v10, v5
+  mov x14, #13689
+  fmla.2d v10, v4, v9
+  movk x14, #8159, lsl 16
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  movk x14, #215, lsl 32
+  add.2d v1, v1, v10
+  movk x14, #4913, lsl 48
+  add.2d v0, v0, v11
+  mul x16, x13, x10
+  mov x17, #18830
+  movk x17, #2465, lsl 16
+  umulh x13, x13, x10
+  movk x17, #36348, lsl 32
+  adds x12, x16, x12
+  cinc x13, x13, hs
+  movk x17, #17194, lsl 48
+  mul x16, x9, x10
+  dup.2d v9, x17
+  mov.16b v10, v5
+  umulh x9, x9, x10
+  fmla.2d v10, v4, v9
+  adds x13, x16, x13
+  cinc x9, x9, hs
+  fsub.2d v11, v6, v10
+  adds x4, x13, x4
+  cinc x9, x9, hs
+  fmla.2d v11, v4, v9
+  add.2d v2, v2, v10
+  mul x13, x15, x10
+  add.2d v1, v1, v11
+  umulh x15, x15, x10
+  mov x16, #21566
+  adds x9, x13, x9
+  cinc x13, x15, hs
+  movk x16, #43708, lsl 16
+  movk x16, #57685, lsl 32
+  adds x5, x9, x5
+  cinc x9, x13, hs
+  movk x16, #17185, lsl 48
+  mul x13, x14, x10
+  dup.2d v9, x16
+  umulh x10, x14, x10
+  mov.16b v10, v5
+  adds x9, x13, x9
+  cinc x10, x10, hs
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  adds x6, x9, x6
+  cinc x9, x10, hs
+  fmla.2d v11, v4, v9
+  add x7, x7, x9
+  add.2d v7, v7, v10
+  mov x9, #61005
+  add.2d v2, v2, v11
+  mov x10, #3072
+  movk x9, #58262, lsl 16
+  movk x10, #8058, lsl 16
+  movk x9, #32851, lsl 32
+  movk x10, #46097, lsl 32
+  movk x9, #11582, lsl 48
+  movk x10, #17047, lsl 48
+  dup.2d v9, x10
+  mov x10, #37581
+  mov.16b v10, v5
+  movk x10, #43836, lsl 16
+  fmla.2d v10, v4, v9
+  movk x10, #36286, lsl 32
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  movk x10, #51783, lsl 48
+  add.2d v3, v3, v10
+  mov x13, #10899
+  add.2d v4, v7, v11
+  movk x13, #30709, lsl 16
+  mov x14, #65535
+  movk x13, #61551, lsl 32
+  movk x14, #61439, lsl 16
+  movk x14, #62867, lsl 32
+  movk x13, #45784, lsl 48
+  movk x14, #1, lsl 48
+  mov x15, #36612
+  umov x16, v8.d[0]
+  movk x15, #63402, lsl 16
+  umov x17, v8.d[1]
+  mul x16, x16, x14
+  movk x15, #47623, lsl 32
+  mul x14, x17, x14
+  movk x15, #9430, lsl 48
+  and x16, x16, x8
+  mul x17, x9, x11
+  and x8, x14, x8
+  ins v7.d[0], x16
+  ins v7.d[1], x8
+  umulh x8, x9, x11
+  ucvtf.2d v7, v7
+  adds x9, x17, x12
+  cinc x8, x8, hs
+  mov x12, #16
+  mul x14, x10, x11
+  movk x12, #22847, lsl 32
+  movk x12, #17151, lsl 48
+  umulh x10, x10, x11
+  dup.2d v9, x12
+  adds x8, x14, x8
   cinc x10, x10, hs
   mov.16b v10, v5
   adds x4, x8, x4
   cinc x8, x10, hs
   fmla.2d v10, v7, v9
   fsub.2d v11, v6, v10
-  mul x10, x9, x11
+  mul x10, x13, x11
   fmla.2d v11, v7, v9
-  umulh x9, x9, x11
-  add.2d v4, v4, v10
-  add.2d v2, v2, v11
+  umulh x12, x13, x11
+  add.2d v0, v0, v10
   adds x8, x10, x8
-  cinc x9, x9, hs
-  mov x10, #39040
+  cinc x10, x12, hs
+  add.2d v8, v8, v11
   adds x5, x8, x5
-  cinc x8, x9, hs
-  movk x10, #14704, lsl 16
-  mul x9, x14, x11
-  movk x10, #12839, lsl 32
-  movk x10, #17096, lsl 48
-  umulh x11, x14, x11
+  cinc x8, x10, hs
+  mov x10, #20728
+  movk x10, #23588, lsl 16
+  mul x12, x15, x11
+  movk x10, #7790, lsl 32
+  umulh x11, x15, x11
+  movk x10, #17170, lsl 48
+  adds x8, x12, x8
+  cinc x11, x11, hs
   dup.2d v9, x10
-  adds x8, x9, x8
-  cinc x9, x11, hs
-  mov.16b v5, v5
-  fmla.2d v5, v7, v9
+  mov.16b v10, v5
   adds x6, x8, x6
-  cinc x8, x9, hs
-  fsub.2d v6, v6, v5
+  cinc x8, x11, hs
+  fmla.2d v10, v7, v9
   add x7, x7, x8
-  fmla.2d v6, v7, v9
+  fsub.2d v11, v6, v10
   mov x8, #65535
-  add.2d v3, v3, v5
-  add.2d v4, v4, v6
+  fmla.2d v11, v7, v9
+  add.2d v1, v1, v10
   movk x8, #61439, lsl 16
-  mov x9, #140737488355328
+  add.2d v0, v0, v11
   movk x8, #62867, lsl 32
-  dup.2d v5, x9
-  and.16b v5, v3, v5
+  mov x10, #16000
   movk x8, #49889, lsl 48
-  cmeq.2d v5, v5, #0
-  mul x8, x8, x12
-  mov x9, #2
-  movk x9, #57344, lsl 16
-  mov x10, #1
-  movk x9, #60199, lsl 32
-  movk x10, #61440, lsl 16
-  movk x9, #3, lsl 48
-  movk x10, #62867, lsl 32
-  dup.2d v6, x9
-  bic.16b v6, v6, v5
-  movk x10, #17377, lsl 48
-  mov x9, #10364
-  mov x11, #28817
-  movk x9, #11794, lsl 16
-  movk x9, #3895, lsl 32
-  movk x11, #31161, lsl 16
-  movk x9, #9, lsl 48
-  movk x11, #59464, lsl 32
-  dup.2d v7, x9
-  movk x11, #10291, lsl 48
-  bic.16b v7, v7, v5
-  mov x9, #26576
+  movk x10, #53891, lsl 16
+  movk x10, #5509, lsl 32
+  mul x8, x8, x9
+  movk x10, #17144, lsl 48
+  mov x11, #1
+  dup.2d v9, x10
+  movk x11, #61440, lsl 16
+  mov.16b v10, v5
+  movk x11, #62867, lsl 32
+  fmla.2d v10, v7, v9
+  fsub.2d v11, v6, v10
+  movk x11, #17377, lsl 48
+  fmla.2d v11, v7, v9
+  mov x10, #28817
+  add.2d v2, v2, v10
+  movk x10, #31161, lsl 16
+  add.2d v9, v1, v11
+  mov x12, #46800
+  movk x10, #59464, lsl 32
+  movk x12, #2568, lsl 16
+  movk x10, #10291, lsl 48
+  movk x12, #1335, lsl 32
   mov x13, #22621
-  movk x9, #47696, lsl 16
+  movk x12, #17188, lsl 48
+  dup.2d v1, x12
   movk x13, #33153, lsl 16
-  movk x9, #688, lsl 32
-  movk x9, #3, lsl 48
+  mov.16b v10, v5
   movk x13, #17846, lsl 32
-  dup.2d v9, x9
+  fmla.2d v10, v7, v1
   movk x13, #47184, lsl 48
-  bic.16b v9, v9, v5
-  mov x9, #46800
-  mov x14, #41001
-  movk x9, #2568, lsl 16
-  movk x14, #57649, lsl 16
-  movk x9, #1335, lsl 32
-  movk x14, #20082, lsl 32
-  movk x9, #4, lsl 48
-  dup.2d v10, x9
-  movk x14, #12388, lsl 48
-  bic.16b v10, v10, v5
-  mul x9, x10, x8
-  mov x15, #49763
-  movk x15, #40165, lsl 16
-  umulh x10, x10, x8
-  movk x15, #24776, lsl 32
-  cmn x9, x12
-  cinc x10, x10, hs
-  dup.2d v11, x15
-  mul x9, x11, x8
-  bic.16b v5, v11, v5
-  sub.2d v0, v0, v6
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v1
+  mov x12, #41001
+  add.2d v1, v4, v10
+  movk x12, #57649, lsl 16
+  add.2d v4, v2, v11
+  movk x12, #20082, lsl 32
+  mov x14, #39040
+  movk x14, #14704, lsl 16
+  movk x12, #12388, lsl 48
+  movk x14, #12839, lsl 32
+  mul x15, x11, x8
+  movk x14, #17096, lsl 48
   umulh x11, x11, x8
-  ssra.2d v0, v8, #52
-  adds x9, x9, x10
-  cinc x10, x11, hs
-  sub.2d v6, v1, v7
-  ssra.2d v6, v0, #52
+  dup.2d v2, x14
+  cmn x15, x9
+  cinc x11, x11, hs
+  mov.16b v5, v5
+  fmla.2d v5, v7, v2
+  mul x9, x10, x8
+  fsub.2d v6, v6, v5
+  umulh x10, x10, x8
+  fmla.2d v6, v7, v2
+  adds x9, x9, x11
+  cinc x10, x10, hs
+  add.2d v5, v3, v5
+  add.2d v6, v1, v6
   adds x4, x9, x4
   cinc x9, x10, hs
-  sub.2d v7, v2, v9
+  ssra.2d v0, v8, #52
   mul x10, x13, x8
-  ssra.2d v7, v6, #52
-  sub.2d v4, v4, v10
+  ssra.2d v9, v0, #52
   umulh x11, x13, x8
-  ssra.2d v4, v7, #52
+  ssra.2d v4, v9, #52
+  ssra.2d v6, v4, #52
   adds x9, x10, x9
   cinc x10, x11, hs
-  sub.2d v5, v3, v5
+  ssra.2d v5, v6, #52
   adds x5, x9, x5
   cinc x9, x10, hs
-  ssra.2d v5, v4, #52
-  ushr.2d v1, v6, #12
-  mul x10, x14, x8
-  ushr.2d v2, v7, #24
-  umulh x8, x14, x8
-  ushr.2d v3, v4, #36
-  sli.2d v0, v6, #52
+  ushr.2d v1, v9, #12
+  mul x10, x12, x8
+  ushr.2d v2, v4, #24
+  ushr.2d v3, v6, #36
+  umulh x8, x12, x8
+  sli.2d v0, v9, #52
   adds x9, x10, x9
   cinc x8, x8, hs
-  sli.2d v1, v7, #40
+  sli.2d v1, v4, #40
   adds x6, x9, x6
   cinc x8, x8, hs
-  sli.2d v2, v4, #28
+  sli.2d v2, v6, #28
   sli.2d v3, v5, #16
   add x7, x7, x8

--- a/block-multiplier/src/aarch64/montgomery_square_log_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_square_log_interleaved_3.s
@@ -1,0 +1,749 @@
+// GENERATED FILE, DO NOT EDIT!
+// in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+// in("v0") av[0], in("v1") av[1], in("v2") av[2], in("v3") av[3],
+// lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3") out[3],
+// lateout("v0") outv[0], lateout("v1") outv[1], lateout("v2") outv[2], lateout("v3") outv[3],
+// lateout("x4") _, lateout("x5") _, lateout("x6") _, lateout("x7") _, lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _, lateout("x17") _, lateout("v4") _, lateout("v5") _, lateout("v6") _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _, lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _, lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _, lateout("v19") _,
+// lateout("lr") _
+  mov x4, #4503599627370495
+  dup.2d v4, x4
+  mul x5, x0, x0
+  mov x6, #5075556780046548992
+  dup.2d v5, x6
+  mov x6, #1
+  umulh x7, x0, x0
+  movk x6, #18032, lsl 48
+  dup.2d v6, x6
+  shl.2d v7, v1, #14
+  mul x6, x0, x1
+  shl.2d v8, v2, #26
+  shl.2d v9, v3, #38
+  ushr.2d v3, v3, #14
+  umulh x8, x0, x1
+  shl.2d v10, v0, #2
+  usra.2d v7, v0, #50
+  usra.2d v8, v1, #38
+  adds x7, x6, x7
+  cinc x9, x8, hs
+  usra.2d v9, v2, #26
+  and.16b v0, v10, v4
+  mul x10, x0, x2
+  and.16b v1, v7, v4
+  and.16b v2, v8, v4
+  and.16b v7, v9, v4
+  umulh x11, x0, x2
+  mov x12, #13605374474286268416
+  dup.2d v8, x12
+  mov x12, #6440147467139809280
+  adds x9, x10, x9
+  cinc x13, x11, hs
+  dup.2d v9, x12
+  mov x12, #3688448094816436224
+  dup.2d v10, x12
+  mul x12, x0, x3
+  mov x14, #9209861237972664320
+  dup.2d v11, x14
+  mov x14, #12218265789056155648
+  umulh x0, x0, x3
+  dup.2d v12, x14
+  mov x14, #17739678932212383744
+  adds x13, x12, x13
+  cinc x15, x0, hs
+  dup.2d v13, x14
+  mov x14, #2301339409586323456
+  dup.2d v14, x14
+  adds x6, x6, x7
+  cinc x7, x8, hs
+  mov x8, #7822752552742551552
+  dup.2d v15, x8
+  mov x8, #5071053180419178496
+  mul x14, x1, x1
+  dup.2d v16, x8
+  mov x8, #16352570246982270976
+  dup.2d v17, x8
+  umulh x8, x1, x1
+  ucvtf.2d v0, v0
+  ucvtf.2d v1, v1
+  ucvtf.2d v2, v2
+  adds x7, x14, x7
+  cinc x8, x8, hs
+  ucvtf.2d v7, v7
+  ucvtf.2d v3, v3
+  adds x7, x7, x9
+  cinc x8, x8, hs
+  mov.16b v18, v5
+  fmla.2d v18, v0, v0
+  fsub.2d v19, v6, v18
+  mul x9, x1, x2
+  fmla.2d v19, v0, v0
+  add.2d v10, v10, v18
+  add.2d v8, v8, v19
+  umulh x14, x1, x2
+  mov.16b v18, v5
+  fmla.2d v18, v0, v1
+  fsub.2d v19, v6, v18
+  adds x8, x9, x8
+  cinc x16, x14, hs
+  fmla.2d v19, v0, v1
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  adds x8, x8, x13
+  cinc x13, x16, hs
+  add.2d v12, v12, v18
+  add.2d v10, v10, v19
+  mul x16, x1, x3
+  mov.16b v18, v5
+  fmla.2d v18, v0, v2
+  fsub.2d v19, v6, v18
+  umulh x1, x1, x3
+  fmla.2d v19, v0, v2
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  adds x13, x16, x13
+  cinc x17, x1, hs
+  add.2d v14, v14, v18
+  add.2d v12, v12, v19
+  mov.16b v18, v5
+  adds x13, x13, x15
+  cinc x15, x17, hs
+  fmla.2d v18, v0, v7
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v7
+  adds x7, x10, x7
+  cinc x10, x11, hs
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  adds x9, x9, x10
+  cinc x10, x14, hs
+  add.2d v16, v16, v18
+  add.2d v14, v14, v19
+  mov.16b v18, v5
+  adds x8, x9, x8
+  cinc x9, x10, hs
+  fmla.2d v18, v0, v3
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v3
+  mul x10, x2, x2
+  add.2d v0, v18, v18
+  add.2d v18, v19, v19
+  add.2d v0, v17, v0
+  umulh x11, x2, x2
+  add.2d v16, v16, v18
+  mov.16b v17, v5
+  fmla.2d v17, v1, v1
+  adds x9, x10, x9
+  cinc x10, x11, hs
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v1
+  adds x9, x9, x13
+  cinc x10, x10, hs
+  add.2d v14, v14, v17
+  add.2d v12, v12, v18
+  mov.16b v17, v5
+  mul x11, x2, x3
+  fmla.2d v17, v1, v2
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v2
+  umulh x2, x2, x3
+  add.2d v17, v17, v17
+  add.2d v18, v18, v18
+  add.2d v16, v16, v17
+  adds x10, x11, x10
+  cinc x13, x2, hs
+  add.2d v14, v14, v18
+  mov.16b v17, v5
+  fmla.2d v17, v1, v7
+  adds x10, x10, x15
+  cinc x13, x13, hs
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v7
+  adds x8, x12, x8
+  cinc x0, x0, hs
+  add.2d v17, v17, v17
+  add.2d v18, v18, v18
+  add.2d v0, v0, v17
+  adds x0, x16, x0
+  cinc x1, x1, hs
+  add.2d v16, v16, v18
+  mov.16b v17, v5
+  fmla.2d v17, v1, v3
+  adds x0, x0, x9
+  cinc x1, x1, hs
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v3
+  add.2d v1, v17, v17
+  adds x1, x11, x1
+  cinc x2, x2, hs
+  add.2d v17, v18, v18
+  add.2d v1, v15, v1
+  add.2d v0, v0, v17
+  adds x1, x1, x10
+  cinc x2, x2, hs
+  mov.16b v15, v5
+  fmla.2d v15, v2, v2
+  mul x9, x3, x3
+  fsub.2d v17, v6, v15
+  fmla.2d v17, v2, v2
+  add.2d v0, v0, v15
+  umulh x3, x3, x3
+  add.2d v15, v16, v17
+  mov.16b v16, v5
+  fmla.2d v16, v2, v7
+  adds x2, x9, x2
+  cinc x3, x3, hs
+  fsub.2d v17, v6, v16
+  fmla.2d v17, v2, v7
+  add.2d v16, v16, v16
+  adds x2, x2, x13
+  cinc x3, x3, hs
+  add.2d v17, v17, v17
+  add.2d v1, v1, v16
+  add.2d v0, v0, v17
+  mov x9, #56431
+  mov.16b v16, v5
+  fmla.2d v16, v2, v3
+  fsub.2d v17, v6, v16
+  movk x9, #30457, lsl 16
+  fmla.2d v17, v2, v3
+  add.2d v2, v16, v16
+  movk x9, #30012, lsl 32
+  add.2d v16, v17, v17
+  add.2d v2, v13, v2
+  add.2d v1, v1, v16
+  movk x9, #6382, lsl 48
+  mov.16b v13, v5
+  fmla.2d v13, v7, v7
+  fsub.2d v16, v6, v13
+  mov x10, #59151
+  fmla.2d v16, v7, v7
+  add.2d v2, v2, v13
+  add.2d v1, v1, v16
+  movk x10, #41769, lsl 16
+  mov.16b v13, v5
+  fmla.2d v13, v7, v3
+  fsub.2d v16, v6, v13
+  movk x10, #32276, lsl 32
+  fmla.2d v16, v7, v3
+  add.2d v7, v13, v13
+  movk x10, #21677, lsl 48
+  add.2d v13, v16, v16
+  add.2d v7, v11, v7
+  add.2d v2, v2, v13
+  mov x11, #34015
+  mov.16b v11, v5
+  fmla.2d v11, v3, v3
+  fsub.2d v13, v6, v11
+  movk x11, #20342, lsl 16
+  fmla.2d v13, v3, v3
+  add.2d v3, v9, v11
+  add.2d v7, v7, v13
+  movk x11, #13935, lsl 32
+  usra.2d v10, v8, #52
+  usra.2d v12, v10, #52
+  usra.2d v14, v12, #52
+  movk x11, #11030, lsl 48
+  usra.2d v15, v14, #52
+  and.16b v8, v8, v4
+  mov x12, #13689
+  and.16b v9, v10, v4
+  and.16b v10, v12, v4
+  and.16b v4, v14, v4
+  movk x12, #8159, lsl 16
+  ucvtf.2d v8, v8
+  mov x13, #37864
+  movk x13, #1815, lsl 16
+  movk x12, #215, lsl 32
+  movk x13, #28960, lsl 32
+  movk x13, #17153, lsl 48
+  dup.2d v11, x13
+  movk x12, #4913, lsl 48
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  mul x13, x9, x5
+  fmla.2d v13, v8, v11
+  add.2d v0, v0, v12
+  umulh x14, x9, x5
+  add.2d v11, v15, v13
+  mov x15, #46128
+  movk x15, #29964, lsl 16
+  adds x7, x13, x7
+  cinc x13, x14, hs
+  movk x15, #7587, lsl 32
+  movk x15, #17161, lsl 48
+  dup.2d v12, x15
+  mul x14, x10, x5
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  umulh x15, x10, x5
+  fmla.2d v14, v8, v12
+  add.2d v1, v1, v13
+  add.2d v0, v0, v14
+  adds x13, x14, x13
+  cinc x14, x15, hs
+  mov x15, #52826
+  movk x15, #57790, lsl 16
+  adds x8, x13, x8
+  cinc x13, x14, hs
+  movk x15, #55431, lsl 32
+  movk x15, #17196, lsl 48
+  dup.2d v12, x15
+  mul x14, x11, x5
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  umulh x15, x11, x5
+  fmla.2d v14, v8, v12
+  add.2d v2, v2, v13
+  add.2d v1, v1, v14
+  adds x13, x14, x13
+  cinc x14, x15, hs
+  mov x15, #31276
+  movk x15, #21262, lsl 16
+  movk x15, #2304, lsl 32
+  adds x0, x13, x0
+  cinc x13, x14, hs
+  movk x15, #17182, lsl 48
+  dup.2d v12, x15
+  mul x14, x12, x5
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  umulh x5, x12, x5
+  fmla.2d v14, v8, v12
+  add.2d v7, v7, v13
+  add.2d v2, v2, v14
+  adds x13, x14, x13
+  cinc x5, x5, hs
+  mov x14, #28672
+  movk x14, #24515, lsl 16
+  movk x14, #54929, lsl 32
+  adds x1, x13, x1
+  cinc x5, x5, hs
+  movk x14, #17064, lsl 48
+  dup.2d v12, x14
+  mov.16b v13, v5
+  adds x2, x2, x5
+  cinc x3, x3, hs
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  mul x5, x9, x6
+  fmla.2d v14, v8, v12
+  add.2d v3, v3, v13
+  add.2d v7, v7, v14
+  umulh x9, x9, x6
+  ucvtf.2d v8, v9
+  mov x13, #44768
+  movk x13, #51919, lsl 16
+  adds x5, x5, x8
+  cinc x8, x9, hs
+  movk x13, #6346, lsl 32
+  movk x13, #17133, lsl 48
+  dup.2d v9, x13
+  mul x9, x10, x6
+  mov.16b v12, v5
+  fmla.2d v12, v8, v9
+  fsub.2d v13, v6, v12
+  umulh x10, x10, x6
+  fmla.2d v13, v8, v9
+  add.2d v0, v0, v12
+  adds x8, x9, x8
+  cinc x9, x10, hs
+  add.2d v9, v11, v13
+  mov x10, #47492
+  movk x10, #23630, lsl 16
+  adds x0, x8, x0
+  cinc x8, x9, hs
+  movk x10, #49985, lsl 32
+  movk x10, #17168, lsl 48
+  dup.2d v11, x10
+  mul x9, x11, x6
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  umulh x10, x11, x6
+  fmla.2d v13, v8, v11
+  add.2d v1, v1, v12
+  add.2d v0, v0, v13
+  adds x8, x9, x8
+  cinc x9, x10, hs
+  mov x10, #57936
+  movk x10, #54828, lsl 16
+  adds x1, x8, x1
+  cinc x8, x9, hs
+  movk x10, #18292, lsl 32
+  movk x10, #17197, lsl 48
+  dup.2d v11, x10
+  mul x9, x12, x6
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  umulh x6, x12, x6
+  fmla.2d v13, v8, v11
+  add.2d v2, v2, v12
+  add.2d v1, v1, v13
+  adds x8, x9, x8
+  cinc x6, x6, hs
+  mov x9, #17708
+  movk x9, #43915, lsl 16
+  movk x9, #64348, lsl 32
+  adds x2, x8, x2
+  cinc x6, x6, hs
+  movk x9, #17188, lsl 48
+  dup.2d v11, x9
+  mov.16b v12, v5
+  add x3, x3, x6
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  mov x6, #61005
+  fmla.2d v13, v8, v11
+  add.2d v7, v7, v12
+  add.2d v2, v2, v13
+  movk x6, #58262, lsl 16
+  mov x8, #29184
+  movk x8, #20789, lsl 16
+  movk x8, #19197, lsl 32
+  movk x6, #32851, lsl 32
+  movk x8, #17083, lsl 48
+  dup.2d v11, x8
+  mov.16b v12, v5
+  movk x6, #11582, lsl 48
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v11
+  mov x8, #37581
+  add.2d v3, v3, v12
+  add.2d v7, v7, v13
+  movk x8, #43836, lsl 16
+  ucvtf.2d v8, v10
+  mov x9, #58856
+  movk x9, #14953, lsl 16
+  movk x8, #36286, lsl 32
+  movk x9, #15155, lsl 32
+  movk x9, #17181, lsl 48
+  dup.2d v10, x9
+  movk x8, #51783, lsl 48
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  mov x9, #10899
+  fmla.2d v12, v8, v10
+  add.2d v0, v0, v11
+  add.2d v9, v9, v12
+  movk x9, #30709, lsl 16
+  mov x10, #35392
+  movk x10, #12477, lsl 16
+  movk x9, #61551, lsl 32
+  movk x10, #56780, lsl 32
+  movk x10, #17142, lsl 48
+  dup.2d v10, x10
+  movk x9, #45784, lsl 48
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  mov x10, #36612
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  add.2d v0, v0, v12
+  movk x10, #63402, lsl 16
+  mov x11, #9848
+  movk x11, #54501, lsl 16
+  movk x11, #31540, lsl 32
+  movk x10, #47623, lsl 32
+  movk x11, #17170, lsl 48
+  dup.2d v10, x11
+  movk x10, #9430, lsl 48
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  mul x11, x6, x7
+  fmla.2d v12, v8, v10
+  add.2d v2, v2, v11
+  add.2d v1, v1, v12
+  umulh x6, x6, x7
+  mov x12, #9584
+  movk x12, #63883, lsl 16
+  movk x12, #18253, lsl 32
+  adds x5, x11, x5
+  cinc x6, x6, hs
+  movk x12, #17190, lsl 48
+  dup.2d v10, x12
+  mov.16b v11, v5
+  mul x11, x8, x7
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  umulh x8, x8, x7
+  fmla.2d v12, v8, v10
+  add.2d v7, v7, v11
+  add.2d v2, v2, v12
+  adds x6, x11, x6
+  cinc x8, x8, hs
+  mov x11, #51712
+  movk x11, #16093, lsl 16
+  movk x11, #30633, lsl 32
+  adds x0, x6, x0
+  cinc x6, x8, hs
+  movk x11, #17068, lsl 48
+  dup.2d v10, x11
+  mov.16b v11, v5
+  mul x8, x9, x7
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  umulh x9, x9, x7
+  add.2d v3, v3, v11
+  add.2d v7, v7, v12
+  adds x6, x8, x6
+  cinc x8, x9, hs
+  ucvtf.2d v4, v4
+  mov x9, #34724
+  movk x9, #40393, lsl 16
+  adds x1, x6, x1
+  cinc x6, x8, hs
+  movk x9, #23752, lsl 32
+  movk x9, #17184, lsl 48
+  dup.2d v8, x9
+  mul x8, x10, x7
+  mov.16b v10, v5
+  fmla.2d v10, v4, v8
+  fsub.2d v11, v6, v10
+  umulh x7, x10, x7
+  fmla.2d v11, v4, v8
+  add.2d v0, v0, v10
+  add.2d v8, v9, v11
+  adds x6, x8, x6
+  cinc x7, x7, hs
+  mov x8, #25532
+  movk x8, #31025, lsl 16
+  adds x2, x6, x2
+  cinc x6, x7, hs
+  movk x8, #10002, lsl 32
+  movk x8, #17199, lsl 48
+  dup.2d v9, x8
+  add x3, x3, x6
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  mov x6, #65535
+  fmla.2d v11, v4, v9
+  add.2d v1, v1, v10
+  add.2d v0, v0, v11
+  movk x6, #61439, lsl 16
+  mov x7, #18830
+  movk x7, #2465, lsl 16
+  movk x7, #36348, lsl 32
+  movk x6, #62867, lsl 32
+  movk x7, #17194, lsl 48
+  dup.2d v9, x7
+  movk x6, #49889, lsl 48
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  mul x6, x6, x5
+  fmla.2d v11, v4, v9
+  add.2d v2, v2, v10
+  add.2d v1, v1, v11
+  mov x7, #1
+  mov x8, #21566
+  movk x8, #43708, lsl 16
+  movk x8, #57685, lsl 32
+  movk x7, #61440, lsl 16
+  movk x8, #17185, lsl 48
+  dup.2d v9, x8
+  mov.16b v10, v5
+  movk x7, #62867, lsl 32
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  movk x7, #17377, lsl 48
+  fmla.2d v11, v4, v9
+  add.2d v7, v7, v10
+  add.2d v2, v2, v11
+  mov x8, #28817
+  mov x9, #3072
+  movk x9, #8058, lsl 16
+  movk x9, #46097, lsl 32
+  movk x8, #31161, lsl 16
+  movk x9, #17047, lsl 48
+  dup.2d v9, x9
+  mov.16b v10, v5
+  movk x8, #59464, lsl 32
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  movk x8, #10291, lsl 48
+  add.2d v3, v3, v10
+  add.2d v4, v7, v11
+  mov x9, #65535
+  mov x10, #22621
+  movk x9, #61439, lsl 16
+  movk x9, #62867, lsl 32
+  movk x10, #33153, lsl 16
+  movk x9, #1, lsl 48
+  umov x11, v8.d[0]
+  umov x12, v8.d[1]
+  movk x10, #17846, lsl 32
+  mul x11, x11, x9
+  mul x9, x12, x9
+  and x11, x11, x4
+  movk x10, #47184, lsl 48
+  and x4, x9, x4
+  ins v7.d[0], x11
+  ins v7.d[1], x4
+  ucvtf.2d v7, v7
+  mov x4, #41001
+  mov x9, #16
+  movk x9, #22847, lsl 32
+  movk x9, #17151, lsl 48
+  movk x4, #57649, lsl 16
+  dup.2d v9, x9
+  mov.16b v10, v5
+  movk x4, #20082, lsl 32
+  fmla.2d v10, v7, v9
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  movk x4, #12388, lsl 48
+  add.2d v0, v0, v10
+  add.2d v8, v8, v11
+  mov x9, #20728
+  mul x11, x7, x6
+  movk x9, #23588, lsl 16
+  movk x9, #7790, lsl 32
+  movk x9, #17170, lsl 48
+  umulh x7, x7, x6
+  dup.2d v9, x9
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  cmn x11, x5
+  cinc x7, x7, hs
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  mul x5, x8, x6
+  add.2d v1, v1, v10
+  add.2d v0, v0, v11
+  mov x9, #16000
+  umulh x8, x8, x6
+  movk x9, #53891, lsl 16
+  movk x9, #5509, lsl 32
+  movk x9, #17144, lsl 48
+  adds x5, x5, x7
+  cinc x7, x8, hs
+  dup.2d v9, x9
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  adds x0, x5, x0
+  cinc x5, x7, hs
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  add.2d v2, v2, v10
+  mul x7, x10, x6
+  add.2d v1, v1, v11
+  mov x8, #46800
+  umulh x9, x10, x6
+  movk x8, #2568, lsl 16
+  movk x8, #1335, lsl 32
+  movk x8, #17188, lsl 48
+  adds x5, x7, x5
+  cinc x7, x9, hs
+  dup.2d v9, x8
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  adds x1, x5, x1
+  cinc x5, x7, hs
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  add.2d v4, v4, v10
+  mul x7, x4, x6
+  add.2d v2, v2, v11
+  mov x8, #39040
+  movk x8, #14704, lsl 16
+  umulh x4, x4, x6
+  movk x8, #12839, lsl 32
+  movk x8, #17096, lsl 48
+  adds x5, x7, x5
+  cinc x4, x4, hs
+  dup.2d v9, x8
+  mov.16b v5, v5
+  fmla.2d v5, v7, v9
+  adds x2, x5, x2
+  cinc x4, x4, hs
+  fsub.2d v6, v6, v5
+  fmla.2d v6, v7, v9
+  add.2d v3, v3, v5
+  add x3, x3, x4
+  add.2d v4, v4, v6
+  mov x4, #140737488355328
+  dup.2d v5, x4
+  mov x4, #2
+  and.16b v5, v3, v5
+  cmeq.2d v5, v5, #0
+  mov x5, #2
+  movk x4, #57344, lsl 16
+  movk x5, #57344, lsl 16
+  movk x5, #60199, lsl 32
+  movk x4, #60199, lsl 32
+  movk x5, #3, lsl 48
+  dup.2d v6, x5
+  bic.16b v6, v6, v5
+  movk x4, #34755, lsl 48
+  mov x5, #10364
+  movk x5, #11794, lsl 16
+  movk x5, #3895, lsl 32
+  mov x6, #57634
+  movk x5, #9, lsl 48
+  dup.2d v7, x5
+  bic.16b v7, v7, v5
+  movk x6, #62322, lsl 16
+  mov x5, #26576
+  movk x5, #47696, lsl 16
+  movk x5, #688, lsl 32
+  movk x6, #53392, lsl 32
+  movk x5, #3, lsl 48
+  dup.2d v9, x5
+  movk x6, #20583, lsl 48
+  bic.16b v9, v9, v5
+  mov x5, #46800
+  movk x5, #2568, lsl 16
+  mov x7, #45242
+  movk x5, #1335, lsl 32
+  movk x5, #4, lsl 48
+  dup.2d v10, x5
+  movk x7, #770, lsl 16
+  bic.16b v10, v10, v5
+  mov x5, #49763
+  movk x5, #40165, lsl 16
+  movk x7, #35693, lsl 32
+  movk x5, #24776, lsl 32
+  dup.2d v11, x5
+  bic.16b v5, v11, v5
+  movk x7, #28832, lsl 48
+  sub.2d v0, v0, v6
+  ssra.2d v0, v8, #52
+  mov x5, #16467
+  sub.2d v6, v1, v7
+  ssra.2d v6, v0, #52
+  sub.2d v7, v2, v9
+  movk x5, #49763, lsl 16
+  ssra.2d v7, v6, #52
+  sub.2d v4, v4, v10
+  ssra.2d v4, v7, #52
+  movk x5, #40165, lsl 32
+  sub.2d v5, v3, v5
+  ssra.2d v5, v4, #52
+  ushr.2d v1, v6, #12
+  movk x5, #24776, lsl 48
+  ushr.2d v2, v7, #24
+  ushr.2d v3, v4, #36
+  sli.2d v0, v6, #52
+  subs x4, x0, x4
+  sbcs x6, x1, x6
+  sbcs x7, x2, x7
+  sbcs x5, x3, x5
+  sli.2d v1, v7, #40
+  sli.2d v2, v4, #28
+  sli.2d v3, v5, #16
+  tst x3, #9223372036854775808
+  csel x0, x4, x0, mi
+  csel x1, x6, x1, mi
+  csel x2, x7, x2, mi
+  csel x3, x5, x3, mi

--- a/block-multiplier/src/aarch64/montgomery_square_log_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_square_log_interleaved_3.s
@@ -7,436 +7,469 @@
 // lateout("lr") _
   mov x4, #4503599627370495
   dup.2d v4, x4
-  mul x5, x0, x0
-  mov x6, #5075556780046548992
-  dup.2d v5, x6
-  mov x6, #1
+  mov x5, #5075556780046548992
+  mul x6, x0, x0
+  dup.2d v5, x5
+  mov x5, #1
+  movk x5, #18032, lsl 48
   umulh x7, x0, x0
-  movk x6, #18032, lsl 48
-  dup.2d v6, x6
+  dup.2d v6, x5
   shl.2d v7, v1, #14
-  mul x6, x0, x1
   shl.2d v8, v2, #26
+  mul x5, x0, x1
   shl.2d v9, v3, #38
   ushr.2d v3, v3, #14
-  umulh x8, x0, x1
   shl.2d v10, v0, #2
+  umulh x8, x0, x1
   usra.2d v7, v0, #50
   usra.2d v8, v1, #38
-  adds x7, x6, x7
-  cinc x9, x8, hs
   usra.2d v9, v2, #26
+  adds x7, x5, x7
+  cinc x9, x8, hs
   and.16b v0, v10, v4
-  mul x10, x0, x2
   and.16b v1, v7, v4
   and.16b v2, v8, v4
+  mul x10, x0, x2
   and.16b v7, v9, v4
+  mov x11, #13605374474286268416
+  dup.2d v8, x11
   umulh x11, x0, x2
-  mov x12, #13605374474286268416
-  dup.2d v8, x12
   mov x12, #6440147467139809280
-  adds x9, x10, x9
-  cinc x13, x11, hs
   dup.2d v9, x12
   mov x12, #3688448094816436224
+  adds x9, x10, x9
+  cinc x13, x11, hs
   dup.2d v10, x12
-  mul x12, x0, x3
-  mov x14, #9209861237972664320
-  dup.2d v11, x14
-  mov x14, #12218265789056155648
+  mov x12, #9209861237972664320
+  dup.2d v11, x12
+  mov x12, #12218265789056155648
+  mul x14, x0, x3
+  dup.2d v12, x12
+  mov x12, #17739678932212383744
+  dup.2d v13, x12
   umulh x0, x0, x3
-  dup.2d v12, x14
-  mov x14, #17739678932212383744
-  adds x13, x12, x13
+  mov x12, #2301339409586323456
+  dup.2d v14, x12
+  mov x12, #7822752552742551552
+  adds x13, x14, x13
   cinc x15, x0, hs
-  dup.2d v13, x14
-  mov x14, #2301339409586323456
-  dup.2d v14, x14
-  adds x6, x6, x7
+  dup.2d v15, x12
+  mov x12, #5071053180419178496
+  dup.2d v16, x12
+  adds x5, x5, x7
   cinc x7, x8, hs
-  mov x8, #7822752552742551552
-  dup.2d v15, x8
-  mov x8, #5071053180419178496
-  mul x14, x1, x1
-  dup.2d v16, x8
   mov x8, #16352570246982270976
   dup.2d v17, x8
-  umulh x8, x1, x1
   ucvtf.2d v0, v0
+  mul x8, x1, x1
   ucvtf.2d v1, v1
   ucvtf.2d v2, v2
-  adds x7, x14, x7
-  cinc x8, x8, hs
   ucvtf.2d v7, v7
+  umulh x12, x1, x1
   ucvtf.2d v3, v3
-  adds x7, x7, x9
-  cinc x8, x8, hs
   mov.16b v18, v5
   fmla.2d v18, v0, v0
+  adds x7, x8, x7
+  cinc x8, x12, hs
   fsub.2d v19, v6, v18
-  mul x9, x1, x2
   fmla.2d v19, v0, v0
   add.2d v10, v10, v18
+  adds x7, x7, x9
+  cinc x8, x8, hs
   add.2d v8, v8, v19
-  umulh x14, x1, x2
   mov.16b v18, v5
   fmla.2d v18, v0, v1
   fsub.2d v19, v6, v18
-  adds x8, x9, x8
-  cinc x16, x14, hs
+  mul x9, x1, x2
   fmla.2d v19, v0, v1
   add.2d v18, v18, v18
   add.2d v19, v19, v19
-  adds x8, x8, x13
-  cinc x13, x16, hs
+  umulh x12, x1, x2
   add.2d v12, v12, v18
   add.2d v10, v10, v19
-  mul x16, x1, x3
-  mov.16b v18, v5
-  fmla.2d v18, v0, v2
-  fsub.2d v19, v6, v18
-  umulh x1, x1, x3
-  fmla.2d v19, v0, v2
-  add.2d v18, v18, v18
-  add.2d v19, v19, v19
-  adds x13, x16, x13
-  cinc x17, x1, hs
-  add.2d v14, v14, v18
-  add.2d v12, v12, v19
-  mov.16b v18, v5
-  adds x13, x13, x15
-  cinc x15, x17, hs
-  fmla.2d v18, v0, v7
-  fsub.2d v19, v6, v18
-  fmla.2d v19, v0, v7
-  adds x7, x10, x7
-  cinc x10, x11, hs
-  add.2d v18, v18, v18
-  add.2d v19, v19, v19
-  adds x9, x9, x10
-  cinc x10, x14, hs
-  add.2d v16, v16, v18
-  add.2d v14, v14, v19
   mov.16b v18, v5
   adds x8, x9, x8
-  cinc x9, x10, hs
+  cinc x16, x12, hs
+  fmla.2d v18, v0, v2
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v2
+  adds x8, x8, x13
+  cinc x13, x16, hs
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  add.2d v14, v14, v18
+  mul x16, x1, x3
+  add.2d v12, v12, v19
+  mov.16b v18, v5
+  fmla.2d v18, v0, v7
+  umulh x1, x1, x3
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v7
+  add.2d v18, v18, v18
+  adds x13, x16, x13
+  cinc x17, x1, hs
+  add.2d v19, v19, v19
+  add.2d v16, v16, v18
+  add.2d v14, v14, v19
+  adds x13, x13, x15
+  cinc x15, x17, hs
+  mov.16b v18, v5
   fmla.2d v18, v0, v3
   fsub.2d v19, v6, v18
+  adds x7, x10, x7
+  cinc x10, x11, hs
   fmla.2d v19, v0, v3
-  mul x10, x2, x2
   add.2d v0, v18, v18
   add.2d v18, v19, v19
   add.2d v0, v17, v0
-  umulh x11, x2, x2
+  adds x9, x9, x10
+  cinc x10, x12, hs
   add.2d v16, v16, v18
   mov.16b v17, v5
   fmla.2d v17, v1, v1
-  adds x9, x10, x9
-  cinc x10, x11, hs
+  adds x8, x9, x8
+  cinc x9, x10, hs
   fsub.2d v18, v6, v17
   fmla.2d v18, v1, v1
-  adds x9, x9, x13
-  cinc x10, x10, hs
   add.2d v14, v14, v17
+  mul x10, x2, x2
   add.2d v12, v12, v18
   mov.16b v17, v5
-  mul x11, x2, x3
   fmla.2d v17, v1, v2
+  umulh x11, x2, x2
   fsub.2d v18, v6, v17
   fmla.2d v18, v1, v2
-  umulh x2, x2, x3
   add.2d v17, v17, v17
+  adds x9, x10, x9
+  cinc x10, x11, hs
   add.2d v18, v18, v18
   add.2d v16, v16, v17
-  adds x10, x11, x10
-  cinc x13, x2, hs
   add.2d v14, v14, v18
+  adds x9, x9, x13
+  cinc x10, x10, hs
   mov.16b v17, v5
   fmla.2d v17, v1, v7
-  adds x10, x10, x15
-  cinc x13, x13, hs
   fsub.2d v18, v6, v17
+  mul x11, x2, x3
   fmla.2d v18, v1, v7
-  adds x8, x12, x8
-  cinc x0, x0, hs
   add.2d v17, v17, v17
   add.2d v18, v18, v18
+  umulh x2, x2, x3
   add.2d v0, v0, v17
-  adds x0, x16, x0
-  cinc x1, x1, hs
   add.2d v16, v16, v18
   mov.16b v17, v5
   fmla.2d v17, v1, v3
-  adds x0, x0, x9
-  cinc x1, x1, hs
+  adds x10, x11, x10
+  cinc x12, x2, hs
   fsub.2d v18, v6, v17
   fmla.2d v18, v1, v3
   add.2d v1, v17, v17
-  adds x1, x11, x1
-  cinc x2, x2, hs
+  adds x10, x10, x15
+  cinc x12, x12, hs
   add.2d v17, v18, v18
   add.2d v1, v15, v1
   add.2d v0, v0, v17
-  adds x1, x1, x10
-  cinc x2, x2, hs
+  adds x8, x14, x8
+  cinc x0, x0, hs
   mov.16b v15, v5
   fmla.2d v15, v2, v2
-  mul x9, x3, x3
   fsub.2d v17, v6, v15
+  adds x0, x16, x0
+  cinc x1, x1, hs
   fmla.2d v17, v2, v2
   add.2d v0, v0, v15
-  umulh x3, x3, x3
   add.2d v15, v16, v17
+  adds x0, x0, x9
+  cinc x1, x1, hs
   mov.16b v16, v5
   fmla.2d v16, v2, v7
-  adds x2, x9, x2
-  cinc x3, x3, hs
   fsub.2d v17, v6, v16
+  adds x1, x11, x1
+  cinc x2, x2, hs
   fmla.2d v17, v2, v7
   add.2d v16, v16, v16
-  adds x2, x2, x13
-  cinc x3, x3, hs
   add.2d v17, v17, v17
+  adds x1, x1, x10
+  cinc x2, x2, hs
   add.2d v1, v1, v16
   add.2d v0, v0, v17
-  mov x9, #56431
   mov.16b v16, v5
+  mul x9, x3, x3
   fmla.2d v16, v2, v3
   fsub.2d v17, v6, v16
-  movk x9, #30457, lsl 16
   fmla.2d v17, v2, v3
+  umulh x3, x3, x3
   add.2d v2, v16, v16
-  movk x9, #30012, lsl 32
   add.2d v16, v17, v17
   add.2d v2, v13, v2
   add.2d v1, v1, v16
-  movk x9, #6382, lsl 48
+  adds x2, x9, x2
+  cinc x3, x3, hs
   mov.16b v13, v5
   fmla.2d v13, v7, v7
   fsub.2d v16, v6, v13
-  mov x10, #59151
+  adds x2, x2, x12
+  cinc x3, x3, hs
   fmla.2d v16, v7, v7
   add.2d v2, v2, v13
   add.2d v1, v1, v16
-  movk x10, #41769, lsl 16
+  mov x9, #56431
   mov.16b v13, v5
   fmla.2d v13, v7, v3
   fsub.2d v16, v6, v13
-  movk x10, #32276, lsl 32
+  movk x9, #30457, lsl 16
   fmla.2d v16, v7, v3
   add.2d v7, v13, v13
-  movk x10, #21677, lsl 48
   add.2d v13, v16, v16
+  movk x9, #30012, lsl 32
   add.2d v7, v11, v7
   add.2d v2, v2, v13
-  mov x11, #34015
   mov.16b v11, v5
+  movk x9, #6382, lsl 48
   fmla.2d v11, v3, v3
   fsub.2d v13, v6, v11
-  movk x11, #20342, lsl 16
   fmla.2d v13, v3, v3
+  mov x10, #59151
   add.2d v3, v9, v11
   add.2d v7, v7, v13
-  movk x11, #13935, lsl 32
   usra.2d v10, v8, #52
+  movk x10, #41769, lsl 16
   usra.2d v12, v10, #52
   usra.2d v14, v12, #52
-  movk x11, #11030, lsl 48
   usra.2d v15, v14, #52
   and.16b v8, v8, v4
-  mov x12, #13689
+  movk x10, #32276, lsl 32
   and.16b v9, v10, v4
   and.16b v10, v12, v4
   and.16b v4, v14, v4
-  movk x12, #8159, lsl 16
+  movk x10, #21677, lsl 48
   ucvtf.2d v8, v8
-  mov x13, #37864
-  movk x13, #1815, lsl 16
-  movk x12, #215, lsl 32
-  movk x13, #28960, lsl 32
-  movk x13, #17153, lsl 48
-  dup.2d v11, x13
-  movk x12, #4913, lsl 48
+  mov x11, #37864
+  movk x11, #1815, lsl 16
+  mov x12, #34015
+  movk x11, #28960, lsl 32
+  movk x11, #17153, lsl 48
+  dup.2d v11, x11
+  movk x12, #20342, lsl 16
   mov.16b v12, v5
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
-  mul x13, x9, x5
+  movk x12, #13935, lsl 32
   fmla.2d v13, v8, v11
   add.2d v0, v0, v12
-  umulh x14, x9, x5
   add.2d v11, v15, v13
-  mov x15, #46128
-  movk x15, #29964, lsl 16
-  adds x7, x13, x7
-  cinc x13, x14, hs
-  movk x15, #7587, lsl 32
-  movk x15, #17161, lsl 48
-  dup.2d v12, x15
-  mul x14, x10, x5
+  movk x12, #11030, lsl 48
+  mov x11, #46128
+  movk x11, #29964, lsl 16
+  movk x11, #7587, lsl 32
+  mov x13, #13689
+  movk x11, #17161, lsl 48
+  dup.2d v12, x11
   mov.16b v13, v5
+  movk x13, #8159, lsl 16
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
-  umulh x15, x10, x5
   fmla.2d v14, v8, v12
+  movk x13, #215, lsl 32
   add.2d v1, v1, v13
   add.2d v0, v0, v14
-  adds x13, x14, x13
-  cinc x14, x15, hs
-  mov x15, #52826
-  movk x15, #57790, lsl 16
-  adds x8, x13, x8
-  cinc x13, x14, hs
-  movk x15, #55431, lsl 32
-  movk x15, #17196, lsl 48
-  dup.2d v12, x15
-  mul x14, x11, x5
+  mov x11, #52826
+  movk x11, #57790, lsl 16
+  movk x13, #4913, lsl 48
+  movk x11, #55431, lsl 32
+  movk x11, #17196, lsl 48
+  dup.2d v12, x11
+  mul x11, x9, x6
   mov.16b v13, v5
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
-  umulh x15, x11, x5
+  umulh x14, x9, x6
   fmla.2d v14, v8, v12
   add.2d v2, v2, v13
   add.2d v1, v1, v14
-  adds x13, x14, x13
-  cinc x14, x15, hs
-  mov x15, #31276
-  movk x15, #21262, lsl 16
-  movk x15, #2304, lsl 32
-  adds x0, x13, x0
-  cinc x13, x14, hs
-  movk x15, #17182, lsl 48
-  dup.2d v12, x15
-  mul x14, x12, x5
-  mov.16b v13, v5
-  fmla.2d v13, v8, v12
-  fsub.2d v14, v6, v13
-  umulh x5, x12, x5
-  fmla.2d v14, v8, v12
-  add.2d v7, v7, v13
-  add.2d v2, v2, v14
-  adds x13, x14, x13
-  cinc x5, x5, hs
-  mov x14, #28672
-  movk x14, #24515, lsl 16
-  movk x14, #54929, lsl 32
-  adds x1, x13, x1
-  cinc x5, x5, hs
-  movk x14, #17064, lsl 48
+  adds x7, x11, x7
+  cinc x11, x14, hs
+  mov x14, #31276
+  movk x14, #21262, lsl 16
+  movk x14, #2304, lsl 32
+  mul x15, x10, x6
+  movk x14, #17182, lsl 48
   dup.2d v12, x14
   mov.16b v13, v5
-  adds x2, x2, x5
-  cinc x3, x3, hs
+  umulh x14, x10, x6
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
-  mul x5, x9, x6
+  fmla.2d v14, v8, v12
+  adds x11, x15, x11
+  cinc x14, x14, hs
+  add.2d v7, v7, v13
+  add.2d v2, v2, v14
+  mov x15, #28672
+  adds x8, x11, x8
+  cinc x11, x14, hs
+  movk x15, #24515, lsl 16
+  movk x15, #54929, lsl 32
+  movk x15, #17064, lsl 48
+  dup.2d v12, x15
+  mul x14, x12, x6
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  umulh x15, x12, x6
   fmla.2d v14, v8, v12
   add.2d v3, v3, v13
   add.2d v7, v7, v14
-  umulh x9, x9, x6
+  adds x11, x14, x11
+  cinc x14, x15, hs
   ucvtf.2d v8, v9
-  mov x13, #44768
-  movk x13, #51919, lsl 16
-  adds x5, x5, x8
-  cinc x8, x9, hs
-  movk x13, #6346, lsl 32
-  movk x13, #17133, lsl 48
-  dup.2d v9, x13
-  mul x9, x10, x6
+  mov x15, #44768
+  movk x15, #51919, lsl 16
+  adds x0, x11, x0
+  cinc x11, x14, hs
+  movk x15, #6346, lsl 32
+  movk x15, #17133, lsl 48
+  dup.2d v9, x15
+  mul x14, x13, x6
   mov.16b v12, v5
   fmla.2d v12, v8, v9
   fsub.2d v13, v6, v12
-  umulh x10, x10, x6
+  umulh x6, x13, x6
   fmla.2d v13, v8, v9
   add.2d v0, v0, v12
-  adds x8, x9, x8
-  cinc x9, x10, hs
   add.2d v9, v11, v13
-  mov x10, #47492
-  movk x10, #23630, lsl 16
-  adds x0, x8, x0
-  cinc x8, x9, hs
-  movk x10, #49985, lsl 32
-  movk x10, #17168, lsl 48
-  dup.2d v11, x10
-  mul x9, x11, x6
+  adds x11, x14, x11
+  cinc x6, x6, hs
+  mov x14, #47492
+  movk x14, #23630, lsl 16
+  movk x14, #49985, lsl 32
+  adds x1, x11, x1
+  cinc x6, x6, hs
+  movk x14, #17168, lsl 48
+  dup.2d v11, x14
   mov.16b v12, v5
+  adds x2, x2, x6
+  cinc x3, x3, hs
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
-  umulh x10, x11, x6
   fmla.2d v13, v8, v11
   add.2d v1, v1, v12
+  mul x6, x9, x5
   add.2d v0, v0, v13
-  adds x8, x9, x8
-  cinc x9, x10, hs
-  mov x10, #57936
-  movk x10, #54828, lsl 16
-  adds x1, x8, x1
+  mov x11, #57936
+  movk x11, #54828, lsl 16
+  umulh x9, x9, x5
+  movk x11, #18292, lsl 32
+  movk x11, #17197, lsl 48
+  dup.2d v11, x11
+  adds x6, x6, x8
   cinc x8, x9, hs
-  movk x10, #18292, lsl 32
-  movk x10, #17197, lsl 48
-  dup.2d v11, x10
-  mul x9, x12, x6
   mov.16b v12, v5
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
-  umulh x6, x12, x6
+  mul x9, x10, x5
   fmla.2d v13, v8, v11
   add.2d v2, v2, v12
   add.2d v1, v1, v13
+  umulh x10, x10, x5
+  mov x11, #17708
+  movk x11, #43915, lsl 16
+  movk x11, #64348, lsl 32
   adds x8, x9, x8
-  cinc x6, x6, hs
-  mov x9, #17708
-  movk x9, #43915, lsl 16
-  movk x9, #64348, lsl 32
-  adds x2, x8, x2
-  cinc x6, x6, hs
-  movk x9, #17188, lsl 48
-  dup.2d v11, x9
+  cinc x9, x10, hs
+  movk x11, #17188, lsl 48
+  dup.2d v11, x11
   mov.16b v12, v5
-  add x3, x3, x6
+  adds x0, x8, x0
+  cinc x8, x9, hs
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
-  mov x6, #61005
   fmla.2d v13, v8, v11
+  mul x9, x12, x5
   add.2d v7, v7, v12
   add.2d v2, v2, v13
-  movk x6, #58262, lsl 16
-  mov x8, #29184
-  movk x8, #20789, lsl 16
-  movk x8, #19197, lsl 32
-  movk x6, #32851, lsl 32
-  movk x8, #17083, lsl 48
-  dup.2d v11, x8
+  mov x10, #29184
+  movk x10, #20789, lsl 16
+  umulh x11, x12, x5
+  movk x10, #19197, lsl 32
+  movk x10, #17083, lsl 48
+  dup.2d v11, x10
+  adds x8, x9, x8
+  cinc x9, x11, hs
   mov.16b v12, v5
-  movk x6, #11582, lsl 48
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
+  adds x1, x8, x1
+  cinc x8, x9, hs
   fmla.2d v13, v8, v11
-  mov x8, #37581
   add.2d v3, v3, v12
   add.2d v7, v7, v13
-  movk x8, #43836, lsl 16
+  mul x9, x13, x5
   ucvtf.2d v8, v10
-  mov x9, #58856
-  movk x9, #14953, lsl 16
-  movk x8, #36286, lsl 32
-  movk x9, #15155, lsl 32
-  movk x9, #17181, lsl 48
-  dup.2d v10, x9
-  movk x8, #51783, lsl 48
+  mov x10, #58856
+  movk x10, #14953, lsl 16
+  umulh x5, x13, x5
+  movk x10, #15155, lsl 32
+  movk x10, #17181, lsl 48
+  dup.2d v10, x10
+  adds x8, x9, x8
+  cinc x5, x5, hs
   mov.16b v11, v5
   fmla.2d v11, v8, v10
   fsub.2d v12, v6, v11
-  mov x9, #10899
+  adds x2, x8, x2
+  cinc x5, x5, hs
   fmla.2d v12, v8, v10
   add.2d v0, v0, v11
   add.2d v9, v9, v12
+  add x3, x3, x5
+  mov x5, #35392
+  movk x5, #12477, lsl 16
+  movk x5, #56780, lsl 32
+  mov x8, #61005
+  movk x5, #17142, lsl 48
+  dup.2d v10, x5
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  movk x8, #58262, lsl 16
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  movk x8, #32851, lsl 32
+  add.2d v0, v0, v12
+  mov x5, #9848
+  movk x5, #54501, lsl 16
+  movk x8, #11582, lsl 48
+  movk x5, #31540, lsl 32
+  movk x5, #17170, lsl 48
+  dup.2d v10, x5
+  mov x5, #37581
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  movk x5, #43836, lsl 16
+  fmla.2d v12, v8, v10
+  add.2d v2, v2, v11
+  add.2d v1, v1, v12
+  movk x5, #36286, lsl 32
+  mov x9, #9584
+  movk x9, #63883, lsl 16
+  movk x9, #18253, lsl 32
+  movk x5, #51783, lsl 48
+  movk x9, #17190, lsl 48
+  dup.2d v10, x9
+  mov.16b v11, v5
+  mov x9, #10899
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  add.2d v7, v7, v11
   movk x9, #30709, lsl 16
-  mov x10, #35392
-  movk x10, #12477, lsl 16
+  add.2d v2, v2, v12
+  mov x10, #51712
+  movk x10, #16093, lsl 16
   movk x9, #61551, lsl 32
-  movk x10, #56780, lsl 32
-  movk x10, #17142, lsl 48
+  movk x10, #30633, lsl 32
+  movk x10, #17068, lsl 48
   dup.2d v10, x10
   movk x9, #45784, lsl 48
   mov.16b v11, v5
@@ -444,306 +477,248 @@
   fsub.2d v12, v6, v11
   mov x10, #36612
   fmla.2d v12, v8, v10
-  add.2d v1, v1, v11
-  add.2d v0, v0, v12
-  movk x10, #63402, lsl 16
-  mov x11, #9848
-  movk x11, #54501, lsl 16
-  movk x11, #31540, lsl 32
-  movk x10, #47623, lsl 32
-  movk x11, #17170, lsl 48
-  dup.2d v10, x11
-  movk x10, #9430, lsl 48
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  mul x11, x6, x7
-  fmla.2d v12, v8, v10
-  add.2d v2, v2, v11
-  add.2d v1, v1, v12
-  umulh x6, x6, x7
-  mov x12, #9584
-  movk x12, #63883, lsl 16
-  movk x12, #18253, lsl 32
-  adds x5, x11, x5
-  cinc x6, x6, hs
-  movk x12, #17190, lsl 48
-  dup.2d v10, x12
-  mov.16b v11, v5
-  mul x11, x8, x7
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  umulh x8, x8, x7
-  fmla.2d v12, v8, v10
-  add.2d v7, v7, v11
-  add.2d v2, v2, v12
-  adds x6, x11, x6
-  cinc x8, x8, hs
-  mov x11, #51712
-  movk x11, #16093, lsl 16
-  movk x11, #30633, lsl 32
-  adds x0, x6, x0
-  cinc x6, x8, hs
-  movk x11, #17068, lsl 48
-  dup.2d v10, x11
-  mov.16b v11, v5
-  mul x8, x9, x7
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  fmla.2d v12, v8, v10
-  umulh x9, x9, x7
   add.2d v3, v3, v11
   add.2d v7, v7, v12
-  adds x6, x8, x6
-  cinc x8, x9, hs
+  movk x10, #63402, lsl 16
   ucvtf.2d v4, v4
-  mov x9, #34724
-  movk x9, #40393, lsl 16
-  adds x1, x6, x1
-  cinc x6, x8, hs
-  movk x9, #23752, lsl 32
-  movk x9, #17184, lsl 48
-  dup.2d v8, x9
-  mul x8, x10, x7
+  mov x11, #34724
+  movk x11, #40393, lsl 16
+  movk x10, #47623, lsl 32
+  movk x11, #23752, lsl 32
+  movk x11, #17184, lsl 48
+  dup.2d v8, x11
+  movk x10, #9430, lsl 48
   mov.16b v10, v5
   fmla.2d v10, v4, v8
   fsub.2d v11, v6, v10
-  umulh x7, x10, x7
+  mul x11, x8, x7
   fmla.2d v11, v4, v8
   add.2d v0, v0, v10
   add.2d v8, v9, v11
-  adds x6, x8, x6
-  cinc x7, x7, hs
-  mov x8, #25532
-  movk x8, #31025, lsl 16
-  adds x2, x6, x2
-  cinc x6, x7, hs
-  movk x8, #10002, lsl 32
-  movk x8, #17199, lsl 48
-  dup.2d v9, x8
-  add x3, x3, x6
+  umulh x8, x8, x7
+  mov x12, #25532
+  movk x12, #31025, lsl 16
+  movk x12, #10002, lsl 32
+  movk x12, #17199, lsl 48
+  adds x6, x11, x6
+  cinc x8, x8, hs
+  dup.2d v9, x12
   mov.16b v10, v5
   fmla.2d v10, v4, v9
+  mul x11, x5, x7
   fsub.2d v11, v6, v10
-  mov x6, #65535
   fmla.2d v11, v4, v9
   add.2d v1, v1, v10
+  umulh x5, x5, x7
   add.2d v0, v0, v11
-  movk x6, #61439, lsl 16
-  mov x7, #18830
-  movk x7, #2465, lsl 16
-  movk x7, #36348, lsl 32
-  movk x6, #62867, lsl 32
-  movk x7, #17194, lsl 48
-  dup.2d v9, x7
-  movk x6, #49889, lsl 48
+  mov x12, #18830
+  movk x12, #2465, lsl 16
+  adds x8, x11, x8
+  cinc x5, x5, hs
+  movk x12, #36348, lsl 32
+  movk x12, #17194, lsl 48
+  dup.2d v9, x12
+  adds x0, x8, x0
+  cinc x5, x5, hs
   mov.16b v10, v5
   fmla.2d v10, v4, v9
   fsub.2d v11, v6, v10
-  mul x6, x6, x5
+  mul x8, x9, x7
   fmla.2d v11, v4, v9
   add.2d v2, v2, v10
   add.2d v1, v1, v11
-  mov x7, #1
-  mov x8, #21566
-  movk x8, #43708, lsl 16
-  movk x8, #57685, lsl 32
-  movk x7, #61440, lsl 16
-  movk x8, #17185, lsl 48
-  dup.2d v9, x8
+  umulh x9, x9, x7
+  mov x11, #21566
+  movk x11, #43708, lsl 16
+  movk x11, #57685, lsl 32
+  adds x5, x8, x5
+  cinc x8, x9, hs
+  movk x11, #17185, lsl 48
+  dup.2d v9, x11
   mov.16b v10, v5
-  movk x7, #62867, lsl 32
   fmla.2d v10, v4, v9
+  adds x1, x5, x1
+  cinc x5, x8, hs
   fsub.2d v11, v6, v10
-  movk x7, #17377, lsl 48
   fmla.2d v11, v4, v9
   add.2d v7, v7, v10
+  mul x8, x10, x7
   add.2d v2, v2, v11
-  mov x8, #28817
   mov x9, #3072
   movk x9, #8058, lsl 16
+  umulh x7, x10, x7
   movk x9, #46097, lsl 32
-  movk x8, #31161, lsl 16
   movk x9, #17047, lsl 48
   dup.2d v9, x9
+  adds x5, x8, x5
+  cinc x7, x7, hs
   mov.16b v10, v5
-  movk x8, #59464, lsl 32
   fmla.2d v10, v4, v9
   fsub.2d v11, v6, v10
+  adds x2, x5, x2
+  cinc x5, x7, hs
   fmla.2d v11, v4, v9
-  movk x8, #10291, lsl 48
   add.2d v3, v3, v10
   add.2d v4, v7, v11
-  mov x9, #65535
-  mov x10, #22621
-  movk x9, #61439, lsl 16
-  movk x9, #62867, lsl 32
-  movk x10, #33153, lsl 16
-  movk x9, #1, lsl 48
-  umov x11, v8.d[0]
-  umov x12, v8.d[1]
-  movk x10, #17846, lsl 32
-  mul x11, x11, x9
-  mul x9, x12, x9
-  and x11, x11, x4
-  movk x10, #47184, lsl 48
-  and x4, x9, x4
-  ins v7.d[0], x11
+  add x3, x3, x5
+  mov x5, #65535
+  movk x5, #61439, lsl 16
+  movk x5, #62867, lsl 32
+  mov x7, #65535
+  movk x5, #1, lsl 48
+  umov x8, v8.d[0]
+  umov x9, v8.d[1]
+  movk x7, #61439, lsl 16
+  mul x8, x8, x5
+  mul x5, x9, x5
+  and x8, x8, x4
+  movk x7, #62867, lsl 32
+  and x4, x5, x4
+  ins v7.d[0], x8
   ins v7.d[1], x4
   ucvtf.2d v7, v7
-  mov x4, #41001
-  mov x9, #16
-  movk x9, #22847, lsl 32
-  movk x9, #17151, lsl 48
-  movk x4, #57649, lsl 16
-  dup.2d v9, x9
+  mov x4, #16
+  movk x7, #49889, lsl 48
+  movk x4, #22847, lsl 32
+  movk x4, #17151, lsl 48
+  dup.2d v9, x4
+  mul x4, x7, x6
   mov.16b v10, v5
-  movk x4, #20082, lsl 32
   fmla.2d v10, v7, v9
   fsub.2d v11, v6, v10
+  mov x5, #1
   fmla.2d v11, v7, v9
-  movk x4, #12388, lsl 48
   add.2d v0, v0, v10
   add.2d v8, v8, v11
-  mov x9, #20728
-  mul x11, x7, x6
-  movk x9, #23588, lsl 16
-  movk x9, #7790, lsl 32
-  movk x9, #17170, lsl 48
-  umulh x7, x7, x6
-  dup.2d v9, x9
+  movk x5, #61440, lsl 16
+  mov x7, #20728
+  movk x7, #23588, lsl 16
+  movk x7, #7790, lsl 32
+  movk x5, #62867, lsl 32
+  movk x7, #17170, lsl 48
+  dup.2d v9, x7
   mov.16b v10, v5
+  movk x5, #17377, lsl 48
   fmla.2d v10, v7, v9
-  cmn x11, x5
-  cinc x7, x7, hs
   fsub.2d v11, v6, v10
   fmla.2d v11, v7, v9
-  mul x5, x8, x6
+  mov x7, #28817
   add.2d v1, v1, v10
   add.2d v0, v0, v11
-  mov x9, #16000
-  umulh x8, x8, x6
-  movk x9, #53891, lsl 16
-  movk x9, #5509, lsl 32
-  movk x9, #17144, lsl 48
-  adds x5, x5, x7
-  cinc x7, x8, hs
-  dup.2d v9, x9
+  mov x8, #16000
+  movk x7, #31161, lsl 16
+  movk x8, #53891, lsl 16
+  movk x8, #5509, lsl 32
+  movk x8, #17144, lsl 48
+  dup.2d v9, x8
+  movk x7, #59464, lsl 32
   mov.16b v10, v5
   fmla.2d v10, v7, v9
-  adds x0, x5, x0
-  cinc x5, x7, hs
   fsub.2d v11, v6, v10
+  movk x7, #10291, lsl 48
   fmla.2d v11, v7, v9
   add.2d v2, v2, v10
-  mul x7, x10, x6
   add.2d v1, v1, v11
-  mov x8, #46800
-  umulh x9, x10, x6
-  movk x8, #2568, lsl 16
-  movk x8, #1335, lsl 32
-  movk x8, #17188, lsl 48
-  adds x5, x7, x5
-  cinc x7, x9, hs
-  dup.2d v9, x8
+  mov x8, #22621
+  mov x9, #46800
+  movk x9, #2568, lsl 16
+  movk x9, #1335, lsl 32
+  movk x8, #33153, lsl 16
+  movk x9, #17188, lsl 48
+  dup.2d v9, x9
   mov.16b v10, v5
+  movk x8, #17846, lsl 32
   fmla.2d v10, v7, v9
-  adds x1, x5, x1
-  cinc x5, x7, hs
   fsub.2d v11, v6, v10
   fmla.2d v11, v7, v9
+  movk x8, #47184, lsl 48
   add.2d v4, v4, v10
-  mul x7, x4, x6
   add.2d v2, v2, v11
-  mov x8, #39040
-  movk x8, #14704, lsl 16
-  umulh x4, x4, x6
-  movk x8, #12839, lsl 32
-  movk x8, #17096, lsl 48
-  adds x5, x7, x5
-  cinc x4, x4, hs
-  dup.2d v9, x8
+  mov x9, #39040
+  mov x10, #41001
+  movk x9, #14704, lsl 16
+  movk x9, #12839, lsl 32
+  movk x9, #17096, lsl 48
+  movk x10, #57649, lsl 16
+  dup.2d v9, x9
   mov.16b v5, v5
   fmla.2d v5, v7, v9
-  adds x2, x5, x2
-  cinc x4, x4, hs
+  movk x10, #20082, lsl 32
   fsub.2d v6, v6, v5
   fmla.2d v6, v7, v9
   add.2d v3, v3, v5
-  add x3, x3, x4
   add.2d v4, v4, v6
-  mov x4, #140737488355328
-  dup.2d v5, x4
-  mov x4, #2
+  movk x10, #12388, lsl 48
+  mov x9, #140737488355328
+  dup.2d v5, x9
   and.16b v5, v3, v5
+  mul x9, x5, x4
   cmeq.2d v5, v5, #0
-  mov x5, #2
-  movk x4, #57344, lsl 16
-  movk x5, #57344, lsl 16
-  movk x5, #60199, lsl 32
-  movk x4, #60199, lsl 32
-  movk x5, #3, lsl 48
-  dup.2d v6, x5
+  mov x11, #2
+  movk x11, #57344, lsl 16
+  umulh x5, x5, x4
+  movk x11, #60199, lsl 32
+  movk x11, #3, lsl 48
+  dup.2d v6, x11
+  cmn x9, x6
+  cinc x5, x5, hs
   bic.16b v6, v6, v5
-  movk x4, #34755, lsl 48
-  mov x5, #10364
-  movk x5, #11794, lsl 16
-  movk x5, #3895, lsl 32
-  mov x6, #57634
-  movk x5, #9, lsl 48
-  dup.2d v7, x5
+  mov x6, #10364
+  movk x6, #11794, lsl 16
+  mul x9, x7, x4
+  movk x6, #3895, lsl 32
+  movk x6, #9, lsl 48
+  dup.2d v7, x6
+  umulh x6, x7, x4
   bic.16b v7, v7, v5
-  movk x6, #62322, lsl 16
-  mov x5, #26576
-  movk x5, #47696, lsl 16
-  movk x5, #688, lsl 32
-  movk x6, #53392, lsl 32
-  movk x5, #3, lsl 48
-  dup.2d v9, x5
-  movk x6, #20583, lsl 48
+  mov x7, #26576
+  movk x7, #47696, lsl 16
+  adds x5, x9, x5
+  cinc x6, x6, hs
+  movk x7, #688, lsl 32
+  movk x7, #3, lsl 48
+  dup.2d v9, x7
+  adds x0, x5, x0
+  cinc x5, x6, hs
   bic.16b v9, v9, v5
-  mov x5, #46800
-  movk x5, #2568, lsl 16
-  mov x7, #45242
-  movk x5, #1335, lsl 32
-  movk x5, #4, lsl 48
-  dup.2d v10, x5
-  movk x7, #770, lsl 16
+  mov x6, #46800
+  movk x6, #2568, lsl 16
+  movk x6, #1335, lsl 32
+  mul x7, x8, x4
+  movk x6, #4, lsl 48
+  dup.2d v10, x6
   bic.16b v10, v10, v5
-  mov x5, #49763
-  movk x5, #40165, lsl 16
-  movk x7, #35693, lsl 32
-  movk x5, #24776, lsl 32
-  dup.2d v11, x5
+  umulh x6, x8, x4
+  mov x8, #49763
+  movk x8, #40165, lsl 16
+  movk x8, #24776, lsl 32
+  adds x5, x7, x5
+  cinc x6, x6, hs
+  dup.2d v11, x8
   bic.16b v5, v11, v5
-  movk x7, #28832, lsl 48
   sub.2d v0, v0, v6
+  adds x1, x5, x1
+  cinc x5, x6, hs
   ssra.2d v0, v8, #52
-  mov x5, #16467
   sub.2d v6, v1, v7
   ssra.2d v6, v0, #52
+  mul x6, x10, x4
   sub.2d v7, v2, v9
-  movk x5, #49763, lsl 16
   ssra.2d v7, v6, #52
   sub.2d v4, v4, v10
+  umulh x4, x10, x4
   ssra.2d v4, v7, #52
-  movk x5, #40165, lsl 32
   sub.2d v5, v3, v5
   ssra.2d v5, v4, #52
+  adds x5, x6, x5
+  cinc x4, x4, hs
   ushr.2d v1, v6, #12
-  movk x5, #24776, lsl 48
   ushr.2d v2, v7, #24
   ushr.2d v3, v4, #36
+  adds x2, x5, x2
+  cinc x4, x4, hs
   sli.2d v0, v6, #52
-  subs x4, x0, x4
-  sbcs x6, x1, x6
-  sbcs x7, x2, x7
-  sbcs x5, x3, x5
   sli.2d v1, v7, #40
   sli.2d v2, v4, #28
   sli.2d v3, v5, #16
-  tst x3, #9223372036854775808
-  csel x0, x4, x0, mi
-  csel x1, x6, x1, mi
-  csel x2, x7, x2, mi
-  csel x3, x5, x3, mi
+  add x3, x3, x4

--- a/block-multiplier/src/aarch64/montgomery_square_log_interleaved_3.s
+++ b/block-multiplier/src/aarch64/montgomery_square_log_interleaved_3.s
@@ -7,718 +7,680 @@
 // lateout("lr") _
   mov x4, #4503599627370495
   dup.2d v4, x4
-  mov x5, #5075556780046548992
-  mul x6, x0, x0
-  dup.2d v5, x5
-  mov x5, #1
-  movk x5, #18032, lsl 48
+  mul x5, x0, x0
+  mov x6, #5075556780046548992
+  dup.2d v5, x6
+  mov x6, #1
   umulh x7, x0, x0
-  dup.2d v6, x5
+  movk x6, #18032, lsl 48
+  dup.2d v6, x6
   shl.2d v7, v1, #14
+  mul x6, x0, x1
   shl.2d v8, v2, #26
-  mul x5, x0, x1
   shl.2d v9, v3, #38
   ushr.2d v3, v3, #14
-  shl.2d v10, v0, #2
   umulh x8, x0, x1
+  shl.2d v10, v0, #2
   usra.2d v7, v0, #50
   usra.2d v8, v1, #38
-  usra.2d v9, v2, #26
-  adds x7, x5, x7
+  adds x7, x6, x7
   cinc x9, x8, hs
+  usra.2d v9, v2, #26
   and.16b v0, v10, v4
   and.16b v1, v7, v4
-  and.16b v2, v8, v4
   mul x10, x0, x2
+  and.16b v2, v8, v4
   and.16b v7, v9, v4
   mov x11, #13605374474286268416
+  umulh x12, x0, x2
   dup.2d v8, x11
-  umulh x11, x0, x2
-  mov x12, #6440147467139809280
-  dup.2d v9, x12
-  mov x12, #3688448094816436224
+  mov x11, #6440147467139809280
+  dup.2d v9, x11
   adds x9, x10, x9
-  cinc x13, x11, hs
-  dup.2d v10, x12
-  mov x12, #9209861237972664320
-  dup.2d v11, x12
-  mov x12, #12218265789056155648
-  mul x14, x0, x3
-  dup.2d v12, x12
-  mov x12, #17739678932212383744
-  dup.2d v13, x12
+  cinc x11, x12, hs
+  mov x13, #3688448094816436224
+  dup.2d v10, x13
+  mul x13, x0, x3
+  mov x14, #9209861237972664320
+  dup.2d v11, x14
+  mov x14, #12218265789056155648
   umulh x0, x0, x3
-  mov x12, #2301339409586323456
-  dup.2d v14, x12
-  mov x12, #7822752552742551552
-  adds x13, x14, x13
-  cinc x15, x0, hs
-  dup.2d v15, x12
-  mov x12, #5071053180419178496
-  dup.2d v16, x12
-  adds x5, x5, x7
+  dup.2d v12, x14
+  mov x14, #17739678932212383744
+  dup.2d v13, x14
+  adds x11, x13, x11
+  cinc x14, x0, hs
+  mov x15, #2301339409586323456
+  dup.2d v14, x15
+  mov x15, #7822752552742551552
+  adds x6, x6, x7
   cinc x7, x8, hs
-  mov x8, #16352570246982270976
-  dup.2d v17, x8
-  ucvtf.2d v0, v0
+  dup.2d v15, x15
+  mov x8, #5071053180419178496
+  dup.2d v16, x8
   mul x8, x1, x1
+  mov x15, #16352570246982270976
+  dup.2d v17, x15
+  ucvtf.2d v0, v0
+  umulh x15, x1, x1
   ucvtf.2d v1, v1
   ucvtf.2d v2, v2
   ucvtf.2d v7, v7
-  umulh x12, x1, x1
+  adds x7, x8, x7
+  cinc x8, x15, hs
   ucvtf.2d v3, v3
   mov.16b v18, v5
   fmla.2d v18, v0, v0
-  adds x7, x8, x7
-  cinc x8, x12, hs
-  fsub.2d v19, v6, v18
-  fmla.2d v19, v0, v0
-  add.2d v10, v10, v18
   adds x7, x7, x9
   cinc x8, x8, hs
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v0
+  mul x9, x1, x2
+  add.2d v10, v10, v18
   add.2d v8, v8, v19
   mov.16b v18, v5
+  umulh x15, x1, x2
   fmla.2d v18, v0, v1
   fsub.2d v19, v6, v18
-  mul x9, x1, x2
   fmla.2d v19, v0, v1
+  adds x8, x9, x8
+  cinc x16, x15, hs
   add.2d v18, v18, v18
   add.2d v19, v19, v19
-  umulh x12, x1, x2
   add.2d v12, v12, v18
+  adds x8, x8, x11
+  cinc x11, x16, hs
   add.2d v10, v10, v19
   mov.16b v18, v5
-  adds x8, x9, x8
-  cinc x16, x12, hs
   fmla.2d v18, v0, v2
+  mul x16, x1, x3
   fsub.2d v19, v6, v18
   fmla.2d v19, v0, v2
-  adds x8, x8, x13
-  cinc x13, x16, hs
   add.2d v18, v18, v18
+  umulh x1, x1, x3
   add.2d v19, v19, v19
   add.2d v14, v14, v18
-  mul x16, x1, x3
   add.2d v12, v12, v19
+  adds x11, x16, x11
+  cinc x17, x1, hs
   mov.16b v18, v5
   fmla.2d v18, v0, v7
-  umulh x1, x1, x3
   fsub.2d v19, v6, v18
+  adds x11, x11, x14
+  cinc x14, x17, hs
   fmla.2d v19, v0, v7
   add.2d v18, v18, v18
-  adds x13, x16, x13
-  cinc x17, x1, hs
   add.2d v19, v19, v19
+  adds x7, x10, x7
+  cinc x10, x12, hs
   add.2d v16, v16, v18
   add.2d v14, v14, v19
-  adds x13, x13, x15
-  cinc x15, x17, hs
+  adds x9, x9, x10
+  cinc x10, x15, hs
   mov.16b v18, v5
   fmla.2d v18, v0, v3
   fsub.2d v19, v6, v18
-  adds x7, x10, x7
-  cinc x10, x11, hs
+  adds x8, x9, x8
+  cinc x9, x10, hs
   fmla.2d v19, v0, v3
   add.2d v0, v18, v18
   add.2d v18, v19, v19
+  mul x10, x2, x2
   add.2d v0, v17, v0
-  adds x9, x9, x10
-  cinc x10, x12, hs
   add.2d v16, v16, v18
   mov.16b v17, v5
+  umulh x12, x2, x2
   fmla.2d v17, v1, v1
-  adds x8, x9, x8
-  cinc x9, x10, hs
   fsub.2d v18, v6, v17
   fmla.2d v18, v1, v1
+  adds x9, x10, x9
+  cinc x10, x12, hs
   add.2d v14, v14, v17
-  mul x10, x2, x2
   add.2d v12, v12, v18
   mov.16b v17, v5
+  adds x9, x9, x11
+  cinc x10, x10, hs
   fmla.2d v17, v1, v2
-  umulh x11, x2, x2
   fsub.2d v18, v6, v17
   fmla.2d v18, v1, v2
+  mul x11, x2, x3
   add.2d v17, v17, v17
-  adds x9, x10, x9
-  cinc x10, x11, hs
   add.2d v18, v18, v18
   add.2d v16, v16, v17
+  umulh x2, x2, x3
   add.2d v14, v14, v18
-  adds x9, x9, x13
-  cinc x10, x10, hs
   mov.16b v17, v5
+  adds x10, x11, x10
+  cinc x12, x2, hs
   fmla.2d v17, v1, v7
   fsub.2d v18, v6, v17
-  mul x11, x2, x3
   fmla.2d v18, v1, v7
+  adds x10, x10, x14
+  cinc x12, x12, hs
   add.2d v17, v17, v17
   add.2d v18, v18, v18
-  umulh x2, x2, x3
   add.2d v0, v0, v17
+  adds x8, x13, x8
+  cinc x0, x0, hs
   add.2d v16, v16, v18
   mov.16b v17, v5
   fmla.2d v17, v1, v3
-  adds x10, x11, x10
-  cinc x12, x2, hs
+  adds x0, x16, x0
+  cinc x1, x1, hs
   fsub.2d v18, v6, v17
   fmla.2d v18, v1, v3
   add.2d v1, v17, v17
-  adds x10, x10, x15
-  cinc x12, x12, hs
+  adds x0, x0, x9
+  cinc x1, x1, hs
   add.2d v17, v18, v18
   add.2d v1, v15, v1
   add.2d v0, v0, v17
-  adds x8, x14, x8
-  cinc x0, x0, hs
+  adds x1, x11, x1
+  cinc x2, x2, hs
   mov.16b v15, v5
   fmla.2d v15, v2, v2
   fsub.2d v17, v6, v15
-  adds x0, x16, x0
-  cinc x1, x1, hs
+  adds x1, x1, x10
+  cinc x2, x2, hs
   fmla.2d v17, v2, v2
   add.2d v0, v0, v15
   add.2d v15, v16, v17
-  adds x0, x0, x9
-  cinc x1, x1, hs
+  mul x9, x3, x3
   mov.16b v16, v5
   fmla.2d v16, v2, v7
   fsub.2d v17, v6, v16
-  adds x1, x11, x1
-  cinc x2, x2, hs
+  umulh x3, x3, x3
   fmla.2d v17, v2, v7
   add.2d v16, v16, v16
-  add.2d v17, v17, v17
-  adds x1, x1, x10
-  cinc x2, x2, hs
-  add.2d v1, v1, v16
-  add.2d v0, v0, v17
-  mov.16b v16, v5
-  mul x9, x3, x3
-  fmla.2d v16, v2, v3
-  fsub.2d v17, v6, v16
-  fmla.2d v17, v2, v3
-  umulh x3, x3, x3
-  add.2d v2, v16, v16
-  add.2d v16, v17, v17
-  add.2d v2, v13, v2
-  add.2d v1, v1, v16
   adds x2, x9, x2
   cinc x3, x3, hs
-  mov.16b v13, v5
-  fmla.2d v13, v7, v7
-  fsub.2d v16, v6, v13
+  add.2d v17, v17, v17
+  add.2d v1, v1, v16
+  add.2d v0, v0, v17
   adds x2, x2, x12
   cinc x3, x3, hs
+  mov.16b v16, v5
+  fmla.2d v16, v2, v3
+  fsub.2d v17, v6, v16
+  mov x9, #56431
+  fmla.2d v17, v2, v3
+  add.2d v2, v16, v16
+  add.2d v16, v17, v17
+  movk x9, #30457, lsl 16
+  add.2d v2, v13, v2
+  add.2d v1, v1, v16
+  mov.16b v13, v5
+  movk x9, #30012, lsl 32
+  fmla.2d v13, v7, v7
+  fsub.2d v16, v6, v13
   fmla.2d v16, v7, v7
+  movk x9, #6382, lsl 48
   add.2d v2, v2, v13
   add.2d v1, v1, v16
-  mov x9, #56431
   mov.16b v13, v5
+  mov x10, #59151
   fmla.2d v13, v7, v3
   fsub.2d v16, v6, v13
-  movk x9, #30457, lsl 16
   fmla.2d v16, v7, v3
+  movk x10, #41769, lsl 16
   add.2d v7, v13, v13
   add.2d v13, v16, v16
-  movk x9, #30012, lsl 32
+  movk x10, #32276, lsl 32
   add.2d v7, v11, v7
   add.2d v2, v2, v13
   mov.16b v11, v5
-  movk x9, #6382, lsl 48
+  movk x10, #21677, lsl 48
   fmla.2d v11, v3, v3
   fsub.2d v13, v6, v11
   fmla.2d v13, v3, v3
-  mov x10, #59151
+  mov x11, #34015
   add.2d v3, v9, v11
   add.2d v7, v7, v13
   usra.2d v10, v8, #52
-  movk x10, #41769, lsl 16
+  movk x11, #20342, lsl 16
   usra.2d v12, v10, #52
   usra.2d v14, v12, #52
   usra.2d v15, v14, #52
+  movk x11, #13935, lsl 32
   and.16b v8, v8, v4
-  movk x10, #32276, lsl 32
   and.16b v9, v10, v4
   and.16b v10, v12, v4
+  movk x11, #11030, lsl 48
   and.16b v4, v14, v4
-  movk x10, #21677, lsl 48
   ucvtf.2d v8, v8
-  mov x11, #37864
-  movk x11, #1815, lsl 16
-  mov x12, #34015
-  movk x11, #28960, lsl 32
-  movk x11, #17153, lsl 48
-  dup.2d v11, x11
-  movk x12, #20342, lsl 16
+  mov x12, #37864
+  mov x13, #13689
+  movk x12, #1815, lsl 16
+  movk x12, #28960, lsl 32
+  movk x12, #17153, lsl 48
+  movk x13, #8159, lsl 16
+  dup.2d v11, x12
   mov.16b v12, v5
   fmla.2d v12, v8, v11
+  movk x13, #215, lsl 32
   fsub.2d v13, v6, v12
-  movk x12, #13935, lsl 32
   fmla.2d v13, v8, v11
+  movk x13, #4913, lsl 48
   add.2d v0, v0, v12
   add.2d v11, v15, v13
-  movk x12, #11030, lsl 48
-  mov x11, #46128
-  movk x11, #29964, lsl 16
-  movk x11, #7587, lsl 32
-  mov x13, #13689
-  movk x11, #17161, lsl 48
-  dup.2d v12, x11
+  mov x12, #46128
+  mul x14, x9, x5
+  movk x12, #29964, lsl 16
+  movk x12, #7587, lsl 32
+  movk x12, #17161, lsl 48
+  umulh x15, x9, x5
+  dup.2d v12, x12
   mov.16b v13, v5
-  movk x13, #8159, lsl 16
   fmla.2d v13, v8, v12
+  adds x7, x14, x7
+  cinc x12, x15, hs
   fsub.2d v14, v6, v13
   fmla.2d v14, v8, v12
-  movk x13, #215, lsl 32
   add.2d v1, v1, v13
+  mul x14, x10, x5
   add.2d v0, v0, v14
-  mov x11, #52826
-  movk x11, #57790, lsl 16
-  movk x13, #4913, lsl 48
-  movk x11, #55431, lsl 32
-  movk x11, #17196, lsl 48
-  dup.2d v12, x11
-  mul x11, x9, x6
+  mov x15, #52826
+  movk x15, #57790, lsl 16
+  umulh x16, x10, x5
+  movk x15, #55431, lsl 32
+  movk x15, #17196, lsl 48
+  dup.2d v12, x15
+  adds x12, x14, x12
+  cinc x14, x16, hs
   mov.16b v13, v5
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
-  umulh x14, x9, x6
+  adds x8, x12, x8
+  cinc x12, x14, hs
   fmla.2d v14, v8, v12
   add.2d v2, v2, v13
+  mul x14, x11, x5
   add.2d v1, v1, v14
-  adds x7, x11, x7
-  cinc x11, x14, hs
-  mov x14, #31276
-  movk x14, #21262, lsl 16
-  movk x14, #2304, lsl 32
-  mul x15, x10, x6
-  movk x14, #17182, lsl 48
-  dup.2d v12, x14
+  mov x15, #31276
+  movk x15, #21262, lsl 16
+  umulh x16, x11, x5
+  movk x15, #2304, lsl 32
+  movk x15, #17182, lsl 48
+  dup.2d v12, x15
+  adds x12, x14, x12
+  cinc x14, x16, hs
   mov.16b v13, v5
-  umulh x14, x10, x6
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
+  adds x0, x12, x0
+  cinc x12, x14, hs
   fmla.2d v14, v8, v12
-  adds x11, x15, x11
-  cinc x14, x14, hs
   add.2d v7, v7, v13
   add.2d v2, v2, v14
+  mul x14, x13, x5
   mov x15, #28672
-  adds x8, x11, x8
-  cinc x11, x14, hs
   movk x15, #24515, lsl 16
   movk x15, #54929, lsl 32
+  umulh x5, x13, x5
   movk x15, #17064, lsl 48
   dup.2d v12, x15
-  mul x14, x12, x6
   mov.16b v13, v5
+  adds x12, x14, x12
+  cinc x5, x5, hs
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
-  umulh x15, x12, x6
   fmla.2d v14, v8, v12
+  adds x1, x12, x1
+  cinc x5, x5, hs
   add.2d v3, v3, v13
   add.2d v7, v7, v14
-  adds x11, x14, x11
-  cinc x14, x15, hs
   ucvtf.2d v8, v9
-  mov x15, #44768
-  movk x15, #51919, lsl 16
-  adds x0, x11, x0
-  cinc x11, x14, hs
-  movk x15, #6346, lsl 32
-  movk x15, #17133, lsl 48
-  dup.2d v9, x15
-  mul x14, x13, x6
+  adds x2, x2, x5
+  cinc x3, x3, hs
+  mov x5, #44768
+  movk x5, #51919, lsl 16
+  mul x12, x9, x6
+  movk x5, #6346, lsl 32
+  movk x5, #17133, lsl 48
+  dup.2d v9, x5
+  umulh x5, x9, x6
   mov.16b v12, v5
   fmla.2d v12, v8, v9
   fsub.2d v13, v6, v12
-  umulh x6, x13, x6
+  adds x8, x12, x8
+  cinc x5, x5, hs
   fmla.2d v13, v8, v9
   add.2d v0, v0, v12
   add.2d v9, v11, v13
-  adds x11, x14, x11
-  cinc x6, x6, hs
-  mov x14, #47492
-  movk x14, #23630, lsl 16
-  movk x14, #49985, lsl 32
-  adds x1, x11, x1
-  cinc x6, x6, hs
-  movk x14, #17168, lsl 48
-  dup.2d v11, x14
+  mul x9, x10, x6
+  mov x12, #47492
+  movk x12, #23630, lsl 16
+  movk x12, #49985, lsl 32
+  umulh x10, x10, x6
+  movk x12, #17168, lsl 48
+  dup.2d v11, x12
   mov.16b v12, v5
-  adds x2, x2, x6
-  cinc x3, x3, hs
+  adds x5, x9, x5
+  cinc x9, x10, hs
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
   fmla.2d v13, v8, v11
+  adds x0, x5, x0
+  cinc x5, x9, hs
   add.2d v1, v1, v12
-  mul x6, x9, x5
   add.2d v0, v0, v13
-  mov x11, #57936
-  movk x11, #54828, lsl 16
-  umulh x9, x9, x5
-  movk x11, #18292, lsl 32
-  movk x11, #17197, lsl 48
-  dup.2d v11, x11
-  adds x6, x6, x8
-  cinc x8, x9, hs
+  mov x9, #57936
+  mul x10, x11, x6
+  movk x9, #54828, lsl 16
+  movk x9, #18292, lsl 32
+  umulh x11, x11, x6
+  movk x9, #17197, lsl 48
+  dup.2d v11, x9
   mov.16b v12, v5
+  adds x5, x10, x5
+  cinc x9, x11, hs
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
-  mul x9, x10, x5
   fmla.2d v13, v8, v11
+  adds x1, x5, x1
+  cinc x5, x9, hs
   add.2d v2, v2, v12
   add.2d v1, v1, v13
-  umulh x10, x10, x5
-  mov x11, #17708
-  movk x11, #43915, lsl 16
-  movk x11, #64348, lsl 32
-  adds x8, x9, x8
-  cinc x9, x10, hs
-  movk x11, #17188, lsl 48
-  dup.2d v11, x11
+  mov x9, #17708
+  mul x10, x13, x6
+  movk x9, #43915, lsl 16
+  movk x9, #64348, lsl 32
+  movk x9, #17188, lsl 48
+  umulh x6, x13, x6
+  dup.2d v11, x9
   mov.16b v12, v5
-  adds x0, x8, x0
-  cinc x8, x9, hs
   fmla.2d v12, v8, v11
+  adds x5, x10, x5
+  cinc x6, x6, hs
   fsub.2d v13, v6, v12
   fmla.2d v13, v8, v11
-  mul x9, x12, x5
   add.2d v7, v7, v12
+  adds x2, x5, x2
+  cinc x5, x6, hs
   add.2d v2, v2, v13
-  mov x10, #29184
-  movk x10, #20789, lsl 16
-  umulh x11, x12, x5
-  movk x10, #19197, lsl 32
-  movk x10, #17083, lsl 48
-  dup.2d v11, x10
-  adds x8, x9, x8
-  cinc x9, x11, hs
+  mov x6, #29184
+  movk x6, #20789, lsl 16
+  add x3, x3, x5
+  movk x6, #19197, lsl 32
+  movk x6, #17083, lsl 48
+  dup.2d v11, x6
+  mov x5, #61005
   mov.16b v12, v5
   fmla.2d v12, v8, v11
+  movk x5, #58262, lsl 16
   fsub.2d v13, v6, v12
-  adds x1, x8, x1
-  cinc x8, x9, hs
   fmla.2d v13, v8, v11
   add.2d v3, v3, v12
+  movk x5, #32851, lsl 32
   add.2d v7, v7, v13
-  mul x9, x13, x5
   ucvtf.2d v8, v10
-  mov x10, #58856
-  movk x10, #14953, lsl 16
-  umulh x5, x13, x5
-  movk x10, #15155, lsl 32
-  movk x10, #17181, lsl 48
-  dup.2d v10, x10
-  adds x8, x9, x8
-  cinc x5, x5, hs
+  mov x6, #58856
+  movk x5, #11582, lsl 48
+  movk x6, #14953, lsl 16
+  movk x6, #15155, lsl 32
+  movk x6, #17181, lsl 48
+  mov x9, #37581
+  dup.2d v10, x6
   mov.16b v11, v5
   fmla.2d v11, v8, v10
+  movk x9, #43836, lsl 16
   fsub.2d v12, v6, v11
-  adds x2, x8, x2
-  cinc x5, x5, hs
   fmla.2d v12, v8, v10
   add.2d v0, v0, v11
+  movk x9, #36286, lsl 32
   add.2d v9, v9, v12
-  add x3, x3, x5
-  mov x5, #35392
-  movk x5, #12477, lsl 16
-  movk x5, #56780, lsl 32
-  mov x8, #61005
-  movk x5, #17142, lsl 48
-  dup.2d v10, x5
+  mov x6, #35392
+  movk x6, #12477, lsl 16
+  movk x9, #51783, lsl 48
+  movk x6, #56780, lsl 32
+  movk x6, #17142, lsl 48
+  dup.2d v10, x6
+  mov x6, #10899
   mov.16b v11, v5
   fmla.2d v11, v8, v10
-  movk x8, #58262, lsl 16
+  movk x6, #30709, lsl 16
   fsub.2d v12, v6, v11
   fmla.2d v12, v8, v10
   add.2d v1, v1, v11
-  movk x8, #32851, lsl 32
+  movk x6, #61551, lsl 32
   add.2d v0, v0, v12
-  mov x5, #9848
-  movk x5, #54501, lsl 16
-  movk x8, #11582, lsl 48
-  movk x5, #31540, lsl 32
-  movk x5, #17170, lsl 48
-  dup.2d v10, x5
-  mov x5, #37581
+  mov x10, #9848
+  movk x10, #54501, lsl 16
+  movk x6, #45784, lsl 48
+  movk x10, #31540, lsl 32
+  movk x10, #17170, lsl 48
+  dup.2d v10, x10
+  mov x10, #36612
   mov.16b v11, v5
   fmla.2d v11, v8, v10
   fsub.2d v12, v6, v11
-  movk x5, #43836, lsl 16
+  movk x10, #63402, lsl 16
   fmla.2d v12, v8, v10
   add.2d v2, v2, v11
   add.2d v1, v1, v12
-  movk x5, #36286, lsl 32
-  mov x9, #9584
-  movk x9, #63883, lsl 16
-  movk x9, #18253, lsl 32
-  movk x5, #51783, lsl 48
-  movk x9, #17190, lsl 48
-  dup.2d v10, x9
-  mov.16b v11, v5
-  mov x9, #10899
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  fmla.2d v12, v8, v10
-  add.2d v7, v7, v11
-  movk x9, #30709, lsl 16
-  add.2d v2, v2, v12
-  mov x10, #51712
-  movk x10, #16093, lsl 16
-  movk x9, #61551, lsl 32
-  movk x10, #30633, lsl 32
-  movk x10, #17068, lsl 48
-  dup.2d v10, x10
-  movk x9, #45784, lsl 48
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  mov x10, #36612
-  fmla.2d v12, v8, v10
-  add.2d v3, v3, v11
-  add.2d v7, v7, v12
-  movk x10, #63402, lsl 16
-  ucvtf.2d v4, v4
-  mov x11, #34724
-  movk x11, #40393, lsl 16
   movk x10, #47623, lsl 32
-  movk x11, #23752, lsl 32
-  movk x11, #17184, lsl 48
-  dup.2d v8, x11
+  mov x11, #9584
+  movk x11, #63883, lsl 16
+  movk x11, #18253, lsl 32
   movk x10, #9430, lsl 48
-  mov.16b v10, v5
-  fmla.2d v10, v4, v8
-  fsub.2d v11, v6, v10
-  mul x11, x8, x7
-  fmla.2d v11, v4, v8
-  add.2d v0, v0, v10
-  add.2d v8, v9, v11
-  umulh x8, x8, x7
-  mov x12, #25532
-  movk x12, #31025, lsl 16
-  movk x12, #10002, lsl 32
-  movk x12, #17199, lsl 48
-  adds x6, x11, x6
-  cinc x8, x8, hs
-  dup.2d v9, x12
-  mov.16b v10, v5
-  fmla.2d v10, v4, v9
+  movk x11, #17190, lsl 48
+  dup.2d v10, x11
+  mov.16b v11, v5
   mul x11, x5, x7
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v4, v9
-  add.2d v1, v1, v10
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
   umulh x5, x5, x7
-  add.2d v0, v0, v11
-  mov x12, #18830
-  movk x12, #2465, lsl 16
+  add.2d v7, v7, v11
+  add.2d v2, v2, v12
   adds x8, x11, x8
   cinc x5, x5, hs
-  movk x12, #36348, lsl 32
-  movk x12, #17194, lsl 48
-  dup.2d v9, x12
-  adds x0, x8, x0
-  cinc x5, x5, hs
+  mov x11, #51712
+  movk x11, #16093, lsl 16
+  movk x11, #30633, lsl 32
+  mul x12, x9, x7
+  movk x11, #17068, lsl 48
+  dup.2d v10, x11
+  mov.16b v11, v5
+  umulh x9, x9, x7
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  adds x5, x12, x5
+  cinc x9, x9, hs
+  add.2d v3, v3, v11
+  add.2d v7, v7, v12
+  ucvtf.2d v4, v4
+  adds x0, x5, x0
+  cinc x5, x9, hs
+  mov x9, #34724
+  movk x9, #40393, lsl 16
+  movk x9, #23752, lsl 32
+  mul x11, x6, x7
+  movk x9, #17184, lsl 48
+  dup.2d v8, x9
   mov.16b v10, v5
+  umulh x6, x6, x7
+  fmla.2d v10, v4, v8
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v8
+  adds x5, x11, x5
+  cinc x6, x6, hs
+  add.2d v0, v0, v10
+  add.2d v8, v9, v11
+  adds x1, x5, x1
+  cinc x5, x6, hs
+  mov x6, #25532
+  movk x6, #31025, lsl 16
+  movk x6, #10002, lsl 32
+  mul x9, x10, x7
+  movk x6, #17199, lsl 48
+  dup.2d v9, x6
+  mov.16b v10, v5
+  umulh x6, x10, x7
   fmla.2d v10, v4, v9
   fsub.2d v11, v6, v10
-  mul x8, x9, x7
   fmla.2d v11, v4, v9
-  add.2d v2, v2, v10
-  add.2d v1, v1, v11
-  umulh x9, x9, x7
-  mov x11, #21566
-  movk x11, #43708, lsl 16
-  movk x11, #57685, lsl 32
-  adds x5, x8, x5
-  cinc x8, x9, hs
-  movk x11, #17185, lsl 48
-  dup.2d v9, x11
+  adds x5, x9, x5
+  cinc x6, x6, hs
+  add.2d v1, v1, v10
+  add.2d v0, v0, v11
+  mov x7, #18830
+  adds x2, x5, x2
+  cinc x5, x6, hs
+  movk x7, #2465, lsl 16
+  movk x7, #36348, lsl 32
+  movk x7, #17194, lsl 48
+  add x3, x3, x5
+  dup.2d v9, x7
   mov.16b v10, v5
   fmla.2d v10, v4, v9
-  adds x1, x5, x1
-  cinc x5, x8, hs
+  mov x5, #65535
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  add.2d v2, v2, v10
+  movk x5, #61439, lsl 16
+  add.2d v1, v1, v11
+  mov x6, #21566
+  movk x6, #43708, lsl 16
+  movk x5, #62867, lsl 32
+  movk x6, #57685, lsl 32
+  movk x6, #17185, lsl 48
+  movk x5, #49889, lsl 48
+  dup.2d v9, x6
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  mul x5, x5, x8
   fsub.2d v11, v6, v10
   fmla.2d v11, v4, v9
   add.2d v7, v7, v10
-  mul x8, x10, x7
+  mov x6, #1
   add.2d v2, v2, v11
-  mov x9, #3072
-  movk x9, #8058, lsl 16
-  umulh x7, x10, x7
-  movk x9, #46097, lsl 32
-  movk x9, #17047, lsl 48
-  dup.2d v9, x9
-  adds x5, x8, x5
-  cinc x7, x7, hs
+  mov x7, #3072
+  movk x7, #8058, lsl 16
+  movk x6, #61440, lsl 16
+  movk x7, #46097, lsl 32
+  movk x7, #17047, lsl 48
+  dup.2d v9, x7
+  movk x6, #62867, lsl 32
   mov.16b v10, v5
   fmla.2d v10, v4, v9
   fsub.2d v11, v6, v10
-  adds x2, x5, x2
-  cinc x5, x7, hs
+  movk x6, #17377, lsl 48
   fmla.2d v11, v4, v9
   add.2d v3, v3, v10
   add.2d v4, v7, v11
-  add x3, x3, x5
-  mov x5, #65535
-  movk x5, #61439, lsl 16
-  movk x5, #62867, lsl 32
-  mov x7, #65535
-  movk x5, #1, lsl 48
-  umov x8, v8.d[0]
-  umov x9, v8.d[1]
-  movk x7, #61439, lsl 16
-  mul x8, x8, x5
-  mul x5, x9, x5
-  and x8, x8, x4
-  movk x7, #62867, lsl 32
-  and x4, x5, x4
-  ins v7.d[0], x8
+  mov x7, #28817
+  mov x9, #65535
+  movk x9, #61439, lsl 16
+  movk x9, #62867, lsl 32
+  movk x7, #31161, lsl 16
+  movk x9, #1, lsl 48
+  umov x10, v8.d[0]
+  movk x7, #59464, lsl 32
+  umov x11, v8.d[1]
+  mul x10, x10, x9
+  mul x9, x11, x9
+  movk x7, #10291, lsl 48
+  and x10, x10, x4
+  and x4, x9, x4
+  ins v7.d[0], x10
   ins v7.d[1], x4
+  mov x4, #22621
   ucvtf.2d v7, v7
-  mov x4, #16
-  movk x7, #49889, lsl 48
-  movk x4, #22847, lsl 32
-  movk x4, #17151, lsl 48
-  dup.2d v9, x4
-  mul x4, x7, x6
+  mov x9, #16
+  movk x9, #22847, lsl 32
+  movk x4, #33153, lsl 16
+  movk x9, #17151, lsl 48
+  dup.2d v9, x9
   mov.16b v10, v5
+  movk x4, #17846, lsl 32
   fmla.2d v10, v7, v9
   fsub.2d v11, v6, v10
-  mov x5, #1
   fmla.2d v11, v7, v9
+  movk x4, #47184, lsl 48
   add.2d v0, v0, v10
   add.2d v8, v8, v11
-  movk x5, #61440, lsl 16
-  mov x7, #20728
-  movk x7, #23588, lsl 16
-  movk x7, #7790, lsl 32
-  movk x5, #62867, lsl 32
-  movk x7, #17170, lsl 48
-  dup.2d v9, x7
-  mov.16b v10, v5
-  movk x5, #17377, lsl 48
-  fmla.2d v10, v7, v9
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v7, v9
-  mov x7, #28817
-  add.2d v1, v1, v10
-  add.2d v0, v0, v11
-  mov x8, #16000
-  movk x7, #31161, lsl 16
-  movk x8, #53891, lsl 16
-  movk x8, #5509, lsl 32
-  movk x8, #17144, lsl 48
-  dup.2d v9, x8
-  movk x7, #59464, lsl 32
-  mov.16b v10, v5
-  fmla.2d v10, v7, v9
-  fsub.2d v11, v6, v10
-  movk x7, #10291, lsl 48
-  fmla.2d v11, v7, v9
-  add.2d v2, v2, v10
-  add.2d v1, v1, v11
-  mov x8, #22621
-  mov x9, #46800
-  movk x9, #2568, lsl 16
-  movk x9, #1335, lsl 32
-  movk x8, #33153, lsl 16
-  movk x9, #17188, lsl 48
-  dup.2d v9, x9
-  mov.16b v10, v5
-  movk x8, #17846, lsl 32
-  fmla.2d v10, v7, v9
-  fsub.2d v11, v6, v10
-  fmla.2d v11, v7, v9
-  movk x8, #47184, lsl 48
-  add.2d v4, v4, v10
-  add.2d v2, v2, v11
-  mov x9, #39040
+  mov x9, #20728
   mov x10, #41001
-  movk x9, #14704, lsl 16
-  movk x9, #12839, lsl 32
-  movk x9, #17096, lsl 48
+  movk x9, #23588, lsl 16
+  movk x9, #7790, lsl 32
+  movk x9, #17170, lsl 48
   movk x10, #57649, lsl 16
   dup.2d v9, x9
-  mov.16b v5, v5
-  fmla.2d v5, v7, v9
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
   movk x10, #20082, lsl 32
-  fsub.2d v6, v6, v5
-  fmla.2d v6, v7, v9
-  add.2d v3, v3, v5
-  add.2d v4, v4, v6
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
   movk x10, #12388, lsl 48
-  mov x9, #140737488355328
-  dup.2d v5, x9
-  and.16b v5, v3, v5
-  mul x9, x5, x4
-  cmeq.2d v5, v5, #0
-  mov x11, #2
-  movk x11, #57344, lsl 16
-  umulh x5, x5, x4
-  movk x11, #60199, lsl 32
-  movk x11, #3, lsl 48
-  dup.2d v6, x11
-  cmn x9, x6
-  cinc x5, x5, hs
-  bic.16b v6, v6, v5
-  mov x6, #10364
-  movk x6, #11794, lsl 16
-  mul x9, x7, x4
-  movk x6, #3895, lsl 32
-  movk x6, #9, lsl 48
-  dup.2d v7, x6
-  umulh x6, x7, x4
-  bic.16b v7, v7, v5
-  mov x7, #26576
-  movk x7, #47696, lsl 16
-  adds x5, x9, x5
+  add.2d v1, v1, v10
+  add.2d v0, v0, v11
+  mov x9, #16000
+  mul x11, x6, x5
+  movk x9, #53891, lsl 16
+  movk x9, #5509, lsl 32
+  movk x9, #17144, lsl 48
+  umulh x6, x6, x5
+  dup.2d v9, x9
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  cmn x11, x8
   cinc x6, x6, hs
-  movk x7, #688, lsl 32
-  movk x7, #3, lsl 48
-  dup.2d v9, x7
-  adds x0, x5, x0
-  cinc x5, x6, hs
-  bic.16b v9, v9, v5
-  mov x6, #46800
-  movk x6, #2568, lsl 16
-  movk x6, #1335, lsl 32
-  mul x7, x8, x4
-  movk x6, #4, lsl 48
-  dup.2d v10, x6
-  bic.16b v10, v10, v5
-  umulh x6, x8, x4
-  mov x8, #49763
-  movk x8, #40165, lsl 16
-  movk x8, #24776, lsl 32
-  adds x5, x7, x5
-  cinc x6, x6, hs
-  dup.2d v11, x8
-  bic.16b v5, v11, v5
-  sub.2d v0, v0, v6
-  adds x1, x5, x1
-  cinc x5, x6, hs
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v7, v9
+  add.2d v2, v2, v10
+  mul x8, x7, x5
+  add.2d v9, v1, v11
+  mov x9, #46800
+  movk x9, #2568, lsl 16
+  umulh x7, x7, x5
+  movk x9, #1335, lsl 32
+  movk x9, #17188, lsl 48
+  dup.2d v1, x9
+  adds x6, x8, x6
+  cinc x7, x7, hs
+  mov.16b v10, v5
+  fmla.2d v10, v7, v1
+  fsub.2d v11, v6, v10
+  adds x0, x6, x0
+  cinc x6, x7, hs
+  fmla.2d v11, v7, v1
+  add.2d v1, v4, v10
+  mul x7, x4, x5
+  add.2d v4, v2, v11
+  mov x8, #39040
+  movk x8, #14704, lsl 16
+  umulh x4, x4, x5
+  movk x8, #12839, lsl 32
+  movk x8, #17096, lsl 48
+  dup.2d v2, x8
+  adds x6, x7, x6
+  cinc x4, x4, hs
+  mov.16b v5, v5
+  fmla.2d v5, v7, v2
+  fsub.2d v6, v6, v5
+  adds x1, x6, x1
+  cinc x4, x4, hs
+  fmla.2d v6, v7, v2
+  add.2d v5, v3, v5
+  add.2d v6, v1, v6
+  mul x6, x10, x5
   ssra.2d v0, v8, #52
-  sub.2d v6, v1, v7
-  ssra.2d v6, v0, #52
-  mul x6, x10, x4
-  sub.2d v7, v2, v9
-  ssra.2d v7, v6, #52
-  sub.2d v4, v4, v10
-  umulh x4, x10, x4
-  ssra.2d v4, v7, #52
-  sub.2d v5, v3, v5
-  ssra.2d v5, v4, #52
-  adds x5, x6, x5
-  cinc x4, x4, hs
-  ushr.2d v1, v6, #12
-  ushr.2d v2, v7, #24
-  ushr.2d v3, v4, #36
-  adds x2, x5, x2
-  cinc x4, x4, hs
-  sli.2d v0, v6, #52
-  sli.2d v1, v7, #40
-  sli.2d v2, v4, #28
+  ssra.2d v9, v0, #52
+  ssra.2d v4, v9, #52
+  umulh x5, x10, x5
+  ssra.2d v6, v4, #52
+  ssra.2d v5, v6, #52
+  ushr.2d v1, v9, #12
+  adds x4, x6, x4
+  cinc x5, x5, hs
+  ushr.2d v2, v4, #24
+  ushr.2d v3, v6, #36
+  sli.2d v0, v9, #52
+  adds x2, x4, x2
+  cinc x4, x5, hs
+  sli.2d v1, v4, #40
+  sli.2d v2, v6, #28
   sli.2d v3, v5, #16
   add x3, x3, x4

--- a/block-multiplier/src/aarch64/montgomery_square_log_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_square_log_interleaved_4.s
@@ -10,685 +10,671 @@
   mov x8, #4503599627370495
   mul x9, x0, x0
   dup.2d v4, x8
-  umulh x10, x0, x0
-  mov x11, #5075556780046548992
-  dup.2d v5, x11
-  mul x11, x0, x1
+  mov x10, #5075556780046548992
+  umulh x11, x0, x0
+  dup.2d v5, x10
+  mul x10, x0, x1
   mov x12, #1
-  umulh x13, x0, x1
   movk x12, #18032, lsl 48
+  umulh x13, x0, x1
   dup.2d v6, x12
-  adds x10, x11, x10
+  adds x11, x10, x11
   cinc x12, x13, hs
   shl.2d v7, v1, #14
-  mul x14, x0, x2
   shl.2d v8, v2, #26
-  umulh x15, x0, x2
+  mul x14, x0, x2
   shl.2d v9, v3, #38
+  umulh x15, x0, x2
   ushr.2d v3, v3, #14
+  shl.2d v10, v0, #2
   adds x12, x14, x12
   cinc x16, x15, hs
-  shl.2d v10, v0, #2
-  mul x17, x0, x3
   usra.2d v7, v0, #50
   usra.2d v8, v1, #38
-  umulh x0, x0, x3
+  mul x17, x0, x3
   usra.2d v9, v2, #26
+  umulh x0, x0, x3
+  and.16b v0, v10, v4
+  and.16b v1, v7, v4
   adds x16, x17, x16
   cinc x20, x0, hs
-  and.16b v0, v10, v4
-  adds x10, x11, x10
-  cinc x11, x13, hs
-  and.16b v1, v7, v4
   and.16b v2, v8, v4
-  mul x13, x1, x1
+  adds x10, x10, x11
+  cinc x11, x13, hs
   and.16b v7, v9, v4
-  umulh x21, x1, x1
-  mov x22, #13605374474286268416
-  dup.2d v8, x22
-  adds x11, x13, x11
-  cinc x13, x21, hs
-  mov x21, #6440147467139809280
+  mov x13, #13605374474286268416
+  mul x21, x1, x1
+  dup.2d v8, x13
+  umulh x13, x1, x1
+  mov x22, #6440147467139809280
+  dup.2d v9, x22
+  adds x11, x21, x11
+  cinc x13, x13, hs
+  mov x21, #3688448094816436224
   adds x11, x11, x12
   cinc x12, x13, hs
-  dup.2d v9, x21
-  mul x13, x1, x2
-  mov x21, #3688448094816436224
   dup.2d v10, x21
-  umulh x21, x1, x2
-  mov x22, #9209861237972664320
-  adds x12, x13, x12
-  cinc x23, x21, hs
-  dup.2d v11, x22
-  mov x22, #12218265789056155648
-  adds x12, x12, x16
-  cinc x16, x23, hs
-  dup.2d v12, x22
-  mul x22, x1, x3
+  mov x13, #9209861237972664320
+  mul x21, x1, x2
+  dup.2d v11, x13
+  mov x13, #12218265789056155648
+  umulh x22, x1, x2
+  dup.2d v12, x13
+  adds x12, x21, x12
+  cinc x13, x22, hs
   mov x23, #17739678932212383744
-  umulh x1, x1, x3
   dup.2d v13, x23
-  mov x23, #2301339409586323456
-  adds x16, x22, x16
-  cinc x24, x1, hs
-  dup.2d v14, x23
-  adds x16, x16, x20
-  cinc x20, x24, hs
-  mov x23, #7822752552742551552
-  dup.2d v15, x23
+  adds x12, x12, x16
+  cinc x13, x13, hs
+  mov x16, #2301339409586323456
+  mul x23, x1, x3
+  dup.2d v14, x16
+  mov x16, #7822752552742551552
+  umulh x1, x1, x3
+  dup.2d v15, x16
+  adds x13, x23, x13
+  cinc x16, x1, hs
+  mov x24, #5071053180419178496
+  dup.2d v16, x24
+  adds x13, x13, x20
+  cinc x16, x16, hs
+  mov x20, #16352570246982270976
   adds x11, x14, x11
   cinc x14, x15, hs
-  mov x15, #5071053180419178496
-  adds x13, x13, x14
-  cinc x14, x21, hs
-  dup.2d v16, x15
-  adds x12, x13, x12
-  cinc x13, x14, hs
-  mov x14, #16352570246982270976
-  dup.2d v17, x14
-  mul x14, x2, x2
+  dup.2d v17, x20
   ucvtf.2d v0, v0
-  umulh x15, x2, x2
+  adds x14, x21, x14
+  cinc x15, x22, hs
   ucvtf.2d v1, v1
   ucvtf.2d v2, v2
-  adds x13, x14, x13
+  adds x12, x14, x12
   cinc x14, x15, hs
   ucvtf.2d v7, v7
-  adds x13, x13, x16
-  cinc x14, x14, hs
+  mul x15, x2, x2
   ucvtf.2d v3, v3
-  mul x15, x2, x3
   mov.16b v18, v5
+  umulh x20, x2, x2
   fmla.2d v18, v0, v0
-  umulh x2, x2, x3
-  fsub.2d v19, v6, v18
   adds x14, x15, x14
-  cinc x16, x2, hs
+  cinc x15, x20, hs
+  fsub.2d v19, v6, v18
   fmla.2d v19, v0, v0
+  adds x13, x14, x13
+  cinc x14, x15, hs
   add.2d v10, v10, v18
-  adds x14, x14, x20
-  cinc x16, x16, hs
+  mul x15, x2, x3
   add.2d v8, v8, v19
-  adds x12, x17, x12
-  cinc x0, x0, hs
   mov.16b v18, v5
-  adds x0, x22, x0
-  cinc x1, x1, hs
+  umulh x2, x2, x3
   fmla.2d v18, v0, v1
   fsub.2d v19, v6, v18
+  adds x14, x15, x14
+  cinc x20, x2, hs
+  fmla.2d v19, v0, v1
+  adds x14, x14, x16
+  cinc x16, x20, hs
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  adds x12, x17, x12
+  cinc x0, x0, hs
+  add.2d v12, v12, v18
+  adds x0, x23, x0
+  cinc x1, x1, hs
+  add.2d v10, v10, v19
+  mov.16b v18, v5
   adds x0, x0, x13
   cinc x1, x1, hs
-  fmla.2d v19, v0, v1
+  fmla.2d v18, v0, v2
   adds x1, x15, x1
   cinc x2, x2, hs
-  add.2d v18, v18, v18
-  add.2d v19, v19, v19
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v2
   adds x1, x1, x14
   cinc x2, x2, hs
-  add.2d v12, v12, v18
-  mul x13, x3, x3
-  add.2d v10, v10, v19
-  umulh x3, x3, x3
-  mov.16b v18, v5
-  fmla.2d v18, v0, v2
-  adds x2, x13, x2
-  cinc x3, x3, hs
-  fsub.2d v19, v6, v18
-  adds x2, x2, x16
-  cinc x3, x3, hs
-  fmla.2d v19, v0, v2
   add.2d v18, v18, v18
-  mov x13, #56431
+  mul x13, x3, x3
   add.2d v19, v19, v19
-  movk x13, #30457, lsl 16
   add.2d v14, v14, v18
-  movk x13, #30012, lsl 32
+  umulh x3, x3, x3
   add.2d v12, v12, v19
   mov.16b v18, v5
-  movk x13, #6382, lsl 48
+  adds x2, x13, x2
+  cinc x3, x3, hs
   fmla.2d v18, v0, v7
-  mov x14, #59151
+  adds x2, x2, x16
+  cinc x3, x3, hs
   fsub.2d v19, v6, v18
   fmla.2d v19, v0, v7
-  movk x14, #41769, lsl 16
+  mov x13, #56431
   add.2d v18, v18, v18
-  movk x14, #32276, lsl 32
+  movk x13, #30457, lsl 16
   add.2d v19, v19, v19
-  movk x14, #21677, lsl 48
   add.2d v16, v16, v18
+  movk x13, #30012, lsl 32
   add.2d v14, v14, v19
-  mov x15, #34015
+  movk x13, #6382, lsl 48
   mov.16b v18, v5
-  movk x15, #20342, lsl 16
   fmla.2d v18, v0, v3
+  mov x14, #59151
   fsub.2d v19, v6, v18
-  movk x15, #13935, lsl 32
+  movk x14, #41769, lsl 16
   fmla.2d v19, v0, v3
-  movk x15, #11030, lsl 48
   add.2d v0, v18, v18
-  mov x16, #13689
+  movk x14, #32276, lsl 32
   add.2d v18, v19, v19
   add.2d v0, v17, v0
-  movk x16, #8159, lsl 16
+  movk x14, #21677, lsl 48
   add.2d v16, v16, v18
-  movk x16, #215, lsl 32
+  mov x15, #34015
   mov.16b v17, v5
   fmla.2d v17, v1, v1
-  movk x16, #4913, lsl 48
+  movk x15, #20342, lsl 16
   fsub.2d v18, v6, v17
-  mul x17, x13, x9
+  movk x15, #13935, lsl 32
   fmla.2d v18, v1, v1
-  umulh x20, x13, x9
   add.2d v14, v14, v17
+  movk x15, #11030, lsl 48
   add.2d v12, v12, v18
-  adds x11, x17, x11
-  cinc x17, x20, hs
+  mov x16, #13689
   mov.16b v17, v5
-  mul x20, x14, x9
   fmla.2d v17, v1, v2
+  movk x16, #8159, lsl 16
   fsub.2d v18, v6, v17
-  umulh x21, x14, x9
+  movk x16, #215, lsl 32
   fmla.2d v18, v1, v2
-  adds x17, x20, x17
-  cinc x20, x21, hs
   add.2d v17, v17, v17
-  adds x12, x17, x12
-  cinc x17, x20, hs
+  movk x16, #4913, lsl 48
   add.2d v18, v18, v18
   add.2d v16, v16, v17
-  mul x20, x15, x9
+  mul x17, x13, x9
   add.2d v14, v14, v18
-  umulh x21, x15, x9
+  umulh x20, x13, x9
   mov.16b v17, v5
   fmla.2d v17, v1, v7
+  adds x11, x17, x11
+  cinc x17, x20, hs
+  fsub.2d v18, v6, v17
+  mul x20, x14, x9
+  fmla.2d v18, v1, v7
+  add.2d v17, v17, v17
+  umulh x21, x14, x9
+  add.2d v18, v18, v18
   adds x17, x20, x17
   cinc x20, x21, hs
-  fsub.2d v18, v6, v17
-  adds x0, x17, x0
-  cinc x17, x20, hs
-  fmla.2d v18, v1, v7
-  mul x20, x16, x9
-  add.2d v17, v17, v17
-  add.2d v18, v18, v18
-  umulh x9, x16, x9
   add.2d v0, v0, v17
-  adds x17, x20, x17
-  cinc x9, x9, hs
   add.2d v16, v16, v18
+  adds x12, x17, x12
+  cinc x17, x20, hs
   mov.16b v17, v5
-  adds x1, x17, x1
-  cinc x9, x9, hs
   fmla.2d v17, v1, v3
-  adds x2, x2, x9
-  cinc x3, x3, hs
+  mul x20, x15, x9
   fsub.2d v18, v6, v17
-  mul x9, x13, x10
+  umulh x21, x15, x9
   fmla.2d v18, v1, v3
   add.2d v1, v17, v17
-  umulh x13, x13, x10
+  adds x17, x20, x17
+  cinc x20, x21, hs
   add.2d v17, v18, v18
-  adds x9, x9, x12
-  cinc x12, x13, hs
+  adds x0, x17, x0
+  cinc x17, x20, hs
   add.2d v1, v15, v1
   add.2d v0, v0, v17
-  mul x13, x14, x10
+  mul x20, x16, x9
   mov.16b v15, v5
-  umulh x14, x14, x10
+  umulh x9, x16, x9
   fmla.2d v15, v2, v2
-  adds x12, x13, x12
-  cinc x13, x14, hs
   fsub.2d v17, v6, v15
+  adds x17, x20, x17
+  cinc x9, x9, hs
   fmla.2d v17, v2, v2
-  adds x0, x12, x0
-  cinc x12, x13, hs
+  adds x1, x17, x1
+  cinc x9, x9, hs
   add.2d v0, v0, v15
-  mul x13, x15, x10
   add.2d v15, v16, v17
+  adds x2, x2, x9
+  cinc x3, x3, hs
   mov.16b v16, v5
-  umulh x14, x15, x10
   fmla.2d v16, v2, v7
-  adds x12, x13, x12
-  cinc x13, x14, hs
+  mul x9, x13, x10
   fsub.2d v17, v6, v16
-  adds x1, x12, x1
-  cinc x12, x13, hs
+  umulh x13, x13, x10
   fmla.2d v17, v2, v7
   add.2d v16, v16, v16
-  mul x13, x16, x10
+  adds x9, x9, x12
+  cinc x12, x13, hs
   add.2d v17, v17, v17
-  umulh x10, x16, x10
+  mul x13, x14, x10
   add.2d v1, v1, v16
   add.2d v0, v0, v17
-  adds x12, x13, x12
-  cinc x10, x10, hs
+  umulh x14, x14, x10
   mov.16b v16, v5
-  adds x2, x12, x2
-  cinc x10, x10, hs
+  adds x12, x13, x12
+  cinc x13, x14, hs
   fmla.2d v16, v2, v3
   fsub.2d v17, v6, v16
-  add x3, x3, x10
+  adds x0, x12, x0
+  cinc x12, x13, hs
   fmla.2d v17, v2, v3
-  mov x10, #61005
+  mul x13, x15, x10
   add.2d v2, v16, v16
-  movk x10, #58262, lsl 16
   add.2d v16, v17, v17
+  umulh x14, x15, x10
   add.2d v2, v13, v2
-  movk x10, #32851, lsl 32
   add.2d v1, v1, v16
-  movk x10, #11582, lsl 48
+  adds x12, x13, x12
+  cinc x13, x14, hs
   mov.16b v13, v5
+  adds x1, x12, x1
+  cinc x12, x13, hs
   fmla.2d v13, v7, v7
-  mov x12, #37581
   fsub.2d v16, v6, v13
-  movk x12, #43836, lsl 16
+  mul x13, x16, x10
   fmla.2d v16, v7, v7
-  movk x12, #36286, lsl 32
+  umulh x10, x16, x10
   add.2d v2, v2, v13
   add.2d v1, v1, v16
-  movk x12, #51783, lsl 48
+  adds x12, x13, x12
+  cinc x10, x10, hs
   mov.16b v13, v5
-  mov x13, #10899
+  adds x2, x12, x2
+  cinc x10, x10, hs
   fmla.2d v13, v7, v3
   fsub.2d v16, v6, v13
-  movk x13, #30709, lsl 16
+  add x3, x3, x10
   fmla.2d v16, v7, v3
-  movk x13, #61551, lsl 32
+  mov x10, #61005
   add.2d v7, v13, v13
-  movk x13, #45784, lsl 48
   add.2d v13, v16, v16
+  movk x10, #58262, lsl 16
   add.2d v7, v11, v7
-  mov x14, #36612
   add.2d v2, v2, v13
-  movk x14, #63402, lsl 16
+  movk x10, #32851, lsl 32
   mov.16b v11, v5
+  movk x10, #11582, lsl 48
   fmla.2d v11, v3, v3
-  movk x14, #47623, lsl 32
   fsub.2d v13, v6, v11
-  movk x14, #9430, lsl 48
+  mov x12, #37581
   fmla.2d v13, v3, v3
-  mul x15, x10, x11
+  movk x12, #43836, lsl 16
   add.2d v3, v9, v11
   add.2d v7, v7, v13
-  umulh x10, x10, x11
+  movk x12, #36286, lsl 32
   usra.2d v10, v8, #52
-  adds x9, x15, x9
-  cinc x10, x10, hs
+  movk x12, #51783, lsl 48
   usra.2d v12, v10, #52
   usra.2d v14, v12, #52
-  mul x15, x12, x11
+  mov x13, #10899
   usra.2d v15, v14, #52
-  umulh x12, x12, x11
   and.16b v8, v8, v4
-  adds x10, x15, x10
-  cinc x12, x12, hs
+  movk x13, #30709, lsl 16
   and.16b v9, v10, v4
+  movk x13, #61551, lsl 32
   and.16b v10, v12, v4
-  adds x0, x10, x0
-  cinc x10, x12, hs
   and.16b v4, v14, v4
-  mul x12, x13, x11
+  movk x13, #45784, lsl 48
   ucvtf.2d v8, v8
+  mov x14, #36612
   mov x15, #37864
-  umulh x13, x13, x11
   movk x15, #1815, lsl 16
-  adds x10, x12, x10
-  cinc x12, x13, hs
+  movk x14, #63402, lsl 16
   movk x15, #28960, lsl 32
-  adds x1, x10, x1
-  cinc x10, x12, hs
+  movk x14, #47623, lsl 32
   movk x15, #17153, lsl 48
   dup.2d v11, x15
-  mul x12, x14, x11
+  movk x14, #9430, lsl 48
   mov.16b v12, v5
-  umulh x11, x14, x11
+  mul x15, x10, x11
   fmla.2d v12, v8, v11
   fsub.2d v13, v6, v12
-  adds x10, x12, x10
-  cinc x11, x11, hs
+  umulh x10, x10, x11
   fmla.2d v13, v8, v11
-  adds x2, x10, x2
-  cinc x10, x11, hs
   add.2d v0, v0, v12
-  add x3, x3, x10
+  adds x9, x15, x9
+  cinc x10, x10, hs
   add.2d v11, v15, v13
-  mov x10, #46128
-  mov x11, #65535
-  movk x10, #29964, lsl 16
-  movk x11, #61439, lsl 16
-  movk x10, #7587, lsl 32
-  movk x10, #17161, lsl 48
-  movk x11, #62867, lsl 32
-  dup.2d v12, x10
-  movk x11, #49889, lsl 48
+  mul x15, x12, x11
+  mov x16, #46128
+  movk x16, #29964, lsl 16
+  umulh x12, x12, x11
+  movk x16, #7587, lsl 32
+  adds x10, x15, x10
+  cinc x12, x12, hs
+  movk x16, #17161, lsl 48
+  dup.2d v12, x16
+  adds x0, x10, x0
+  cinc x10, x12, hs
   mov.16b v13, v5
-  mul x10, x11, x9
+  mul x12, x13, x11
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
-  mov x11, #1
+  umulh x13, x13, x11
   fmla.2d v14, v8, v12
-  movk x11, #61440, lsl 16
+  adds x10, x12, x10
+  cinc x12, x13, hs
   add.2d v1, v1, v13
   add.2d v0, v0, v14
-  movk x11, #62867, lsl 32
+  adds x1, x10, x1
+  cinc x10, x12, hs
   mov x12, #52826
-  movk x11, #17377, lsl 48
   movk x12, #57790, lsl 16
-  mov x13, #28817
+  mul x13, x14, x11
   movk x12, #55431, lsl 32
+  umulh x11, x14, x11
   movk x12, #17196, lsl 48
+  dup.2d v12, x12
+  adds x10, x13, x10
+  cinc x11, x11, hs
+  mov.16b v13, v5
+  adds x2, x10, x2
+  cinc x10, x11, hs
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  add x3, x3, x10
+  fmla.2d v14, v8, v12
+  mov x10, #65535
+  add.2d v2, v2, v13
+  add.2d v1, v1, v14
+  movk x10, #61439, lsl 16
+  mov x11, #31276
+  movk x10, #62867, lsl 32
+  movk x11, #21262, lsl 16
+  movk x11, #2304, lsl 32
+  movk x10, #49889, lsl 48
+  movk x11, #17182, lsl 48
+  dup.2d v12, x11
+  mul x10, x10, x9
+  mov.16b v13, v5
+  mov x11, #1
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  movk x11, #61440, lsl 16
+  fmla.2d v14, v8, v12
+  movk x11, #62867, lsl 32
+  add.2d v7, v7, v13
+  add.2d v2, v2, v14
+  movk x11, #17377, lsl 48
+  mov x12, #28672
+  mov x13, #28817
+  movk x12, #24515, lsl 16
+  movk x12, #54929, lsl 32
   movk x13, #31161, lsl 16
+  movk x12, #17064, lsl 48
   dup.2d v12, x12
   movk x13, #59464, lsl 32
   mov.16b v13, v5
-  fmla.2d v13, v8, v12
   movk x13, #10291, lsl 48
+  fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
   mov x12, #22621
   fmla.2d v14, v8, v12
   movk x12, #33153, lsl 16
-  add.2d v2, v2, v13
-  add.2d v1, v1, v14
+  add.2d v3, v3, v13
+  add.2d v7, v7, v14
   movk x12, #17846, lsl 32
-  mov x14, #31276
+  ucvtf.2d v8, v9
   movk x12, #47184, lsl 48
-  movk x14, #21262, lsl 16
-  movk x14, #2304, lsl 32
+  mov x14, #44768
+  movk x14, #51919, lsl 16
   mov x15, #41001
-  movk x14, #17182, lsl 48
+  movk x14, #6346, lsl 32
   movk x15, #57649, lsl 16
-  dup.2d v12, x14
+  movk x14, #17133, lsl 48
+  dup.2d v9, x14
   movk x15, #20082, lsl 32
-  mov.16b v13, v5
-  fmla.2d v13, v8, v12
+  mov.16b v12, v5
+  fmla.2d v12, v8, v9
   movk x15, #12388, lsl 48
-  fsub.2d v14, v6, v13
+  fsub.2d v13, v6, v12
   mul x14, x11, x10
-  fmla.2d v14, v8, v12
-  add.2d v7, v7, v13
+  fmla.2d v13, v8, v9
+  add.2d v0, v0, v12
   umulh x11, x11, x10
-  add.2d v2, v2, v14
+  add.2d v9, v11, v13
   cmn x14, x9
   cinc x11, x11, hs
-  mov x9, #28672
+  mov x9, #47492
+  movk x9, #23630, lsl 16
   mul x14, x13, x10
-  movk x9, #24515, lsl 16
-  movk x9, #54929, lsl 32
+  movk x9, #49985, lsl 32
   umulh x13, x13, x10
-  movk x9, #17064, lsl 48
-  adds x11, x14, x11
-  cinc x13, x13, hs
-  dup.2d v12, x9
-  mov.16b v13, v5
-  adds x0, x11, x0
-  cinc x9, x13, hs
-  fmla.2d v13, v8, v12
+  movk x9, #17168, lsl 48
+  dup.2d v11, x9
+  adds x9, x14, x11
+  cinc x11, x13, hs
+  mov.16b v12, v5
+  adds x0, x9, x0
+  cinc x9, x11, hs
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
   mul x11, x12, x10
-  fsub.2d v14, v6, v13
+  fmla.2d v13, v8, v11
+  add.2d v1, v1, v12
   umulh x12, x12, x10
-  fmla.2d v14, v8, v12
-  add.2d v3, v3, v13
+  add.2d v0, v0, v13
   adds x9, x11, x9
   cinc x11, x12, hs
-  add.2d v7, v7, v14
+  mov x12, #57936
+  movk x12, #54828, lsl 16
   adds x1, x9, x1
   cinc x9, x11, hs
-  ucvtf.2d v8, v9
-  mov x11, #44768
-  mul x12, x15, x10
-  movk x11, #51919, lsl 16
+  movk x12, #18292, lsl 32
+  mul x11, x15, x10
+  movk x12, #17197, lsl 48
+  dup.2d v11, x12
   umulh x10, x15, x10
-  movk x11, #6346, lsl 32
-  adds x9, x12, x9
+  mov.16b v12, v5
+  adds x9, x11, x9
   cinc x10, x10, hs
-  movk x11, #17133, lsl 48
-  dup.2d v9, x11
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
   adds x2, x9, x2
   cinc x9, x10, hs
-  mov.16b v12, v5
-  add x3, x3, x9
-  fmla.2d v12, v8, v9
-  fsub.2d v13, v6, v12
-  mov x9, #2
-  fmla.2d v13, v8, v9
-  movk x9, #57344, lsl 16
-  add.2d v0, v0, v12
-  movk x9, #60199, lsl 32
-  add.2d v9, v11, v13
-  mov x10, #47492
-  movk x9, #34755, lsl 48
-  movk x10, #23630, lsl 16
-  mov x11, #57634
-  movk x10, #49985, lsl 32
-  movk x10, #17168, lsl 48
-  movk x11, #62322, lsl 16
-  dup.2d v11, x10
-  movk x11, #53392, lsl 32
-  mov.16b v12, v5
-  movk x11, #20583, lsl 48
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
-  mov x10, #45242
-  fmla.2d v13, v8, v11
-  movk x10, #770, lsl 16
-  add.2d v1, v1, v12
-  add.2d v0, v0, v13
-  movk x10, #35693, lsl 32
-  mov x12, #57936
-  movk x10, #28832, lsl 48
-  movk x12, #54828, lsl 16
-  mov x13, #16467
-  movk x12, #18292, lsl 32
-  movk x12, #17197, lsl 48
-  movk x13, #49763, lsl 16
-  dup.2d v11, x12
-  movk x13, #40165, lsl 32
-  mov.16b v12, v5
-  fmla.2d v12, v8, v11
-  movk x13, #24776, lsl 48
-  fsub.2d v13, v6, v12
-  subs x9, x0, x9
-  sbcs x11, x1, x11
-  sbcs x10, x2, x10
-  sbcs x12, x3, x13
   fmla.2d v13, v8, v11
   add.2d v2, v2, v12
-  tst x3, #9223372036854775808
-  csel x0, x9, x0, mi
-  csel x1, x11, x1, mi
-  csel x2, x10, x2, mi
-  csel x3, x12, x3, mi
+  add x3, x3, x9
   add.2d v1, v1, v13
   mul x9, x4, x4
   mov x10, #17708
-  umulh x11, x4, x4
   movk x10, #43915, lsl 16
+  umulh x11, x4, x4
   movk x10, #64348, lsl 32
   mul x12, x4, x5
   movk x10, #17188, lsl 48
-  umulh x13, x4, x5
   dup.2d v11, x10
+  umulh x10, x4, x5
   mov.16b v12, v5
-  adds x10, x12, x11
-  cinc x11, x13, hs
-  fmla.2d v12, v8, v11
-  mul x14, x4, x6
-  fsub.2d v13, v6, v12
-  umulh x15, x4, x6
-  fmla.2d v13, v8, v11
-  add.2d v7, v7, v12
-  adds x11, x14, x11
-  cinc x16, x15, hs
-  add.2d v2, v2, v13
-  mul x17, x4, x7
-  mov x20, #29184
-  movk x20, #20789, lsl 16
-  umulh x4, x4, x7
-  movk x20, #19197, lsl 32
-  adds x16, x17, x16
-  cinc x21, x4, hs
-  movk x20, #17083, lsl 48
-  adds x10, x12, x10
-  cinc x12, x13, hs
-  dup.2d v11, x20
-  mov.16b v12, v5
-  mul x13, x5, x5
-  fmla.2d v12, v8, v11
-  umulh x20, x5, x5
-  fsub.2d v13, v6, v12
-  fmla.2d v13, v8, v11
-  adds x12, x13, x12
-  cinc x13, x20, hs
-  add.2d v3, v3, v12
   adds x11, x12, x11
-  cinc x12, x13, hs
-  add.2d v7, v7, v13
-  mul x13, x5, x6
-  ucvtf.2d v8, v10
-  mov x20, #58856
-  umulh x22, x5, x6
-  movk x20, #14953, lsl 16
-  adds x12, x13, x12
-  cinc x23, x22, hs
-  movk x20, #15155, lsl 32
-  movk x20, #17181, lsl 48
-  adds x12, x12, x16
-  cinc x16, x23, hs
-  dup.2d v10, x20
-  mul x20, x5, x7
-  mov.16b v11, v5
-  umulh x5, x5, x7
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
+  cinc x13, x10, hs
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  mul x14, x4, x6
+  fmla.2d v13, v8, v11
+  umulh x15, x4, x6
+  add.2d v7, v7, v12
+  add.2d v2, v2, v13
+  adds x13, x14, x13
+  cinc x16, x15, hs
+  mov x17, #29184
+  movk x17, #20789, lsl 16
+  mul x20, x4, x7
+  movk x17, #19197, lsl 32
+  umulh x4, x4, x7
+  movk x17, #17083, lsl 48
+  dup.2d v11, x17
   adds x16, x20, x16
-  cinc x23, x5, hs
-  fmla.2d v12, v8, v10
-  adds x16, x16, x21
-  cinc x21, x23, hs
-  add.2d v0, v0, v11
-  add.2d v9, v9, v12
-  adds x11, x14, x11
-  cinc x14, x15, hs
-  mov x15, #35392
-  adds x13, x13, x14
-  cinc x14, x22, hs
-  movk x15, #12477, lsl 16
-  adds x12, x13, x12
-  cinc x13, x14, hs
-  movk x15, #56780, lsl 32
-  movk x15, #17142, lsl 48
-  mul x14, x6, x6
-  dup.2d v10, x15
-  umulh x15, x6, x6
+  cinc x17, x4, hs
+  mov.16b v12, v5
+  adds x11, x12, x11
+  cinc x10, x10, hs
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  mul x12, x5, x5
+  fmla.2d v13, v8, v11
+  umulh x21, x5, x5
+  add.2d v3, v3, v12
+  add.2d v7, v7, v13
+  adds x10, x12, x10
+  cinc x12, x21, hs
+  ucvtf.2d v8, v10
+  adds x10, x10, x13
+  cinc x12, x12, hs
+  mov x13, #58856
+  movk x13, #14953, lsl 16
+  mul x21, x5, x6
+  movk x13, #15155, lsl 32
+  movk x13, #17181, lsl 48
+  umulh x22, x5, x6
+  dup.2d v10, x13
+  adds x12, x21, x12
+  cinc x13, x22, hs
   mov.16b v11, v5
   fmla.2d v11, v8, v10
+  adds x12, x12, x16
+  cinc x13, x13, hs
+  fsub.2d v12, v6, v11
+  mul x16, x5, x7
+  fmla.2d v12, v8, v10
+  add.2d v0, v0, v11
+  umulh x5, x5, x7
+  add.2d v9, v9, v12
+  adds x13, x16, x13
+  cinc x23, x5, hs
+  mov x24, #35392
+  movk x24, #12477, lsl 16
+  adds x13, x13, x17
+  cinc x17, x23, hs
+  movk x24, #56780, lsl 32
+  adds x10, x14, x10
+  cinc x14, x15, hs
+  movk x24, #17142, lsl 48
+  dup.2d v10, x24
+  adds x14, x21, x14
+  cinc x15, x22, hs
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  adds x12, x14, x12
+  cinc x14, x15, hs
+  fsub.2d v12, v6, v11
+  mul x15, x6, x6
+  fmla.2d v12, v8, v10
+  add.2d v1, v1, v11
+  umulh x21, x6, x6
+  add.2d v0, v0, v12
+  adds x14, x15, x14
+  cinc x15, x21, hs
+  mov x21, #9848
+  movk x21, #54501, lsl 16
   adds x13, x14, x13
   cinc x14, x15, hs
-  fsub.2d v12, v6, v11
-  adds x13, x13, x16
-  cinc x14, x14, hs
-  fmla.2d v12, v8, v10
+  movk x21, #31540, lsl 32
   mul x15, x6, x7
-  add.2d v1, v1, v11
-  add.2d v0, v0, v12
+  movk x21, #17170, lsl 48
+  dup.2d v10, x21
   umulh x6, x6, x7
-  mov x16, #9848
-  adds x14, x15, x14
-  cinc x22, x6, hs
-  movk x16, #54501, lsl 16
-  movk x16, #31540, lsl 32
-  adds x14, x14, x21
-  cinc x21, x22, hs
-  movk x16, #17170, lsl 48
-  adds x12, x17, x12
-  cinc x4, x4, hs
-  dup.2d v10, x16
-  adds x4, x20, x4
-  cinc x5, x5, hs
   mov.16b v11, v5
   fmla.2d v11, v8, v10
-  adds x4, x4, x13
-  cinc x5, x5, hs
+  adds x14, x15, x14
+  cinc x21, x6, hs
   fsub.2d v12, v6, v11
-  adds x5, x15, x5
-  cinc x6, x6, hs
+  adds x14, x14, x17
+  cinc x17, x21, hs
   fmla.2d v12, v8, v10
   add.2d v2, v2, v11
+  adds x12, x20, x12
+  cinc x4, x4, hs
+  add.2d v1, v1, v12
+  adds x4, x16, x4
+  cinc x5, x5, hs
+  mov x16, #9584
+  movk x16, #63883, lsl 16
+  adds x4, x4, x13
+  cinc x5, x5, hs
+  movk x16, #18253, lsl 32
+  adds x5, x15, x5
+  cinc x6, x6, hs
+  movk x16, #17190, lsl 48
+  dup.2d v10, x16
   adds x5, x5, x14
   cinc x6, x6, hs
-  add.2d v1, v1, v12
-  mul x13, x7, x7
-  mov x14, #9584
-  umulh x7, x7, x7
-  movk x14, #63883, lsl 16
-  movk x14, #18253, lsl 32
-  adds x6, x13, x6
-  cinc x7, x7, hs
-  movk x14, #17190, lsl 48
-  adds x6, x6, x21
-  cinc x7, x7, hs
-  dup.2d v10, x14
   mov.16b v11, v5
-  mov x13, #56431
+  mul x13, x7, x7
   fmla.2d v11, v8, v10
-  movk x13, #30457, lsl 16
   fsub.2d v12, v6, v11
-  movk x13, #30012, lsl 32
+  umulh x7, x7, x7
   fmla.2d v12, v8, v10
   add.2d v7, v7, v11
-  movk x13, #6382, lsl 48
+  adds x6, x13, x6
+  cinc x7, x7, hs
   add.2d v2, v2, v12
-  mov x14, #59151
-  mov x15, #51712
-  movk x15, #16093, lsl 16
-  movk x14, #41769, lsl 16
-  movk x15, #30633, lsl 32
-  movk x14, #32276, lsl 32
-  movk x15, #17068, lsl 48
-  movk x14, #21677, lsl 48
-  dup.2d v10, x15
+  adds x6, x6, x17
+  cinc x7, x7, hs
+  mov x13, #51712
+  movk x13, #16093, lsl 16
+  mov x14, #56431
+  movk x13, #30633, lsl 32
+  movk x14, #30457, lsl 16
+  movk x13, #17068, lsl 48
+  dup.2d v10, x13
+  movk x14, #30012, lsl 32
   mov.16b v11, v5
-  mov x15, #34015
+  movk x14, #6382, lsl 48
   fmla.2d v11, v8, v10
-  movk x15, #20342, lsl 16
   fsub.2d v12, v6, v11
+  mov x13, #59151
   fmla.2d v12, v8, v10
-  movk x15, #13935, lsl 32
+  movk x13, #41769, lsl 16
   add.2d v3, v3, v11
-  movk x15, #11030, lsl 48
   add.2d v7, v7, v12
-  mov x16, #13689
+  movk x13, #32276, lsl 32
   ucvtf.2d v4, v4
-  mov x17, #34724
-  movk x16, #8159, lsl 16
-  movk x17, #40393, lsl 16
-  movk x16, #215, lsl 32
-  movk x17, #23752, lsl 32
-  movk x17, #17184, lsl 48
-  movk x16, #4913, lsl 48
-  dup.2d v8, x17
-  mul x17, x13, x9
+  mov x15, #34724
+  movk x13, #21677, lsl 48
+  movk x15, #40393, lsl 16
+  mov x16, #34015
+  movk x15, #23752, lsl 32
+  movk x15, #17184, lsl 48
+  movk x16, #20342, lsl 16
+  dup.2d v8, x15
+  movk x16, #13935, lsl 32
   mov.16b v10, v5
-  umulh x20, x13, x9
   fmla.2d v10, v4, v8
+  movk x16, #11030, lsl 48
   fsub.2d v11, v6, v10
-  adds x11, x17, x11
-  cinc x17, x20, hs
+  mov x15, #13689
   fmla.2d v11, v4, v8
-  mul x20, x14, x9
   add.2d v0, v0, v10
+  movk x15, #8159, lsl 16
   add.2d v8, v9, v11
-  umulh x21, x14, x9
-  mov x22, #25532
+  movk x15, #215, lsl 32
+  mov x17, #25532
+  movk x17, #31025, lsl 16
+  movk x15, #4913, lsl 48
+  movk x17, #10002, lsl 32
+  movk x17, #17199, lsl 48
+  mul x20, x14, x9
+  dup.2d v9, x17
+  umulh x17, x14, x9
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  adds x10, x20, x10
+  cinc x17, x17, hs
+  fsub.2d v11, v6, v10
+  mul x20, x13, x9
+  fmla.2d v11, v4, v9
+  add.2d v1, v1, v10
+  umulh x21, x13, x9
+  add.2d v0, v0, v11
   adds x17, x20, x17
   cinc x20, x21, hs
-  movk x22, #31025, lsl 16
+  mov x21, #18830
+  movk x21, #2465, lsl 16
   adds x12, x17, x12
   cinc x17, x20, hs
-  movk x22, #10002, lsl 32
-  movk x22, #17199, lsl 48
-  mul x20, x15, x9
-  dup.2d v9, x22
-  umulh x21, x15, x9
+  movk x21, #36348, lsl 32
+  movk x21, #17194, lsl 48
+  mul x20, x16, x9
+  dup.2d v9, x21
+  umulh x21, x16, x9
   mov.16b v10, v5
   fmla.2d v10, v4, v9
   adds x17, x20, x17
@@ -697,294 +683,258 @@
   adds x4, x17, x4
   cinc x17, x20, hs
   fmla.2d v11, v4, v9
-  mul x20, x16, x9
-  add.2d v1, v1, v10
-  add.2d v0, v0, v11
-  umulh x9, x16, x9
-  mov x21, #18830
+  add.2d v2, v2, v10
+  mul x20, x15, x9
+  add.2d v1, v1, v11
+  umulh x9, x15, x9
+  mov x21, #21566
+  movk x21, #43708, lsl 16
   adds x17, x20, x17
   cinc x9, x9, hs
-  movk x21, #2465, lsl 16
-  movk x21, #36348, lsl 32
+  movk x21, #57685, lsl 32
   adds x5, x17, x5
   cinc x9, x9, hs
-  movk x21, #17194, lsl 48
+  movk x21, #17185, lsl 48
+  dup.2d v9, x21
   adds x6, x6, x9
   cinc x7, x7, hs
-  dup.2d v9, x21
-  mul x9, x13, x10
   mov.16b v10, v5
   fmla.2d v10, v4, v9
-  umulh x13, x13, x10
+  mul x9, x14, x11
   fsub.2d v11, v6, v10
-  adds x9, x9, x12
-  cinc x12, x13, hs
-  fmla.2d v11, v4, v9
-  add.2d v2, v2, v10
-  mul x13, x14, x10
-  add.2d v1, v1, v11
-  umulh x14, x14, x10
-  mov x17, #21566
-  adds x12, x13, x12
-  cinc x13, x14, hs
-  movk x17, #43708, lsl 16
-  movk x17, #57685, lsl 32
-  adds x4, x12, x4
-  cinc x12, x13, hs
-  movk x17, #17185, lsl 48
-  mul x13, x15, x10
-  dup.2d v9, x17
-  mov.16b v10, v5
-  umulh x14, x15, x10
-  fmla.2d v10, v4, v9
-  adds x12, x13, x12
-  cinc x13, x14, hs
-  fsub.2d v11, v6, v10
-  adds x5, x12, x5
-  cinc x12, x13, hs
+  umulh x14, x14, x11
   fmla.2d v11, v4, v9
   add.2d v7, v7, v10
-  mul x13, x16, x10
+  adds x9, x9, x12
+  cinc x12, x14, hs
   add.2d v2, v2, v11
-  umulh x10, x16, x10
-  mov x14, #3072
-  movk x14, #8058, lsl 16
-  adds x12, x13, x12
-  cinc x10, x10, hs
-  movk x14, #46097, lsl 32
-  adds x6, x12, x6
-  cinc x10, x10, hs
-  movk x14, #17047, lsl 48
-  dup.2d v9, x14
-  add x7, x7, x10
+  mul x14, x13, x11
+  mov x17, #3072
+  movk x17, #8058, lsl 16
+  umulh x13, x13, x11
+  movk x17, #46097, lsl 32
+  adds x12, x14, x12
+  cinc x13, x13, hs
+  movk x17, #17047, lsl 48
+  dup.2d v9, x17
+  adds x4, x12, x4
+  cinc x12, x13, hs
   mov.16b v10, v5
-  mov x10, #61005
+  mul x13, x16, x11
   fmla.2d v10, v4, v9
-  movk x10, #58262, lsl 16
   fsub.2d v11, v6, v10
+  umulh x14, x16, x11
   fmla.2d v11, v4, v9
-  movk x10, #32851, lsl 32
   add.2d v3, v3, v10
-  movk x10, #11582, lsl 48
+  adds x12, x13, x12
+  cinc x13, x14, hs
   add.2d v4, v7, v11
-  mov x12, #65535
-  mov x13, #37581
-  movk x12, #61439, lsl 16
-  movk x13, #43836, lsl 16
-  movk x12, #62867, lsl 32
-  movk x13, #36286, lsl 32
-  movk x12, #1, lsl 48
-  umov x14, v8.d[0]
-  movk x13, #51783, lsl 48
-  umov x15, v8.d[1]
-  mov x16, #10899
-  mul x14, x14, x12
-  mul x12, x15, x12
-  movk x16, #30709, lsl 16
-  and x14, x14, x8
-  movk x16, #61551, lsl 32
-  and x8, x12, x8
-  movk x16, #45784, lsl 48
-  ins v7.d[0], x14
+  adds x5, x12, x5
+  cinc x12, x13, hs
+  mov x13, #65535
+  movk x13, #61439, lsl 16
+  mul x14, x15, x11
+  movk x13, #62867, lsl 32
+  umulh x11, x15, x11
+  movk x13, #1, lsl 48
+  umov x15, v8.d[0]
+  adds x12, x14, x12
+  cinc x11, x11, hs
+  umov x14, v8.d[1]
+  adds x6, x12, x6
+  cinc x11, x11, hs
+  mul x12, x15, x13
+  mul x13, x14, x13
+  add x7, x7, x11
+  and x11, x12, x8
+  mov x12, #61005
+  and x8, x13, x8
+  ins v7.d[0], x11
   ins v7.d[1], x8
+  movk x12, #58262, lsl 16
   ucvtf.2d v7, v7
-  mov x8, #36612
-  mov x12, #16
-  movk x8, #63402, lsl 16
-  movk x12, #22847, lsl 32
-  movk x12, #17151, lsl 48
-  movk x8, #47623, lsl 32
-  dup.2d v9, x12
-  movk x8, #9430, lsl 48
+  mov x8, #16
+  movk x12, #32851, lsl 32
+  movk x8, #22847, lsl 32
+  movk x12, #11582, lsl 48
+  movk x8, #17151, lsl 48
+  dup.2d v9, x8
+  mov x8, #37581
   mov.16b v10, v5
-  mul x12, x10, x11
+  movk x8, #43836, lsl 16
   fmla.2d v10, v7, v9
   fsub.2d v11, v6, v10
-  umulh x10, x10, x11
+  movk x8, #36286, lsl 32
   fmla.2d v11, v7, v9
-  adds x9, x12, x9
-  cinc x10, x10, hs
+  movk x8, #51783, lsl 48
   add.2d v0, v0, v10
   add.2d v8, v8, v11
-  mul x12, x13, x11
-  mov x14, #20728
-  umulh x13, x13, x11
-  movk x14, #23588, lsl 16
-  adds x10, x12, x10
-  cinc x12, x13, hs
-  movk x14, #7790, lsl 32
-  movk x14, #17170, lsl 48
-  adds x4, x10, x4
-  cinc x10, x12, hs
-  dup.2d v9, x14
-  mul x12, x16, x11
+  mov x11, #10899
+  mov x13, #20728
+  movk x13, #23588, lsl 16
+  movk x11, #30709, lsl 16
+  movk x13, #7790, lsl 32
+  movk x11, #61551, lsl 32
+  movk x13, #17170, lsl 48
+  dup.2d v9, x13
+  movk x11, #45784, lsl 48
   mov.16b v10, v5
+  mov x13, #36612
   fmla.2d v10, v7, v9
-  umulh x13, x16, x11
   fsub.2d v11, v6, v10
-  adds x10, x12, x10
-  cinc x12, x13, hs
+  movk x13, #63402, lsl 16
   fmla.2d v11, v7, v9
-  adds x5, x10, x5
-  cinc x10, x12, hs
+  movk x13, #47623, lsl 32
   add.2d v1, v1, v10
   add.2d v0, v0, v11
-  mul x12, x8, x11
-  mov x13, #16000
-  umulh x8, x8, x11
-  movk x13, #53891, lsl 16
-  movk x13, #5509, lsl 32
-  adds x10, x12, x10
-  cinc x8, x8, hs
-  movk x13, #17144, lsl 48
-  adds x6, x10, x6
-  cinc x8, x8, hs
-  dup.2d v9, x13
-  add x7, x7, x8
+  movk x13, #9430, lsl 48
+  mov x14, #16000
+  mul x15, x12, x10
+  movk x14, #53891, lsl 16
+  movk x14, #5509, lsl 32
+  umulh x12, x12, x10
+  movk x14, #17144, lsl 48
+  dup.2d v9, x14
+  adds x9, x15, x9
+  cinc x12, x12, hs
   mov.16b v10, v5
+  mul x14, x8, x10
   fmla.2d v10, v7, v9
-  mov x8, #65535
   fsub.2d v11, v6, v10
-  movk x8, #61439, lsl 16
+  umulh x8, x8, x10
   fmla.2d v11, v7, v9
+  adds x12, x14, x12
+  cinc x8, x8, hs
   add.2d v2, v2, v10
-  movk x8, #62867, lsl 32
   add.2d v1, v1, v11
-  movk x8, #49889, lsl 48
-  mov x10, #46800
-  mul x8, x8, x9
-  movk x10, #2568, lsl 16
-  movk x10, #1335, lsl 32
-  mov x11, #1
-  movk x10, #17188, lsl 48
-  movk x11, #61440, lsl 16
-  dup.2d v9, x10
-  mov.16b v10, v5
-  movk x11, #62867, lsl 32
-  fmla.2d v10, v7, v9
-  movk x11, #17377, lsl 48
-  fsub.2d v11, v6, v10
-  mov x10, #28817
-  fmla.2d v11, v7, v9
-  add.2d v4, v4, v10
-  movk x10, #31161, lsl 16
-  add.2d v2, v2, v11
-  movk x10, #59464, lsl 32
-  mov x12, #39040
-  movk x12, #14704, lsl 16
-  movk x10, #10291, lsl 48
-  movk x12, #12839, lsl 32
-  mov x13, #22621
-  movk x12, #17096, lsl 48
-  movk x13, #33153, lsl 16
+  adds x4, x12, x4
+  cinc x8, x8, hs
+  mov x12, #46800
+  mul x14, x11, x10
+  movk x12, #2568, lsl 16
+  movk x12, #1335, lsl 32
+  umulh x11, x11, x10
+  movk x12, #17188, lsl 48
+  adds x8, x14, x8
+  cinc x11, x11, hs
   dup.2d v9, x12
+  mov.16b v10, v5
+  adds x5, x8, x5
+  cinc x8, x11, hs
+  fmla.2d v10, v7, v9
+  fsub.2d v11, v6, v10
+  mul x11, x13, x10
+  fmla.2d v11, v7, v9
+  umulh x10, x13, x10
+  add.2d v4, v4, v10
+  add.2d v2, v2, v11
+  adds x8, x11, x8
+  cinc x10, x10, hs
+  mov x11, #39040
+  adds x6, x8, x6
+  cinc x8, x10, hs
+  movk x11, #14704, lsl 16
+  movk x11, #12839, lsl 32
+  add x7, x7, x8
+  movk x11, #17096, lsl 48
+  mov x8, #65535
+  dup.2d v9, x11
   mov.16b v5, v5
-  movk x13, #17846, lsl 32
+  movk x8, #61439, lsl 16
   fmla.2d v5, v7, v9
-  movk x13, #47184, lsl 48
+  movk x8, #62867, lsl 32
   fsub.2d v6, v6, v5
   fmla.2d v6, v7, v9
-  mov x12, #41001
+  movk x8, #49889, lsl 48
   add.2d v3, v3, v5
-  movk x12, #57649, lsl 16
   add.2d v4, v4, v6
-  movk x12, #20082, lsl 32
-  mov x14, #140737488355328
-  dup.2d v5, x14
-  movk x12, #12388, lsl 48
+  mul x8, x8, x9
+  mov x10, #140737488355328
+  mov x11, #1
+  dup.2d v5, x10
   and.16b v5, v3, v5
-  mul x14, x11, x8
+  movk x11, #61440, lsl 16
   cmeq.2d v5, v5, #0
-  mov x15, #2
-  umulh x11, x11, x8
-  movk x15, #57344, lsl 16
-  cmn x14, x9
-  cinc x11, x11, hs
-  movk x15, #60199, lsl 32
-  mul x9, x10, x8
-  movk x15, #3, lsl 48
-  dup.2d v6, x15
-  umulh x10, x10, x8
+  movk x11, #62867, lsl 32
+  mov x10, #2
+  movk x10, #57344, lsl 16
+  movk x11, #17377, lsl 48
+  movk x10, #60199, lsl 32
+  mov x12, #28817
+  movk x10, #3, lsl 48
+  dup.2d v6, x10
+  movk x12, #31161, lsl 16
   bic.16b v6, v6, v5
-  adds x9, x9, x11
-  cinc x10, x10, hs
-  mov x11, #10364
-  movk x11, #11794, lsl 16
-  adds x4, x9, x4
-  cinc x9, x10, hs
-  movk x11, #3895, lsl 32
-  mul x10, x13, x8
-  movk x11, #9, lsl 48
-  umulh x13, x13, x8
-  dup.2d v7, x11
+  mov x10, #10364
+  movk x12, #59464, lsl 32
+  movk x10, #11794, lsl 16
+  movk x12, #10291, lsl 48
+  movk x10, #3895, lsl 32
+  movk x10, #9, lsl 48
+  mov x13, #22621
+  dup.2d v7, x10
+  movk x13, #33153, lsl 16
   bic.16b v7, v7, v5
-  adds x9, x10, x9
-  cinc x10, x13, hs
-  mov x11, #26576
-  adds x5, x9, x5
-  cinc x9, x10, hs
-  movk x11, #47696, lsl 16
-  movk x11, #688, lsl 32
-  mul x10, x12, x8
-  movk x11, #3, lsl 48
-  umulh x8, x12, x8
-  dup.2d v9, x11
-  adds x9, x10, x9
-  cinc x8, x8, hs
+  mov x10, #26576
+  movk x13, #17846, lsl 32
+  movk x10, #47696, lsl 16
+  movk x13, #47184, lsl 48
+  movk x10, #688, lsl 32
+  movk x10, #3, lsl 48
+  mov x14, #41001
+  dup.2d v9, x10
+  movk x14, #57649, lsl 16
   bic.16b v9, v9, v5
   mov x10, #46800
-  adds x6, x9, x6
-  cinc x8, x8, hs
+  movk x14, #20082, lsl 32
   movk x10, #2568, lsl 16
-  add x7, x7, x8
   movk x10, #1335, lsl 32
+  movk x14, #12388, lsl 48
   movk x10, #4, lsl 48
-  mov x8, #2
+  mul x15, x11, x8
   dup.2d v10, x10
-  movk x8, #57344, lsl 16
   bic.16b v10, v10, v5
-  movk x8, #60199, lsl 32
-  mov x9, #49763
-  movk x9, #40165, lsl 16
-  movk x8, #34755, lsl 48
-  movk x9, #24776, lsl 32
-  mov x10, #57634
-  dup.2d v11, x9
+  umulh x10, x11, x8
+  mov x11, #49763
+  cmn x15, x9
+  cinc x10, x10, hs
+  movk x11, #40165, lsl 16
+  movk x11, #24776, lsl 32
+  mul x9, x12, x8
+  dup.2d v11, x11
+  umulh x11, x12, x8
   bic.16b v5, v11, v5
-  movk x10, #62322, lsl 16
   sub.2d v0, v0, v6
-  movk x10, #53392, lsl 32
+  adds x9, x9, x10
+  cinc x10, x11, hs
   ssra.2d v0, v8, #52
-  movk x10, #20583, lsl 48
+  adds x4, x9, x4
+  cinc x9, x10, hs
   sub.2d v6, v1, v7
   ssra.2d v6, v0, #52
-  mov x9, #45242
+  mul x10, x13, x8
   sub.2d v7, v2, v9
-  movk x9, #770, lsl 16
   ssra.2d v7, v6, #52
+  umulh x11, x13, x8
   sub.2d v4, v4, v10
-  movk x9, #35693, lsl 32
+  adds x9, x10, x9
+  cinc x10, x11, hs
   ssra.2d v4, v7, #52
-  movk x9, #28832, lsl 48
   sub.2d v5, v3, v5
-  mov x11, #16467
+  adds x5, x9, x5
+  cinc x9, x10, hs
   ssra.2d v5, v4, #52
+  mul x10, x14, x8
   ushr.2d v1, v6, #12
-  movk x11, #49763, lsl 16
   ushr.2d v2, v7, #24
-  movk x11, #40165, lsl 32
+  umulh x8, x14, x8
   ushr.2d v3, v4, #36
+  adds x9, x10, x9
+  cinc x8, x8, hs
   sli.2d v0, v6, #52
-  movk x11, #24776, lsl 48
   sli.2d v1, v7, #40
-  subs x8, x4, x8
-  sbcs x10, x5, x10
-  sbcs x9, x6, x9
-  sbcs x11, x7, x11
+  adds x6, x9, x6
+  cinc x8, x8, hs
   sli.2d v2, v4, #28
   sli.2d v3, v5, #16
-  tst x7, #9223372036854775808
-  csel x4, x8, x4, mi
-  csel x5, x10, x5, mi
-  csel x6, x9, x6, mi
-  csel x7, x11, x7, mi
+  add x7, x7, x8

--- a/block-multiplier/src/aarch64/montgomery_square_log_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_square_log_interleaved_4.s
@@ -10,931 +10,893 @@
   mov x8, #4503599627370495
   mul x9, x0, x0
   dup.2d v4, x8
-  mov x10, #5075556780046548992
-  umulh x11, x0, x0
-  dup.2d v5, x10
-  mul x10, x0, x1
+  umulh x10, x0, x0
+  mov x11, #5075556780046548992
+  dup.2d v5, x11
+  mul x11, x0, x1
   mov x12, #1
-  movk x12, #18032, lsl 48
   umulh x13, x0, x1
+  movk x12, #18032, lsl 48
   dup.2d v6, x12
-  adds x11, x10, x11
+  adds x10, x11, x10
   cinc x12, x13, hs
   shl.2d v7, v1, #14
-  shl.2d v8, v2, #26
   mul x14, x0, x2
+  shl.2d v8, v2, #26
   shl.2d v9, v3, #38
   umulh x15, x0, x2
   ushr.2d v3, v3, #14
-  shl.2d v10, v0, #2
   adds x12, x14, x12
   cinc x16, x15, hs
+  shl.2d v10, v0, #2
+  mul x17, x0, x3
   usra.2d v7, v0, #50
   usra.2d v8, v1, #38
-  mul x17, x0, x3
-  usra.2d v9, v2, #26
   umulh x0, x0, x3
-  and.16b v0, v10, v4
-  and.16b v1, v7, v4
+  usra.2d v9, v2, #26
   adds x16, x17, x16
   cinc x20, x0, hs
-  and.16b v2, v8, v4
-  adds x10, x10, x11
+  and.16b v0, v10, v4
+  and.16b v1, v7, v4
+  adds x10, x11, x10
   cinc x11, x13, hs
+  and.16b v2, v8, v4
+  mul x13, x1, x1
   and.16b v7, v9, v4
-  mov x13, #13605374474286268416
-  mul x21, x1, x1
-  dup.2d v8, x13
-  umulh x13, x1, x1
-  mov x22, #6440147467139809280
-  dup.2d v9, x22
-  adds x11, x21, x11
-  cinc x13, x13, hs
-  mov x21, #3688448094816436224
+  mov x21, #13605374474286268416
+  umulh x22, x1, x1
+  dup.2d v8, x21
+  adds x11, x13, x11
+  cinc x13, x22, hs
+  mov x21, #6440147467139809280
+  dup.2d v9, x21
   adds x11, x11, x12
   cinc x12, x13, hs
-  dup.2d v10, x21
-  mov x13, #9209861237972664320
+  mov x13, #3688448094816436224
   mul x21, x1, x2
-  dup.2d v11, x13
-  mov x13, #12218265789056155648
-  umulh x22, x1, x2
-  dup.2d v12, x13
+  dup.2d v10, x13
+  umulh x13, x1, x2
+  mov x22, #9209861237972664320
+  dup.2d v11, x22
   adds x12, x21, x12
-  cinc x13, x22, hs
-  mov x23, #17739678932212383744
-  dup.2d v13, x23
+  cinc x22, x13, hs
+  mov x23, #12218265789056155648
   adds x12, x12, x16
-  cinc x13, x13, hs
-  mov x16, #2301339409586323456
+  cinc x16, x22, hs
+  dup.2d v12, x23
+  mov x22, #17739678932212383744
   mul x23, x1, x3
-  dup.2d v14, x16
-  mov x16, #7822752552742551552
+  dup.2d v13, x22
   umulh x1, x1, x3
-  dup.2d v15, x16
-  adds x13, x23, x13
-  cinc x16, x1, hs
-  mov x24, #5071053180419178496
-  dup.2d v16, x24
-  adds x13, x13, x20
-  cinc x16, x16, hs
-  mov x20, #16352570246982270976
+  mov x22, #2301339409586323456
+  dup.2d v14, x22
+  adds x16, x23, x16
+  cinc x22, x1, hs
+  mov x24, #7822752552742551552
+  adds x16, x16, x20
+  cinc x20, x22, hs
+  dup.2d v15, x24
+  mov x22, #5071053180419178496
   adds x11, x14, x11
   cinc x14, x15, hs
-  dup.2d v17, x20
-  ucvtf.2d v0, v0
+  dup.2d v16, x22
   adds x14, x21, x14
-  cinc x15, x22, hs
-  ucvtf.2d v1, v1
-  ucvtf.2d v2, v2
+  cinc x13, x13, hs
+  mov x15, #16352570246982270976
   adds x12, x14, x12
-  cinc x14, x15, hs
+  cinc x13, x13, hs
+  dup.2d v17, x15
+  ucvtf.2d v0, v0
+  mul x14, x2, x2
+  ucvtf.2d v1, v1
+  umulh x15, x2, x2
+  ucvtf.2d v2, v2
   ucvtf.2d v7, v7
-  mul x15, x2, x2
-  ucvtf.2d v3, v3
-  mov.16b v18, v5
-  umulh x20, x2, x2
-  fmla.2d v18, v0, v0
-  adds x14, x15, x14
-  cinc x15, x20, hs
-  fsub.2d v19, v6, v18
-  fmla.2d v19, v0, v0
   adds x13, x14, x13
   cinc x14, x15, hs
-  add.2d v10, v10, v18
-  mul x15, x2, x3
-  add.2d v8, v8, v19
+  ucvtf.2d v3, v3
+  adds x13, x13, x16
+  cinc x14, x14, hs
   mov.16b v18, v5
-  umulh x2, x2, x3
-  fmla.2d v18, v0, v1
+  fmla.2d v18, v0, v0
+  mul x15, x2, x3
   fsub.2d v19, v6, v18
+  umulh x2, x2, x3
+  fmla.2d v19, v0, v0
   adds x14, x15, x14
-  cinc x20, x2, hs
-  fmla.2d v19, v0, v1
-  adds x14, x14, x16
-  cinc x16, x20, hs
-  add.2d v18, v18, v18
-  add.2d v19, v19, v19
+  cinc x16, x2, hs
+  add.2d v10, v10, v18
+  add.2d v8, v8, v19
+  adds x14, x14, x20
+  cinc x16, x16, hs
+  mov.16b v18, v5
   adds x12, x17, x12
   cinc x0, x0, hs
-  add.2d v12, v12, v18
+  fmla.2d v18, v0, v1
+  fsub.2d v19, v6, v18
   adds x0, x23, x0
   cinc x1, x1, hs
-  add.2d v10, v10, v19
-  mov.16b v18, v5
+  fmla.2d v19, v0, v1
   adds x0, x0, x13
   cinc x1, x1, hs
-  fmla.2d v18, v0, v2
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
   adds x1, x15, x1
   cinc x2, x2, hs
-  fsub.2d v19, v6, v18
-  fmla.2d v19, v0, v2
+  add.2d v12, v12, v18
   adds x1, x1, x14
   cinc x2, x2, hs
-  add.2d v18, v18, v18
-  mul x13, x3, x3
-  add.2d v19, v19, v19
-  add.2d v14, v14, v18
-  umulh x3, x3, x3
-  add.2d v12, v12, v19
+  add.2d v10, v10, v19
   mov.16b v18, v5
+  mul x13, x3, x3
+  fmla.2d v18, v0, v2
+  umulh x3, x3, x3
+  fsub.2d v19, v6, v18
   adds x2, x13, x2
   cinc x3, x3, hs
-  fmla.2d v18, v0, v7
+  fmla.2d v19, v0, v2
+  add.2d v18, v18, v18
   adds x2, x2, x16
   cinc x3, x3, hs
-  fsub.2d v19, v6, v18
-  fmla.2d v19, v0, v7
-  mov x13, #56431
-  add.2d v18, v18, v18
-  movk x13, #30457, lsl 16
   add.2d v19, v19, v19
-  add.2d v16, v16, v18
+  mov x13, #56431
+  add.2d v14, v14, v18
+  add.2d v12, v12, v19
+  movk x13, #30457, lsl 16
+  mov.16b v18, v5
   movk x13, #30012, lsl 32
-  add.2d v14, v14, v19
+  fmla.2d v18, v0, v7
+  fsub.2d v19, v6, v18
   movk x13, #6382, lsl 48
+  fmla.2d v19, v0, v7
+  mov x14, #59151
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  movk x14, #41769, lsl 16
+  add.2d v16, v16, v18
+  movk x14, #32276, lsl 32
+  add.2d v14, v14, v19
+  movk x14, #21677, lsl 48
   mov.16b v18, v5
   fmla.2d v18, v0, v3
-  mov x14, #59151
+  mov x15, #34015
   fsub.2d v19, v6, v18
-  movk x14, #41769, lsl 16
+  movk x15, #20342, lsl 16
   fmla.2d v19, v0, v3
   add.2d v0, v18, v18
-  movk x14, #32276, lsl 32
-  add.2d v18, v19, v19
-  add.2d v0, v17, v0
-  movk x14, #21677, lsl 48
-  add.2d v16, v16, v18
-  mov x15, #34015
-  mov.16b v17, v5
-  fmla.2d v17, v1, v1
-  movk x15, #20342, lsl 16
-  fsub.2d v18, v6, v17
   movk x15, #13935, lsl 32
-  fmla.2d v18, v1, v1
-  add.2d v14, v14, v17
+  add.2d v18, v19, v19
   movk x15, #11030, lsl 48
-  add.2d v12, v12, v18
+  add.2d v0, v17, v0
+  add.2d v16, v16, v18
   mov x16, #13689
   mov.16b v17, v5
-  fmla.2d v17, v1, v2
   movk x16, #8159, lsl 16
+  fmla.2d v17, v1, v1
   fsub.2d v18, v6, v17
   movk x16, #215, lsl 32
-  fmla.2d v18, v1, v2
-  add.2d v17, v17, v17
+  fmla.2d v18, v1, v1
   movk x16, #4913, lsl 48
-  add.2d v18, v18, v18
-  add.2d v16, v16, v17
+  add.2d v14, v14, v17
   mul x17, x13, x9
-  add.2d v14, v14, v18
-  umulh x20, x13, x9
+  add.2d v12, v12, v18
   mov.16b v17, v5
-  fmla.2d v17, v1, v7
+  umulh x20, x13, x9
+  fmla.2d v17, v1, v2
   adds x11, x17, x11
   cinc x17, x20, hs
   fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v2
   mul x20, x14, x9
-  fmla.2d v18, v1, v7
   add.2d v17, v17, v17
   umulh x21, x14, x9
   add.2d v18, v18, v18
+  add.2d v16, v16, v17
   adds x17, x20, x17
   cinc x20, x21, hs
-  add.2d v0, v0, v17
-  add.2d v16, v16, v18
+  add.2d v14, v14, v18
   adds x12, x17, x12
   cinc x17, x20, hs
   mov.16b v17, v5
-  fmla.2d v17, v1, v3
   mul x20, x15, x9
+  fmla.2d v17, v1, v7
   fsub.2d v18, v6, v17
   umulh x21, x15, x9
-  fmla.2d v18, v1, v3
-  add.2d v1, v17, v17
+  fmla.2d v18, v1, v7
   adds x17, x20, x17
   cinc x20, x21, hs
-  add.2d v17, v18, v18
+  add.2d v17, v17, v17
+  add.2d v18, v18, v18
   adds x0, x17, x0
   cinc x17, x20, hs
-  add.2d v1, v15, v1
   add.2d v0, v0, v17
   mul x20, x16, x9
-  mov.16b v15, v5
+  add.2d v16, v16, v18
+  mov.16b v17, v5
   umulh x9, x16, x9
-  fmla.2d v15, v2, v2
-  fsub.2d v17, v6, v15
+  fmla.2d v17, v1, v3
   adds x17, x20, x17
   cinc x9, x9, hs
-  fmla.2d v17, v2, v2
+  fsub.2d v18, v6, v17
+  fmla.2d v18, v1, v3
   adds x1, x17, x1
   cinc x9, x9, hs
-  add.2d v0, v0, v15
-  add.2d v15, v16, v17
+  add.2d v1, v17, v17
   adds x2, x2, x9
   cinc x3, x3, hs
-  mov.16b v16, v5
-  fmla.2d v16, v2, v7
+  add.2d v17, v18, v18
   mul x9, x13, x10
-  fsub.2d v17, v6, v16
+  add.2d v1, v15, v1
+  add.2d v0, v0, v17
   umulh x13, x13, x10
-  fmla.2d v17, v2, v7
-  add.2d v16, v16, v16
+  mov.16b v15, v5
   adds x9, x9, x12
   cinc x12, x13, hs
-  add.2d v17, v17, v17
+  fmla.2d v15, v2, v2
+  fsub.2d v17, v6, v15
   mul x13, x14, x10
-  add.2d v1, v1, v16
-  add.2d v0, v0, v17
+  fmla.2d v17, v2, v2
   umulh x14, x14, x10
-  mov.16b v16, v5
+  add.2d v0, v0, v15
+  add.2d v15, v16, v17
   adds x12, x13, x12
   cinc x13, x14, hs
-  fmla.2d v16, v2, v3
-  fsub.2d v17, v6, v16
+  mov.16b v16, v5
   adds x0, x12, x0
   cinc x12, x13, hs
-  fmla.2d v17, v2, v3
+  fmla.2d v16, v2, v7
+  fsub.2d v17, v6, v16
   mul x13, x15, x10
-  add.2d v2, v16, v16
-  add.2d v16, v17, v17
+  fmla.2d v17, v2, v7
   umulh x14, x15, x10
-  add.2d v2, v13, v2
-  add.2d v1, v1, v16
+  add.2d v16, v16, v16
   adds x12, x13, x12
   cinc x13, x14, hs
-  mov.16b v13, v5
+  add.2d v17, v17, v17
+  add.2d v1, v1, v16
   adds x1, x12, x1
   cinc x12, x13, hs
-  fmla.2d v13, v7, v7
-  fsub.2d v16, v6, v13
+  add.2d v0, v0, v17
   mul x13, x16, x10
-  fmla.2d v16, v7, v7
+  mov.16b v16, v5
+  fmla.2d v16, v2, v3
   umulh x10, x16, x10
-  add.2d v2, v2, v13
-  add.2d v1, v1, v16
+  fsub.2d v17, v6, v16
   adds x12, x13, x12
   cinc x10, x10, hs
-  mov.16b v13, v5
+  fmla.2d v17, v2, v3
+  add.2d v2, v16, v16
   adds x2, x12, x2
   cinc x10, x10, hs
-  fmla.2d v13, v7, v3
-  fsub.2d v16, v6, v13
+  add.2d v16, v17, v17
   add x3, x3, x10
-  fmla.2d v16, v7, v3
+  add.2d v2, v13, v2
+  add.2d v1, v1, v16
   mov x10, #61005
-  add.2d v7, v13, v13
-  add.2d v13, v16, v16
+  mov.16b v13, v5
   movk x10, #58262, lsl 16
+  fmla.2d v13, v7, v7
+  movk x10, #32851, lsl 32
+  fsub.2d v16, v6, v13
+  fmla.2d v16, v7, v7
+  movk x10, #11582, lsl 48
+  add.2d v2, v2, v13
+  mov x12, #37581
+  add.2d v1, v1, v16
+  mov.16b v13, v5
+  movk x12, #43836, lsl 16
+  fmla.2d v13, v7, v3
+  movk x12, #36286, lsl 32
+  fsub.2d v16, v6, v13
+  fmla.2d v16, v7, v3
+  movk x12, #51783, lsl 48
+  add.2d v7, v13, v13
+  mov x13, #10899
+  add.2d v13, v16, v16
+  movk x13, #30709, lsl 16
   add.2d v7, v11, v7
   add.2d v2, v2, v13
-  movk x10, #32851, lsl 32
+  movk x13, #61551, lsl 32
   mov.16b v11, v5
-  movk x10, #11582, lsl 48
+  movk x13, #45784, lsl 48
   fmla.2d v11, v3, v3
   fsub.2d v13, v6, v11
-  mov x12, #37581
+  mov x14, #36612
   fmla.2d v13, v3, v3
-  movk x12, #43836, lsl 16
+  movk x14, #63402, lsl 16
   add.2d v3, v9, v11
   add.2d v7, v7, v13
-  movk x12, #36286, lsl 32
+  movk x14, #47623, lsl 32
   usra.2d v10, v8, #52
-  movk x12, #51783, lsl 48
+  movk x14, #9430, lsl 48
   usra.2d v12, v10, #52
   usra.2d v14, v12, #52
-  mov x13, #10899
-  usra.2d v15, v14, #52
-  and.16b v8, v8, v4
-  movk x13, #30709, lsl 16
-  and.16b v9, v10, v4
-  movk x13, #61551, lsl 32
-  and.16b v10, v12, v4
-  and.16b v4, v14, v4
-  movk x13, #45784, lsl 48
-  ucvtf.2d v8, v8
-  mov x14, #36612
-  mov x15, #37864
-  movk x15, #1815, lsl 16
-  movk x14, #63402, lsl 16
-  movk x15, #28960, lsl 32
-  movk x14, #47623, lsl 32
-  movk x15, #17153, lsl 48
-  dup.2d v11, x15
-  movk x14, #9430, lsl 48
-  mov.16b v12, v5
   mul x15, x10, x11
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
+  usra.2d v15, v14, #52
   umulh x10, x10, x11
-  fmla.2d v13, v8, v11
-  add.2d v0, v0, v12
+  and.16b v8, v8, v4
   adds x9, x15, x9
   cinc x10, x10, hs
-  add.2d v11, v15, v13
+  and.16b v9, v10, v4
+  and.16b v10, v12, v4
   mul x15, x12, x11
-  mov x16, #46128
-  movk x16, #29964, lsl 16
+  and.16b v4, v14, v4
   umulh x12, x12, x11
-  movk x16, #7587, lsl 32
+  ucvtf.2d v8, v8
+  mov x16, #37864
   adds x10, x15, x10
   cinc x12, x12, hs
-  movk x16, #17161, lsl 48
-  dup.2d v12, x16
+  movk x16, #1815, lsl 16
   adds x0, x10, x0
   cinc x10, x12, hs
-  mov.16b v13, v5
+  movk x16, #28960, lsl 32
+  movk x16, #17153, lsl 48
   mul x12, x13, x11
-  fmla.2d v13, v8, v12
-  fsub.2d v14, v6, v13
+  dup.2d v11, x16
   umulh x13, x13, x11
-  fmla.2d v14, v8, v12
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
   adds x10, x12, x10
   cinc x12, x13, hs
-  add.2d v1, v1, v13
-  add.2d v0, v0, v14
+  fsub.2d v13, v6, v12
   adds x1, x10, x1
   cinc x10, x12, hs
-  mov x12, #52826
-  movk x12, #57790, lsl 16
-  mul x13, x14, x11
-  movk x12, #55431, lsl 32
+  fmla.2d v13, v8, v11
+  mul x12, x14, x11
+  add.2d v0, v0, v12
+  add.2d v11, v15, v13
   umulh x11, x14, x11
-  movk x12, #17196, lsl 48
-  dup.2d v12, x12
-  adds x10, x13, x10
+  mov x13, #46128
+  adds x10, x12, x10
   cinc x11, x11, hs
-  mov.16b v13, v5
+  movk x13, #29964, lsl 16
+  movk x13, #7587, lsl 32
   adds x2, x10, x2
   cinc x10, x11, hs
-  fmla.2d v13, v8, v12
-  fsub.2d v14, v6, v13
+  movk x13, #17161, lsl 48
   add x3, x3, x10
-  fmla.2d v14, v8, v12
+  dup.2d v12, x13
+  mov.16b v13, v5
   mov x10, #65535
-  add.2d v2, v2, v13
-  add.2d v1, v1, v14
+  fmla.2d v13, v8, v12
   movk x10, #61439, lsl 16
-  mov x11, #31276
+  fsub.2d v14, v6, v13
+  fmla.2d v14, v8, v12
   movk x10, #62867, lsl 32
-  movk x11, #21262, lsl 16
-  movk x11, #2304, lsl 32
+  add.2d v1, v1, v13
   movk x10, #49889, lsl 48
-  movk x11, #17182, lsl 48
-  dup.2d v12, x11
+  add.2d v0, v0, v14
   mul x10, x10, x9
+  mov x11, #52826
+  movk x11, #57790, lsl 16
+  mov x12, #1
+  movk x11, #55431, lsl 32
+  movk x12, #61440, lsl 16
+  movk x11, #17196, lsl 48
+  dup.2d v12, x11
+  movk x12, #62867, lsl 32
   mov.16b v13, v5
-  mov x11, #1
+  movk x12, #17377, lsl 48
   fmla.2d v13, v8, v12
   fsub.2d v14, v6, v13
-  movk x11, #61440, lsl 16
+  mov x11, #28817
   fmla.2d v14, v8, v12
-  movk x11, #62867, lsl 32
+  movk x11, #31161, lsl 16
+  add.2d v2, v2, v13
+  movk x11, #59464, lsl 32
+  add.2d v1, v1, v14
+  mov x13, #31276
+  movk x11, #10291, lsl 48
+  movk x13, #21262, lsl 16
+  mov x14, #22621
+  movk x13, #2304, lsl 32
+  movk x13, #17182, lsl 48
+  movk x14, #33153, lsl 16
+  dup.2d v12, x13
+  movk x14, #17846, lsl 32
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  movk x14, #47184, lsl 48
+  fsub.2d v14, v6, v13
+  mov x13, #41001
+  fmla.2d v14, v8, v12
   add.2d v7, v7, v13
+  movk x13, #57649, lsl 16
   add.2d v2, v2, v14
-  movk x11, #17377, lsl 48
-  mov x12, #28672
-  mov x13, #28817
-  movk x12, #24515, lsl 16
-  movk x12, #54929, lsl 32
-  movk x13, #31161, lsl 16
-  movk x12, #17064, lsl 48
-  dup.2d v12, x12
-  movk x13, #59464, lsl 32
+  movk x13, #20082, lsl 32
+  mov x15, #28672
+  movk x13, #12388, lsl 48
+  movk x15, #24515, lsl 16
+  movk x15, #54929, lsl 32
+  mul x16, x12, x10
+  movk x15, #17064, lsl 48
+  umulh x12, x12, x10
+  dup.2d v12, x15
   mov.16b v13, v5
-  movk x13, #10291, lsl 48
+  cmn x16, x9
+  cinc x12, x12, hs
   fmla.2d v13, v8, v12
+  mul x9, x11, x10
   fsub.2d v14, v6, v13
-  mov x12, #22621
   fmla.2d v14, v8, v12
-  movk x12, #33153, lsl 16
-  add.2d v3, v3, v13
-  add.2d v7, v7, v14
-  movk x12, #17846, lsl 32
-  ucvtf.2d v8, v9
-  movk x12, #47184, lsl 48
-  mov x14, #44768
-  movk x14, #51919, lsl 16
-  mov x15, #41001
-  movk x14, #6346, lsl 32
-  movk x15, #57649, lsl 16
-  movk x14, #17133, lsl 48
-  dup.2d v9, x14
-  movk x15, #20082, lsl 32
-  mov.16b v12, v5
-  fmla.2d v12, v8, v9
-  movk x15, #12388, lsl 48
-  fsub.2d v13, v6, v12
-  mul x14, x11, x10
-  fmla.2d v13, v8, v9
-  add.2d v0, v0, v12
   umulh x11, x11, x10
-  add.2d v9, v11, v13
-  cmn x14, x9
+  add.2d v3, v3, v13
+  adds x9, x9, x12
   cinc x11, x11, hs
-  mov x9, #47492
-  movk x9, #23630, lsl 16
-  mul x14, x13, x10
-  movk x9, #49985, lsl 32
-  umulh x13, x13, x10
-  movk x9, #17168, lsl 48
-  dup.2d v11, x9
-  adds x9, x14, x11
-  cinc x11, x13, hs
-  mov.16b v12, v5
+  add.2d v7, v7, v14
+  ucvtf.2d v8, v9
   adds x0, x9, x0
   cinc x9, x11, hs
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
-  mul x11, x12, x10
-  fmla.2d v13, v8, v11
-  add.2d v1, v1, v12
-  umulh x12, x12, x10
-  add.2d v0, v0, v13
-  adds x9, x11, x9
-  cinc x11, x12, hs
-  mov x12, #57936
-  movk x12, #54828, lsl 16
+  mov x11, #44768
+  mul x12, x14, x10
+  movk x11, #51919, lsl 16
+  umulh x14, x14, x10
+  movk x11, #6346, lsl 32
+  movk x11, #17133, lsl 48
+  adds x9, x12, x9
+  cinc x12, x14, hs
+  dup.2d v9, x11
   adds x1, x9, x1
-  cinc x9, x11, hs
-  movk x12, #18292, lsl 32
-  mul x11, x15, x10
-  movk x12, #17197, lsl 48
-  dup.2d v11, x12
-  umulh x10, x15, x10
+  cinc x9, x12, hs
   mov.16b v12, v5
+  fmla.2d v12, v8, v9
+  mul x11, x13, x10
+  fsub.2d v13, v6, v12
+  umulh x10, x13, x10
+  fmla.2d v13, v8, v9
+  add.2d v0, v0, v12
   adds x9, x11, x9
   cinc x10, x10, hs
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
+  add.2d v9, v11, v13
   adds x2, x9, x2
   cinc x9, x10, hs
-  fmla.2d v13, v8, v11
-  add.2d v2, v2, v12
+  mov x10, #47492
+  movk x10, #23630, lsl 16
   add x3, x3, x9
-  add.2d v1, v1, v13
+  movk x10, #49985, lsl 32
   mul x9, x4, x4
-  mov x10, #17708
-  movk x10, #43915, lsl 16
+  movk x10, #17168, lsl 48
   umulh x11, x4, x4
-  movk x10, #64348, lsl 32
-  mul x12, x4, x5
-  movk x10, #17188, lsl 48
   dup.2d v11, x10
-  umulh x10, x4, x5
   mov.16b v12, v5
-  adds x11, x12, x11
-  cinc x13, x10, hs
+  mul x10, x4, x5
   fmla.2d v12, v8, v11
+  umulh x12, x4, x5
   fsub.2d v13, v6, v12
-  mul x14, x4, x6
   fmla.2d v13, v8, v11
-  umulh x15, x4, x6
-  add.2d v7, v7, v12
-  add.2d v2, v2, v13
-  adds x13, x14, x13
-  cinc x16, x15, hs
-  mov x17, #29184
-  movk x17, #20789, lsl 16
-  mul x20, x4, x7
-  movk x17, #19197, lsl 32
-  umulh x4, x4, x7
-  movk x17, #17083, lsl 48
-  dup.2d v11, x17
-  adds x16, x20, x16
-  cinc x17, x4, hs
-  mov.16b v12, v5
-  adds x11, x12, x11
-  cinc x10, x10, hs
-  fmla.2d v12, v8, v11
-  fsub.2d v13, v6, v12
-  mul x12, x5, x5
-  fmla.2d v13, v8, v11
-  umulh x21, x5, x5
-  add.2d v3, v3, v12
-  add.2d v7, v7, v13
-  adds x10, x12, x10
-  cinc x12, x21, hs
-  ucvtf.2d v8, v10
-  adds x10, x10, x13
-  cinc x12, x12, hs
-  mov x13, #58856
-  movk x13, #14953, lsl 16
-  mul x21, x5, x6
-  movk x13, #15155, lsl 32
-  movk x13, #17181, lsl 48
-  umulh x22, x5, x6
-  dup.2d v10, x13
-  adds x12, x21, x12
-  cinc x13, x22, hs
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  adds x12, x12, x16
-  cinc x13, x13, hs
-  fsub.2d v12, v6, v11
-  mul x16, x5, x7
-  fmla.2d v12, v8, v10
-  add.2d v0, v0, v11
-  umulh x5, x5, x7
-  add.2d v9, v9, v12
-  adds x13, x16, x13
-  cinc x23, x5, hs
-  mov x24, #35392
-  movk x24, #12477, lsl 16
-  adds x13, x13, x17
-  cinc x17, x23, hs
-  movk x24, #56780, lsl 32
-  adds x10, x14, x10
-  cinc x14, x15, hs
-  movk x24, #17142, lsl 48
-  dup.2d v10, x24
-  adds x14, x21, x14
-  cinc x15, x22, hs
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  adds x12, x14, x12
-  cinc x14, x15, hs
-  fsub.2d v12, v6, v11
-  mul x15, x6, x6
-  fmla.2d v12, v8, v10
-  add.2d v1, v1, v11
-  umulh x21, x6, x6
-  add.2d v0, v0, v12
-  adds x14, x15, x14
-  cinc x15, x21, hs
-  mov x21, #9848
-  movk x21, #54501, lsl 16
-  adds x13, x14, x13
-  cinc x14, x15, hs
-  movk x21, #31540, lsl 32
-  mul x15, x6, x7
-  movk x21, #17170, lsl 48
-  dup.2d v10, x21
-  umulh x6, x6, x7
-  mov.16b v11, v5
-  fmla.2d v11, v8, v10
-  adds x14, x15, x14
-  cinc x21, x6, hs
-  fsub.2d v12, v6, v11
-  adds x14, x14, x17
-  cinc x17, x21, hs
-  fmla.2d v12, v8, v10
-  add.2d v2, v2, v11
-  adds x12, x20, x12
-  cinc x4, x4, hs
+  adds x11, x10, x11
+  cinc x13, x12, hs
   add.2d v1, v1, v12
-  adds x4, x16, x4
-  cinc x5, x5, hs
-  mov x16, #9584
-  movk x16, #63883, lsl 16
-  adds x4, x4, x13
-  cinc x5, x5, hs
-  movk x16, #18253, lsl 32
-  adds x5, x15, x5
-  cinc x6, x6, hs
-  movk x16, #17190, lsl 48
-  dup.2d v10, x16
-  adds x5, x5, x14
-  cinc x6, x6, hs
-  mov.16b v11, v5
-  mul x13, x7, x7
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  umulh x7, x7, x7
-  fmla.2d v12, v8, v10
-  add.2d v7, v7, v11
-  adds x6, x13, x6
-  cinc x7, x7, hs
+  mul x14, x4, x6
+  add.2d v0, v0, v13
+  mov x15, #57936
+  umulh x16, x4, x6
+  movk x15, #54828, lsl 16
+  adds x13, x14, x13
+  cinc x17, x16, hs
+  movk x15, #18292, lsl 32
+  mul x20, x4, x7
+  movk x15, #17197, lsl 48
+  dup.2d v11, x15
+  umulh x4, x4, x7
+  mov.16b v12, v5
+  adds x15, x20, x17
+  cinc x17, x4, hs
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  adds x10, x10, x11
+  cinc x11, x12, hs
+  fmla.2d v13, v8, v11
+  mul x12, x5, x5
   add.2d v2, v2, v12
-  adds x6, x6, x17
-  cinc x7, x7, hs
-  mov x13, #51712
-  movk x13, #16093, lsl 16
-  mov x14, #56431
-  movk x13, #30633, lsl 32
-  movk x14, #30457, lsl 16
-  movk x13, #17068, lsl 48
-  dup.2d v10, x13
-  movk x14, #30012, lsl 32
-  mov.16b v11, v5
-  movk x14, #6382, lsl 48
-  fmla.2d v11, v8, v10
-  fsub.2d v12, v6, v11
-  mov x13, #59151
-  fmla.2d v12, v8, v10
-  movk x13, #41769, lsl 16
-  add.2d v3, v3, v11
+  add.2d v1, v1, v13
+  umulh x21, x5, x5
+  mov x22, #17708
+  adds x11, x12, x11
+  cinc x12, x21, hs
+  movk x22, #43915, lsl 16
+  movk x22, #64348, lsl 32
+  adds x11, x11, x13
+  cinc x12, x12, hs
+  movk x22, #17188, lsl 48
+  mul x13, x5, x6
+  dup.2d v11, x22
+  umulh x21, x5, x6
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  adds x12, x13, x12
+  cinc x22, x21, hs
+  fsub.2d v13, v6, v12
+  adds x12, x12, x15
+  cinc x15, x22, hs
+  fmla.2d v13, v8, v11
   add.2d v7, v7, v12
-  movk x13, #32276, lsl 32
-  ucvtf.2d v4, v4
-  mov x15, #34724
-  movk x13, #21677, lsl 48
-  movk x15, #40393, lsl 16
-  mov x16, #34015
-  movk x15, #23752, lsl 32
-  movk x15, #17184, lsl 48
-  movk x16, #20342, lsl 16
-  dup.2d v8, x15
-  movk x16, #13935, lsl 32
-  mov.16b v10, v5
-  fmla.2d v10, v4, v8
-  movk x16, #11030, lsl 48
-  fsub.2d v11, v6, v10
-  mov x15, #13689
-  fmla.2d v11, v4, v8
-  add.2d v0, v0, v10
-  movk x15, #8159, lsl 16
-  add.2d v8, v9, v11
-  movk x15, #215, lsl 32
-  mov x17, #25532
-  movk x17, #31025, lsl 16
-  movk x15, #4913, lsl 48
-  movk x17, #10002, lsl 32
-  movk x17, #17199, lsl 48
-  mul x20, x14, x9
-  dup.2d v9, x17
-  umulh x17, x14, x9
-  mov.16b v10, v5
-  fmla.2d v10, v4, v9
-  adds x10, x20, x10
-  cinc x17, x17, hs
-  fsub.2d v11, v6, v10
-  mul x20, x13, x9
-  fmla.2d v11, v4, v9
-  add.2d v1, v1, v10
-  umulh x21, x13, x9
-  add.2d v0, v0, v11
-  adds x17, x20, x17
-  cinc x20, x21, hs
-  mov x21, #18830
-  movk x21, #2465, lsl 16
-  adds x12, x17, x12
-  cinc x17, x20, hs
-  movk x21, #36348, lsl 32
-  movk x21, #17194, lsl 48
-  mul x20, x16, x9
-  dup.2d v9, x21
-  umulh x21, x16, x9
-  mov.16b v10, v5
-  fmla.2d v10, v4, v9
-  adds x17, x20, x17
-  cinc x20, x21, hs
-  fsub.2d v11, v6, v10
-  adds x4, x17, x4
-  cinc x17, x20, hs
-  fmla.2d v11, v4, v9
-  add.2d v2, v2, v10
-  mul x20, x15, x9
-  add.2d v1, v1, v11
-  umulh x9, x15, x9
-  mov x21, #21566
-  movk x21, #43708, lsl 16
-  adds x17, x20, x17
-  cinc x9, x9, hs
-  movk x21, #57685, lsl 32
-  adds x5, x17, x5
-  cinc x9, x9, hs
-  movk x21, #17185, lsl 48
-  dup.2d v9, x21
-  adds x6, x6, x9
-  cinc x7, x7, hs
-  mov.16b v10, v5
-  fmla.2d v10, v4, v9
-  mul x9, x14, x11
-  fsub.2d v11, v6, v10
-  umulh x14, x14, x11
-  fmla.2d v11, v4, v9
-  add.2d v7, v7, v10
-  adds x9, x9, x12
-  cinc x12, x14, hs
-  add.2d v2, v2, v11
-  mul x14, x13, x11
-  mov x17, #3072
-  movk x17, #8058, lsl 16
-  umulh x13, x13, x11
-  movk x17, #46097, lsl 32
-  adds x12, x14, x12
-  cinc x13, x13, hs
-  movk x17, #17047, lsl 48
-  dup.2d v9, x17
-  adds x4, x12, x4
-  cinc x12, x13, hs
-  mov.16b v10, v5
-  mul x13, x16, x11
-  fmla.2d v10, v4, v9
-  fsub.2d v11, v6, v10
-  umulh x14, x16, x11
-  fmla.2d v11, v4, v9
-  add.2d v3, v3, v10
+  mul x22, x5, x7
+  add.2d v2, v2, v13
+  umulh x5, x5, x7
+  mov x23, #29184
+  movk x23, #20789, lsl 16
+  adds x15, x22, x15
+  cinc x24, x5, hs
+  movk x23, #19197, lsl 32
+  adds x15, x15, x17
+  cinc x17, x24, hs
+  movk x23, #17083, lsl 48
+  dup.2d v11, x23
+  adds x11, x14, x11
+  cinc x14, x16, hs
+  mov.16b v12, v5
+  adds x13, x13, x14
+  cinc x14, x21, hs
+  fmla.2d v12, v8, v11
   adds x12, x13, x12
   cinc x13, x14, hs
-  add.2d v4, v7, v11
-  adds x5, x12, x5
-  cinc x12, x13, hs
-  mov x13, #65535
-  movk x13, #61439, lsl 16
-  mul x14, x15, x11
-  movk x13, #62867, lsl 32
-  umulh x11, x15, x11
-  movk x13, #1, lsl 48
-  umov x15, v8.d[0]
-  adds x12, x14, x12
-  cinc x11, x11, hs
-  umov x14, v8.d[1]
-  adds x6, x12, x6
-  cinc x11, x11, hs
-  mul x12, x15, x13
-  mul x13, x14, x13
-  add x7, x7, x11
-  and x11, x12, x8
-  mov x12, #61005
-  and x8, x13, x8
-  ins v7.d[0], x11
-  ins v7.d[1], x8
-  movk x12, #58262, lsl 16
-  ucvtf.2d v7, v7
-  mov x8, #16
-  movk x12, #32851, lsl 32
-  movk x8, #22847, lsl 32
-  movk x12, #11582, lsl 48
-  movk x8, #17151, lsl 48
-  dup.2d v9, x8
-  mov x8, #37581
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v11
+  mul x14, x6, x6
+  add.2d v3, v3, v12
+  umulh x16, x6, x6
+  add.2d v7, v7, v13
+  ucvtf.2d v8, v10
+  adds x13, x14, x13
+  cinc x14, x16, hs
+  mov x16, #58856
+  adds x13, x13, x15
+  cinc x14, x14, hs
+  movk x16, #14953, lsl 16
+  movk x16, #15155, lsl 32
+  mul x15, x6, x7
+  movk x16, #17181, lsl 48
+  umulh x6, x6, x7
+  dup.2d v10, x16
+  adds x14, x15, x14
+  cinc x16, x6, hs
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  adds x14, x14, x17
+  cinc x16, x16, hs
+  fsub.2d v12, v6, v11
+  adds x12, x20, x12
+  cinc x4, x4, hs
+  fmla.2d v12, v8, v10
+  add.2d v0, v0, v11
+  adds x4, x22, x4
+  cinc x5, x5, hs
+  add.2d v9, v9, v12
+  adds x4, x4, x13
+  cinc x5, x5, hs
+  mov x13, #35392
+  movk x13, #12477, lsl 16
+  adds x5, x15, x5
+  cinc x6, x6, hs
+  movk x13, #56780, lsl 32
+  adds x5, x5, x14
+  cinc x6, x6, hs
+  movk x13, #17142, lsl 48
+  dup.2d v10, x13
+  mul x13, x7, x7
+  mov.16b v11, v5
+  umulh x7, x7, x7
+  fmla.2d v11, v8, v10
+  adds x6, x13, x6
+  cinc x7, x7, hs
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  adds x6, x6, x16
+  cinc x7, x7, hs
+  add.2d v1, v1, v11
+  mov x13, #56431
+  add.2d v0, v0, v12
+  mov x14, #9848
+  movk x13, #30457, lsl 16
+  movk x14, #54501, lsl 16
+  movk x13, #30012, lsl 32
+  movk x14, #31540, lsl 32
+  movk x14, #17170, lsl 48
+  movk x13, #6382, lsl 48
+  dup.2d v10, x14
+  mov x14, #59151
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  movk x14, #41769, lsl 16
+  fsub.2d v12, v6, v11
+  movk x14, #32276, lsl 32
+  fmla.2d v12, v8, v10
+  movk x14, #21677, lsl 48
+  add.2d v2, v2, v11
+  add.2d v1, v1, v12
+  mov x15, #34015
+  mov x16, #9584
+  movk x15, #20342, lsl 16
+  movk x16, #63883, lsl 16
+  movk x16, #18253, lsl 32
+  movk x15, #13935, lsl 32
+  movk x16, #17190, lsl 48
+  movk x15, #11030, lsl 48
+  dup.2d v10, x16
+  mov.16b v11, v5
+  mov x16, #13689
+  fmla.2d v11, v8, v10
+  movk x16, #8159, lsl 16
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  movk x16, #215, lsl 32
+  add.2d v7, v7, v11
+  movk x16, #4913, lsl 48
+  add.2d v2, v2, v12
+  mul x17, x13, x9
+  mov x20, #51712
+  movk x20, #16093, lsl 16
+  umulh x21, x13, x9
+  movk x20, #30633, lsl 32
+  adds x11, x17, x11
+  cinc x17, x21, hs
+  movk x20, #17068, lsl 48
+  dup.2d v10, x20
+  mul x20, x14, x9
+  mov.16b v11, v5
+  umulh x21, x14, x9
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  adds x17, x20, x17
+  cinc x20, x21, hs
+  fmla.2d v12, v8, v10
+  adds x12, x17, x12
+  cinc x17, x20, hs
+  add.2d v3, v3, v11
+  mul x20, x15, x9
+  add.2d v7, v7, v12
+  ucvtf.2d v4, v4
+  umulh x21, x15, x9
+  mov x22, #34724
+  adds x17, x20, x17
+  cinc x20, x21, hs
+  movk x22, #40393, lsl 16
+  movk x22, #23752, lsl 32
+  adds x4, x17, x4
+  cinc x17, x20, hs
+  movk x22, #17184, lsl 48
+  mul x20, x16, x9
+  dup.2d v8, x22
   mov.16b v10, v5
-  movk x8, #43836, lsl 16
-  fmla.2d v10, v7, v9
+  umulh x9, x16, x9
+  fmla.2d v10, v4, v8
+  adds x17, x20, x17
+  cinc x9, x9, hs
   fsub.2d v11, v6, v10
-  movk x8, #36286, lsl 32
-  fmla.2d v11, v7, v9
-  movk x8, #51783, lsl 48
+  fmla.2d v11, v4, v8
+  adds x5, x17, x5
+  cinc x9, x9, hs
   add.2d v0, v0, v10
-  add.2d v8, v8, v11
-  mov x11, #10899
-  mov x13, #20728
-  movk x13, #23588, lsl 16
-  movk x11, #30709, lsl 16
-  movk x13, #7790, lsl 32
-  movk x11, #61551, lsl 32
-  movk x13, #17170, lsl 48
-  dup.2d v9, x13
-  movk x11, #45784, lsl 48
+  adds x6, x6, x9
+  cinc x7, x7, hs
+  add.2d v8, v9, v11
+  mul x9, x13, x10
+  mov x17, #25532
+  movk x17, #31025, lsl 16
+  umulh x13, x13, x10
+  movk x17, #10002, lsl 32
+  adds x9, x9, x12
+  cinc x12, x13, hs
+  movk x17, #17199, lsl 48
+  dup.2d v9, x17
+  mul x13, x14, x10
   mov.16b v10, v5
-  mov x13, #36612
-  fmla.2d v10, v7, v9
+  umulh x14, x14, x10
+  fmla.2d v10, v4, v9
   fsub.2d v11, v6, v10
-  movk x13, #63402, lsl 16
-  fmla.2d v11, v7, v9
-  movk x13, #47623, lsl 32
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  fmla.2d v11, v4, v9
+  adds x4, x12, x4
+  cinc x12, x13, hs
   add.2d v1, v1, v10
   add.2d v0, v0, v11
-  movk x13, #9430, lsl 48
-  mov x14, #16000
-  mul x15, x12, x10
-  movk x14, #53891, lsl 16
-  movk x14, #5509, lsl 32
-  umulh x12, x12, x10
-  movk x14, #17144, lsl 48
+  mul x13, x15, x10
+  mov x14, #18830
+  umulh x15, x15, x10
+  movk x14, #2465, lsl 16
+  adds x12, x13, x12
+  cinc x13, x15, hs
+  movk x14, #36348, lsl 32
+  movk x14, #17194, lsl 48
+  adds x5, x12, x5
+  cinc x12, x13, hs
   dup.2d v9, x14
-  adds x9, x15, x9
-  cinc x12, x12, hs
+  mul x13, x16, x10
   mov.16b v10, v5
-  mul x14, x8, x10
-  fmla.2d v10, v7, v9
+  fmla.2d v10, v4, v9
+  umulh x10, x16, x10
   fsub.2d v11, v6, v10
-  umulh x8, x8, x10
-  fmla.2d v11, v7, v9
-  adds x12, x14, x12
-  cinc x8, x8, hs
+  adds x12, x13, x12
+  cinc x10, x10, hs
+  fmla.2d v11, v4, v9
   add.2d v2, v2, v10
+  adds x6, x12, x6
+  cinc x10, x10, hs
   add.2d v1, v1, v11
+  add x7, x7, x10
+  mov x10, #21566
+  movk x10, #43708, lsl 16
+  mov x12, #61005
+  movk x10, #57685, lsl 32
+  movk x12, #58262, lsl 16
+  movk x10, #17185, lsl 48
+  movk x12, #32851, lsl 32
+  dup.2d v9, x10
+  mov.16b v10, v5
+  movk x12, #11582, lsl 48
+  fmla.2d v10, v4, v9
+  mov x10, #37581
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  movk x10, #43836, lsl 16
+  add.2d v7, v7, v10
+  movk x10, #36286, lsl 32
+  add.2d v2, v2, v11
+  mov x13, #3072
+  movk x10, #51783, lsl 48
+  movk x13, #8058, lsl 16
+  mov x14, #10899
+  movk x13, #46097, lsl 32
+  movk x14, #30709, lsl 16
+  movk x13, #17047, lsl 48
+  dup.2d v9, x13
+  movk x14, #61551, lsl 32
+  mov.16b v10, v5
+  movk x14, #45784, lsl 48
+  fmla.2d v10, v4, v9
+  fsub.2d v11, v6, v10
+  mov x13, #36612
+  fmla.2d v11, v4, v9
+  movk x13, #63402, lsl 16
+  add.2d v3, v3, v10
+  add.2d v4, v7, v11
+  movk x13, #47623, lsl 32
+  mov x15, #65535
+  movk x13, #9430, lsl 48
+  movk x15, #61439, lsl 16
+  movk x15, #62867, lsl 32
+  mul x16, x12, x11
+  movk x15, #1, lsl 48
+  umulh x12, x12, x11
+  umov x17, v8.d[0]
+  adds x9, x16, x9
+  cinc x12, x12, hs
+  umov x16, v8.d[1]
+  mul x17, x17, x15
+  mul x20, x10, x11
+  mul x15, x16, x15
+  umulh x10, x10, x11
+  and x16, x17, x8
+  and x8, x15, x8
+  adds x12, x20, x12
+  cinc x10, x10, hs
+  ins v7.d[0], x16
+  ins v7.d[1], x8
   adds x4, x12, x4
-  cinc x8, x8, hs
-  mov x12, #46800
-  mul x14, x11, x10
-  movk x12, #2568, lsl 16
-  movk x12, #1335, lsl 32
-  umulh x11, x11, x10
-  movk x12, #17188, lsl 48
-  adds x8, x14, x8
-  cinc x11, x11, hs
-  dup.2d v9, x12
+  cinc x8, x10, hs
+  ucvtf.2d v7, v7
+  mov x10, #16
+  mul x12, x14, x11
+  movk x10, #22847, lsl 32
+  umulh x14, x14, x11
+  movk x10, #17151, lsl 48
+  dup.2d v9, x10
+  adds x8, x12, x8
+  cinc x10, x14, hs
   mov.16b v10, v5
   adds x5, x8, x5
-  cinc x8, x11, hs
+  cinc x8, x10, hs
   fmla.2d v10, v7, v9
+  mul x10, x13, x11
   fsub.2d v11, v6, v10
-  mul x11, x13, x10
   fmla.2d v11, v7, v9
-  umulh x10, x13, x10
-  add.2d v4, v4, v10
-  add.2d v2, v2, v11
-  adds x8, x11, x8
-  cinc x10, x10, hs
-  mov x11, #39040
+  umulh x11, x13, x11
+  add.2d v0, v0, v10
+  adds x8, x10, x8
+  cinc x10, x11, hs
+  add.2d v8, v8, v11
+  mov x11, #20728
   adds x6, x8, x6
   cinc x8, x10, hs
-  movk x11, #14704, lsl 16
-  movk x11, #12839, lsl 32
+  movk x11, #23588, lsl 16
   add x7, x7, x8
-  movk x11, #17096, lsl 48
+  movk x11, #7790, lsl 32
+  movk x11, #17170, lsl 48
   mov x8, #65535
   dup.2d v9, x11
-  mov.16b v5, v5
   movk x8, #61439, lsl 16
-  fmla.2d v5, v7, v9
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
   movk x8, #62867, lsl 32
-  fsub.2d v6, v6, v5
-  fmla.2d v6, v7, v9
+  fsub.2d v11, v6, v10
   movk x8, #49889, lsl 48
-  add.2d v3, v3, v5
-  add.2d v4, v4, v6
+  fmla.2d v11, v7, v9
   mul x8, x8, x9
-  mov x10, #140737488355328
-  mov x11, #1
-  dup.2d v5, x10
-  and.16b v5, v3, v5
-  movk x11, #61440, lsl 16
-  cmeq.2d v5, v5, #0
-  movk x11, #62867, lsl 32
-  mov x10, #2
-  movk x10, #57344, lsl 16
-  movk x11, #17377, lsl 48
-  movk x10, #60199, lsl 32
-  mov x12, #28817
-  movk x10, #3, lsl 48
-  dup.2d v6, x10
-  movk x12, #31161, lsl 16
-  bic.16b v6, v6, v5
-  mov x10, #10364
-  movk x12, #59464, lsl 32
-  movk x10, #11794, lsl 16
-  movk x12, #10291, lsl 48
-  movk x10, #3895, lsl 32
-  movk x10, #9, lsl 48
-  mov x13, #22621
-  dup.2d v7, x10
-  movk x13, #33153, lsl 16
-  bic.16b v7, v7, v5
-  mov x10, #26576
-  movk x13, #17846, lsl 32
-  movk x10, #47696, lsl 16
-  movk x13, #47184, lsl 48
-  movk x10, #688, lsl 32
-  movk x10, #3, lsl 48
-  mov x14, #41001
-  dup.2d v9, x10
-  movk x14, #57649, lsl 16
-  bic.16b v9, v9, v5
-  mov x10, #46800
-  movk x14, #20082, lsl 32
-  movk x10, #2568, lsl 16
-  movk x10, #1335, lsl 32
-  movk x14, #12388, lsl 48
-  movk x10, #4, lsl 48
-  mul x15, x11, x8
-  dup.2d v10, x10
-  bic.16b v10, v10, v5
-  umulh x10, x11, x8
-  mov x11, #49763
+  add.2d v1, v1, v10
+  add.2d v0, v0, v11
+  mov x10, #1
+  mov x11, #16000
+  movk x10, #61440, lsl 16
+  movk x11, #53891, lsl 16
+  movk x11, #5509, lsl 32
+  movk x10, #62867, lsl 32
+  movk x11, #17144, lsl 48
+  movk x10, #17377, lsl 48
+  dup.2d v9, x11
+  mov.16b v10, v5
+  mov x11, #28817
+  fmla.2d v10, v7, v9
+  movk x11, #31161, lsl 16
+  fsub.2d v11, v6, v10
+  movk x11, #59464, lsl 32
+  fmla.2d v11, v7, v9
+  add.2d v2, v2, v10
+  movk x11, #10291, lsl 48
+  add.2d v9, v1, v11
+  mov x12, #22621
+  mov x13, #46800
+  movk x13, #2568, lsl 16
+  movk x12, #33153, lsl 16
+  movk x13, #1335, lsl 32
+  movk x12, #17846, lsl 32
+  movk x13, #17188, lsl 48
+  dup.2d v1, x13
+  movk x12, #47184, lsl 48
+  mov.16b v10, v5
+  mov x13, #41001
+  fmla.2d v10, v7, v1
+  fsub.2d v11, v6, v10
+  movk x13, #57649, lsl 16
+  fmla.2d v11, v7, v1
+  movk x13, #20082, lsl 32
+  add.2d v1, v4, v10
+  movk x13, #12388, lsl 48
+  add.2d v4, v2, v11
+  mov x14, #39040
+  mul x15, x10, x8
+  movk x14, #14704, lsl 16
+  umulh x10, x10, x8
+  movk x14, #12839, lsl 32
+  movk x14, #17096, lsl 48
   cmn x15, x9
   cinc x10, x10, hs
-  movk x11, #40165, lsl 16
-  movk x11, #24776, lsl 32
-  mul x9, x12, x8
-  dup.2d v11, x11
-  umulh x11, x12, x8
-  bic.16b v5, v11, v5
-  sub.2d v0, v0, v6
+  dup.2d v2, x14
+  mul x9, x11, x8
+  mov.16b v5, v5
+  fmla.2d v5, v7, v2
+  umulh x11, x11, x8
+  fsub.2d v6, v6, v5
   adds x9, x9, x10
   cinc x10, x11, hs
-  ssra.2d v0, v8, #52
+  fmla.2d v6, v7, v2
+  add.2d v5, v3, v5
   adds x4, x9, x4
   cinc x9, x10, hs
-  sub.2d v6, v1, v7
-  ssra.2d v6, v0, #52
-  mul x10, x13, x8
-  sub.2d v7, v2, v9
-  ssra.2d v7, v6, #52
-  umulh x11, x13, x8
-  sub.2d v4, v4, v10
+  add.2d v6, v1, v6
+  mul x10, x12, x8
+  ssra.2d v0, v8, #52
+  umulh x11, x12, x8
+  ssra.2d v9, v0, #52
+  ssra.2d v4, v9, #52
   adds x9, x10, x9
   cinc x10, x11, hs
-  ssra.2d v4, v7, #52
-  sub.2d v5, v3, v5
+  ssra.2d v6, v4, #52
   adds x5, x9, x5
   cinc x9, x10, hs
-  ssra.2d v5, v4, #52
-  mul x10, x14, x8
-  ushr.2d v1, v6, #12
-  ushr.2d v2, v7, #24
-  umulh x8, x14, x8
-  ushr.2d v3, v4, #36
+  ssra.2d v5, v6, #52
+  ushr.2d v1, v9, #12
+  mul x10, x13, x8
+  ushr.2d v2, v4, #24
+  umulh x8, x13, x8
+  ushr.2d v3, v6, #36
+  sli.2d v0, v9, #52
   adds x9, x10, x9
   cinc x8, x8, hs
-  sli.2d v0, v6, #52
-  sli.2d v1, v7, #40
+  sli.2d v1, v4, #40
   adds x6, x9, x6
   cinc x8, x8, hs
-  sli.2d v2, v4, #28
+  sli.2d v2, v6, #28
   sli.2d v3, v5, #16
   add x7, x7, x8

--- a/block-multiplier/src/aarch64/montgomery_square_log_interleaved_4.s
+++ b/block-multiplier/src/aarch64/montgomery_square_log_interleaved_4.s
@@ -1,0 +1,990 @@
+// GENERATED FILE, DO NOT EDIT!
+// in("x0") a[0], in("x1") a[1], in("x2") a[2], in("x3") a[3],
+// in("x4") a1[0], in("x5") a1[1], in("x6") a1[2], in("x7") a1[3],
+// in("v0") av[0], in("v1") av[1], in("v2") av[2], in("v3") av[3],
+// lateout("x0") out[0], lateout("x1") out[1], lateout("x2") out[2], lateout("x3") out[3],
+// lateout("x4") out1[0], lateout("x5") out1[1], lateout("x6") out1[2], lateout("x7") out1[3],
+// lateout("v0") outv[0], lateout("v1") outv[1], lateout("v2") outv[2], lateout("v3") outv[3],
+// lateout("x8") _, lateout("x9") _, lateout("x10") _, lateout("x11") _, lateout("x12") _, lateout("x13") _, lateout("x14") _, lateout("x15") _, lateout("x16") _, lateout("x17") _, lateout("x20") _, lateout("x21") _, lateout("x22") _, lateout("x23") _, lateout("x24") _, lateout("v4") _, lateout("v5") _, lateout("v6") _, lateout("v7") _, lateout("v8") _, lateout("v9") _, lateout("v10") _, lateout("v11") _, lateout("v12") _, lateout("v13") _, lateout("v14") _, lateout("v15") _, lateout("v16") _, lateout("v17") _, lateout("v18") _, lateout("v19") _,
+// lateout("lr") _
+  mov x8, #4503599627370495
+  mul x9, x0, x0
+  dup.2d v4, x8
+  umulh x10, x0, x0
+  mov x11, #5075556780046548992
+  dup.2d v5, x11
+  mul x11, x0, x1
+  mov x12, #1
+  umulh x13, x0, x1
+  movk x12, #18032, lsl 48
+  dup.2d v6, x12
+  adds x10, x11, x10
+  cinc x12, x13, hs
+  shl.2d v7, v1, #14
+  mul x14, x0, x2
+  shl.2d v8, v2, #26
+  umulh x15, x0, x2
+  shl.2d v9, v3, #38
+  ushr.2d v3, v3, #14
+  adds x12, x14, x12
+  cinc x16, x15, hs
+  shl.2d v10, v0, #2
+  mul x17, x0, x3
+  usra.2d v7, v0, #50
+  usra.2d v8, v1, #38
+  umulh x0, x0, x3
+  usra.2d v9, v2, #26
+  adds x16, x17, x16
+  cinc x20, x0, hs
+  and.16b v0, v10, v4
+  adds x10, x11, x10
+  cinc x11, x13, hs
+  and.16b v1, v7, v4
+  and.16b v2, v8, v4
+  mul x13, x1, x1
+  and.16b v7, v9, v4
+  umulh x21, x1, x1
+  mov x22, #13605374474286268416
+  dup.2d v8, x22
+  adds x11, x13, x11
+  cinc x13, x21, hs
+  mov x21, #6440147467139809280
+  adds x11, x11, x12
+  cinc x12, x13, hs
+  dup.2d v9, x21
+  mul x13, x1, x2
+  mov x21, #3688448094816436224
+  dup.2d v10, x21
+  umulh x21, x1, x2
+  mov x22, #9209861237972664320
+  adds x12, x13, x12
+  cinc x23, x21, hs
+  dup.2d v11, x22
+  mov x22, #12218265789056155648
+  adds x12, x12, x16
+  cinc x16, x23, hs
+  dup.2d v12, x22
+  mul x22, x1, x3
+  mov x23, #17739678932212383744
+  umulh x1, x1, x3
+  dup.2d v13, x23
+  mov x23, #2301339409586323456
+  adds x16, x22, x16
+  cinc x24, x1, hs
+  dup.2d v14, x23
+  adds x16, x16, x20
+  cinc x20, x24, hs
+  mov x23, #7822752552742551552
+  dup.2d v15, x23
+  adds x11, x14, x11
+  cinc x14, x15, hs
+  mov x15, #5071053180419178496
+  adds x13, x13, x14
+  cinc x14, x21, hs
+  dup.2d v16, x15
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  mov x14, #16352570246982270976
+  dup.2d v17, x14
+  mul x14, x2, x2
+  ucvtf.2d v0, v0
+  umulh x15, x2, x2
+  ucvtf.2d v1, v1
+  ucvtf.2d v2, v2
+  adds x13, x14, x13
+  cinc x14, x15, hs
+  ucvtf.2d v7, v7
+  adds x13, x13, x16
+  cinc x14, x14, hs
+  ucvtf.2d v3, v3
+  mul x15, x2, x3
+  mov.16b v18, v5
+  fmla.2d v18, v0, v0
+  umulh x2, x2, x3
+  fsub.2d v19, v6, v18
+  adds x14, x15, x14
+  cinc x16, x2, hs
+  fmla.2d v19, v0, v0
+  add.2d v10, v10, v18
+  adds x14, x14, x20
+  cinc x16, x16, hs
+  add.2d v8, v8, v19
+  adds x12, x17, x12
+  cinc x0, x0, hs
+  mov.16b v18, v5
+  adds x0, x22, x0
+  cinc x1, x1, hs
+  fmla.2d v18, v0, v1
+  fsub.2d v19, v6, v18
+  adds x0, x0, x13
+  cinc x1, x1, hs
+  fmla.2d v19, v0, v1
+  adds x1, x15, x1
+  cinc x2, x2, hs
+  add.2d v18, v18, v18
+  add.2d v19, v19, v19
+  adds x1, x1, x14
+  cinc x2, x2, hs
+  add.2d v12, v12, v18
+  mul x13, x3, x3
+  add.2d v10, v10, v19
+  umulh x3, x3, x3
+  mov.16b v18, v5
+  fmla.2d v18, v0, v2
+  adds x2, x13, x2
+  cinc x3, x3, hs
+  fsub.2d v19, v6, v18
+  adds x2, x2, x16
+  cinc x3, x3, hs
+  fmla.2d v19, v0, v2
+  add.2d v18, v18, v18
+  mov x13, #56431
+  add.2d v19, v19, v19
+  movk x13, #30457, lsl 16
+  add.2d v14, v14, v18
+  movk x13, #30012, lsl 32
+  add.2d v12, v12, v19
+  mov.16b v18, v5
+  movk x13, #6382, lsl 48
+  fmla.2d v18, v0, v7
+  mov x14, #59151
+  fsub.2d v19, v6, v18
+  fmla.2d v19, v0, v7
+  movk x14, #41769, lsl 16
+  add.2d v18, v18, v18
+  movk x14, #32276, lsl 32
+  add.2d v19, v19, v19
+  movk x14, #21677, lsl 48
+  add.2d v16, v16, v18
+  add.2d v14, v14, v19
+  mov x15, #34015
+  mov.16b v18, v5
+  movk x15, #20342, lsl 16
+  fmla.2d v18, v0, v3
+  fsub.2d v19, v6, v18
+  movk x15, #13935, lsl 32
+  fmla.2d v19, v0, v3
+  movk x15, #11030, lsl 48
+  add.2d v0, v18, v18
+  mov x16, #13689
+  add.2d v18, v19, v19
+  add.2d v0, v17, v0
+  movk x16, #8159, lsl 16
+  add.2d v16, v16, v18
+  movk x16, #215, lsl 32
+  mov.16b v17, v5
+  fmla.2d v17, v1, v1
+  movk x16, #4913, lsl 48
+  fsub.2d v18, v6, v17
+  mul x17, x13, x9
+  fmla.2d v18, v1, v1
+  umulh x20, x13, x9
+  add.2d v14, v14, v17
+  add.2d v12, v12, v18
+  adds x11, x17, x11
+  cinc x17, x20, hs
+  mov.16b v17, v5
+  mul x20, x14, x9
+  fmla.2d v17, v1, v2
+  fsub.2d v18, v6, v17
+  umulh x21, x14, x9
+  fmla.2d v18, v1, v2
+  adds x17, x20, x17
+  cinc x20, x21, hs
+  add.2d v17, v17, v17
+  adds x12, x17, x12
+  cinc x17, x20, hs
+  add.2d v18, v18, v18
+  add.2d v16, v16, v17
+  mul x20, x15, x9
+  add.2d v14, v14, v18
+  umulh x21, x15, x9
+  mov.16b v17, v5
+  fmla.2d v17, v1, v7
+  adds x17, x20, x17
+  cinc x20, x21, hs
+  fsub.2d v18, v6, v17
+  adds x0, x17, x0
+  cinc x17, x20, hs
+  fmla.2d v18, v1, v7
+  mul x20, x16, x9
+  add.2d v17, v17, v17
+  add.2d v18, v18, v18
+  umulh x9, x16, x9
+  add.2d v0, v0, v17
+  adds x17, x20, x17
+  cinc x9, x9, hs
+  add.2d v16, v16, v18
+  mov.16b v17, v5
+  adds x1, x17, x1
+  cinc x9, x9, hs
+  fmla.2d v17, v1, v3
+  adds x2, x2, x9
+  cinc x3, x3, hs
+  fsub.2d v18, v6, v17
+  mul x9, x13, x10
+  fmla.2d v18, v1, v3
+  add.2d v1, v17, v17
+  umulh x13, x13, x10
+  add.2d v17, v18, v18
+  adds x9, x9, x12
+  cinc x12, x13, hs
+  add.2d v1, v15, v1
+  add.2d v0, v0, v17
+  mul x13, x14, x10
+  mov.16b v15, v5
+  umulh x14, x14, x10
+  fmla.2d v15, v2, v2
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  fsub.2d v17, v6, v15
+  fmla.2d v17, v2, v2
+  adds x0, x12, x0
+  cinc x12, x13, hs
+  add.2d v0, v0, v15
+  mul x13, x15, x10
+  add.2d v15, v16, v17
+  mov.16b v16, v5
+  umulh x14, x15, x10
+  fmla.2d v16, v2, v7
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  fsub.2d v17, v6, v16
+  adds x1, x12, x1
+  cinc x12, x13, hs
+  fmla.2d v17, v2, v7
+  add.2d v16, v16, v16
+  mul x13, x16, x10
+  add.2d v17, v17, v17
+  umulh x10, x16, x10
+  add.2d v1, v1, v16
+  add.2d v0, v0, v17
+  adds x12, x13, x12
+  cinc x10, x10, hs
+  mov.16b v16, v5
+  adds x2, x12, x2
+  cinc x10, x10, hs
+  fmla.2d v16, v2, v3
+  fsub.2d v17, v6, v16
+  add x3, x3, x10
+  fmla.2d v17, v2, v3
+  mov x10, #61005
+  add.2d v2, v16, v16
+  movk x10, #58262, lsl 16
+  add.2d v16, v17, v17
+  add.2d v2, v13, v2
+  movk x10, #32851, lsl 32
+  add.2d v1, v1, v16
+  movk x10, #11582, lsl 48
+  mov.16b v13, v5
+  fmla.2d v13, v7, v7
+  mov x12, #37581
+  fsub.2d v16, v6, v13
+  movk x12, #43836, lsl 16
+  fmla.2d v16, v7, v7
+  movk x12, #36286, lsl 32
+  add.2d v2, v2, v13
+  add.2d v1, v1, v16
+  movk x12, #51783, lsl 48
+  mov.16b v13, v5
+  mov x13, #10899
+  fmla.2d v13, v7, v3
+  fsub.2d v16, v6, v13
+  movk x13, #30709, lsl 16
+  fmla.2d v16, v7, v3
+  movk x13, #61551, lsl 32
+  add.2d v7, v13, v13
+  movk x13, #45784, lsl 48
+  add.2d v13, v16, v16
+  add.2d v7, v11, v7
+  mov x14, #36612
+  add.2d v2, v2, v13
+  movk x14, #63402, lsl 16
+  mov.16b v11, v5
+  fmla.2d v11, v3, v3
+  movk x14, #47623, lsl 32
+  fsub.2d v13, v6, v11
+  movk x14, #9430, lsl 48
+  fmla.2d v13, v3, v3
+  mul x15, x10, x11
+  add.2d v3, v9, v11
+  add.2d v7, v7, v13
+  umulh x10, x10, x11
+  usra.2d v10, v8, #52
+  adds x9, x15, x9
+  cinc x10, x10, hs
+  usra.2d v12, v10, #52
+  usra.2d v14, v12, #52
+  mul x15, x12, x11
+  usra.2d v15, v14, #52
+  umulh x12, x12, x11
+  and.16b v8, v8, v4
+  adds x10, x15, x10
+  cinc x12, x12, hs
+  and.16b v9, v10, v4
+  and.16b v10, v12, v4
+  adds x0, x10, x0
+  cinc x10, x12, hs
+  and.16b v4, v14, v4
+  mul x12, x13, x11
+  ucvtf.2d v8, v8
+  mov x15, #37864
+  umulh x13, x13, x11
+  movk x15, #1815, lsl 16
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  movk x15, #28960, lsl 32
+  adds x1, x10, x1
+  cinc x10, x12, hs
+  movk x15, #17153, lsl 48
+  dup.2d v11, x15
+  mul x12, x14, x11
+  mov.16b v12, v5
+  umulh x11, x14, x11
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  adds x10, x12, x10
+  cinc x11, x11, hs
+  fmla.2d v13, v8, v11
+  adds x2, x10, x2
+  cinc x10, x11, hs
+  add.2d v0, v0, v12
+  add x3, x3, x10
+  add.2d v11, v15, v13
+  mov x10, #46128
+  mov x11, #65535
+  movk x10, #29964, lsl 16
+  movk x11, #61439, lsl 16
+  movk x10, #7587, lsl 32
+  movk x10, #17161, lsl 48
+  movk x11, #62867, lsl 32
+  dup.2d v12, x10
+  movk x11, #49889, lsl 48
+  mov.16b v13, v5
+  mul x10, x11, x9
+  fmla.2d v13, v8, v12
+  fsub.2d v14, v6, v13
+  mov x11, #1
+  fmla.2d v14, v8, v12
+  movk x11, #61440, lsl 16
+  add.2d v1, v1, v13
+  add.2d v0, v0, v14
+  movk x11, #62867, lsl 32
+  mov x12, #52826
+  movk x11, #17377, lsl 48
+  movk x12, #57790, lsl 16
+  mov x13, #28817
+  movk x12, #55431, lsl 32
+  movk x12, #17196, lsl 48
+  movk x13, #31161, lsl 16
+  dup.2d v12, x12
+  movk x13, #59464, lsl 32
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  movk x13, #10291, lsl 48
+  fsub.2d v14, v6, v13
+  mov x12, #22621
+  fmla.2d v14, v8, v12
+  movk x12, #33153, lsl 16
+  add.2d v2, v2, v13
+  add.2d v1, v1, v14
+  movk x12, #17846, lsl 32
+  mov x14, #31276
+  movk x12, #47184, lsl 48
+  movk x14, #21262, lsl 16
+  movk x14, #2304, lsl 32
+  mov x15, #41001
+  movk x14, #17182, lsl 48
+  movk x15, #57649, lsl 16
+  dup.2d v12, x14
+  movk x15, #20082, lsl 32
+  mov.16b v13, v5
+  fmla.2d v13, v8, v12
+  movk x15, #12388, lsl 48
+  fsub.2d v14, v6, v13
+  mul x14, x11, x10
+  fmla.2d v14, v8, v12
+  add.2d v7, v7, v13
+  umulh x11, x11, x10
+  add.2d v2, v2, v14
+  cmn x14, x9
+  cinc x11, x11, hs
+  mov x9, #28672
+  mul x14, x13, x10
+  movk x9, #24515, lsl 16
+  movk x9, #54929, lsl 32
+  umulh x13, x13, x10
+  movk x9, #17064, lsl 48
+  adds x11, x14, x11
+  cinc x13, x13, hs
+  dup.2d v12, x9
+  mov.16b v13, v5
+  adds x0, x11, x0
+  cinc x9, x13, hs
+  fmla.2d v13, v8, v12
+  mul x11, x12, x10
+  fsub.2d v14, v6, v13
+  umulh x12, x12, x10
+  fmla.2d v14, v8, v12
+  add.2d v3, v3, v13
+  adds x9, x11, x9
+  cinc x11, x12, hs
+  add.2d v7, v7, v14
+  adds x1, x9, x1
+  cinc x9, x11, hs
+  ucvtf.2d v8, v9
+  mov x11, #44768
+  mul x12, x15, x10
+  movk x11, #51919, lsl 16
+  umulh x10, x15, x10
+  movk x11, #6346, lsl 32
+  adds x9, x12, x9
+  cinc x10, x10, hs
+  movk x11, #17133, lsl 48
+  dup.2d v9, x11
+  adds x2, x9, x2
+  cinc x9, x10, hs
+  mov.16b v12, v5
+  add x3, x3, x9
+  fmla.2d v12, v8, v9
+  fsub.2d v13, v6, v12
+  mov x9, #2
+  fmla.2d v13, v8, v9
+  movk x9, #57344, lsl 16
+  add.2d v0, v0, v12
+  movk x9, #60199, lsl 32
+  add.2d v9, v11, v13
+  mov x10, #47492
+  movk x9, #34755, lsl 48
+  movk x10, #23630, lsl 16
+  mov x11, #57634
+  movk x10, #49985, lsl 32
+  movk x10, #17168, lsl 48
+  movk x11, #62322, lsl 16
+  dup.2d v11, x10
+  movk x11, #53392, lsl 32
+  mov.16b v12, v5
+  movk x11, #20583, lsl 48
+  fmla.2d v12, v8, v11
+  fsub.2d v13, v6, v12
+  mov x10, #45242
+  fmla.2d v13, v8, v11
+  movk x10, #770, lsl 16
+  add.2d v1, v1, v12
+  add.2d v0, v0, v13
+  movk x10, #35693, lsl 32
+  mov x12, #57936
+  movk x10, #28832, lsl 48
+  movk x12, #54828, lsl 16
+  mov x13, #16467
+  movk x12, #18292, lsl 32
+  movk x12, #17197, lsl 48
+  movk x13, #49763, lsl 16
+  dup.2d v11, x12
+  movk x13, #40165, lsl 32
+  mov.16b v12, v5
+  fmla.2d v12, v8, v11
+  movk x13, #24776, lsl 48
+  fsub.2d v13, v6, v12
+  subs x9, x0, x9
+  sbcs x11, x1, x11
+  sbcs x10, x2, x10
+  sbcs x12, x3, x13
+  fmla.2d v13, v8, v11
+  add.2d v2, v2, v12
+  tst x3, #9223372036854775808
+  csel x0, x9, x0, mi
+  csel x1, x11, x1, mi
+  csel x2, x10, x2, mi
+  csel x3, x12, x3, mi
+  add.2d v1, v1, v13
+  mul x9, x4, x4
+  mov x10, #17708
+  umulh x11, x4, x4
+  movk x10, #43915, lsl 16
+  movk x10, #64348, lsl 32
+  mul x12, x4, x5
+  movk x10, #17188, lsl 48
+  umulh x13, x4, x5
+  dup.2d v11, x10
+  mov.16b v12, v5
+  adds x10, x12, x11
+  cinc x11, x13, hs
+  fmla.2d v12, v8, v11
+  mul x14, x4, x6
+  fsub.2d v13, v6, v12
+  umulh x15, x4, x6
+  fmla.2d v13, v8, v11
+  add.2d v7, v7, v12
+  adds x11, x14, x11
+  cinc x16, x15, hs
+  add.2d v2, v2, v13
+  mul x17, x4, x7
+  mov x20, #29184
+  movk x20, #20789, lsl 16
+  umulh x4, x4, x7
+  movk x20, #19197, lsl 32
+  adds x16, x17, x16
+  cinc x21, x4, hs
+  movk x20, #17083, lsl 48
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  dup.2d v11, x20
+  mov.16b v12, v5
+  mul x13, x5, x5
+  fmla.2d v12, v8, v11
+  umulh x20, x5, x5
+  fsub.2d v13, v6, v12
+  fmla.2d v13, v8, v11
+  adds x12, x13, x12
+  cinc x13, x20, hs
+  add.2d v3, v3, v12
+  adds x11, x12, x11
+  cinc x12, x13, hs
+  add.2d v7, v7, v13
+  mul x13, x5, x6
+  ucvtf.2d v8, v10
+  mov x20, #58856
+  umulh x22, x5, x6
+  movk x20, #14953, lsl 16
+  adds x12, x13, x12
+  cinc x23, x22, hs
+  movk x20, #15155, lsl 32
+  movk x20, #17181, lsl 48
+  adds x12, x12, x16
+  cinc x16, x23, hs
+  dup.2d v10, x20
+  mul x20, x5, x7
+  mov.16b v11, v5
+  umulh x5, x5, x7
+  fmla.2d v11, v8, v10
+  fsub.2d v12, v6, v11
+  adds x16, x20, x16
+  cinc x23, x5, hs
+  fmla.2d v12, v8, v10
+  adds x16, x16, x21
+  cinc x21, x23, hs
+  add.2d v0, v0, v11
+  add.2d v9, v9, v12
+  adds x11, x14, x11
+  cinc x14, x15, hs
+  mov x15, #35392
+  adds x13, x13, x14
+  cinc x14, x22, hs
+  movk x15, #12477, lsl 16
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  movk x15, #56780, lsl 32
+  movk x15, #17142, lsl 48
+  mul x14, x6, x6
+  dup.2d v10, x15
+  umulh x15, x6, x6
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  adds x13, x14, x13
+  cinc x14, x15, hs
+  fsub.2d v12, v6, v11
+  adds x13, x13, x16
+  cinc x14, x14, hs
+  fmla.2d v12, v8, v10
+  mul x15, x6, x7
+  add.2d v1, v1, v11
+  add.2d v0, v0, v12
+  umulh x6, x6, x7
+  mov x16, #9848
+  adds x14, x15, x14
+  cinc x22, x6, hs
+  movk x16, #54501, lsl 16
+  movk x16, #31540, lsl 32
+  adds x14, x14, x21
+  cinc x21, x22, hs
+  movk x16, #17170, lsl 48
+  adds x12, x17, x12
+  cinc x4, x4, hs
+  dup.2d v10, x16
+  adds x4, x20, x4
+  cinc x5, x5, hs
+  mov.16b v11, v5
+  fmla.2d v11, v8, v10
+  adds x4, x4, x13
+  cinc x5, x5, hs
+  fsub.2d v12, v6, v11
+  adds x5, x15, x5
+  cinc x6, x6, hs
+  fmla.2d v12, v8, v10
+  add.2d v2, v2, v11
+  adds x5, x5, x14
+  cinc x6, x6, hs
+  add.2d v1, v1, v12
+  mul x13, x7, x7
+  mov x14, #9584
+  umulh x7, x7, x7
+  movk x14, #63883, lsl 16
+  movk x14, #18253, lsl 32
+  adds x6, x13, x6
+  cinc x7, x7, hs
+  movk x14, #17190, lsl 48
+  adds x6, x6, x21
+  cinc x7, x7, hs
+  dup.2d v10, x14
+  mov.16b v11, v5
+  mov x13, #56431
+  fmla.2d v11, v8, v10
+  movk x13, #30457, lsl 16
+  fsub.2d v12, v6, v11
+  movk x13, #30012, lsl 32
+  fmla.2d v12, v8, v10
+  add.2d v7, v7, v11
+  movk x13, #6382, lsl 48
+  add.2d v2, v2, v12
+  mov x14, #59151
+  mov x15, #51712
+  movk x15, #16093, lsl 16
+  movk x14, #41769, lsl 16
+  movk x15, #30633, lsl 32
+  movk x14, #32276, lsl 32
+  movk x15, #17068, lsl 48
+  movk x14, #21677, lsl 48
+  dup.2d v10, x15
+  mov.16b v11, v5
+  mov x15, #34015
+  fmla.2d v11, v8, v10
+  movk x15, #20342, lsl 16
+  fsub.2d v12, v6, v11
+  fmla.2d v12, v8, v10
+  movk x15, #13935, lsl 32
+  add.2d v3, v3, v11
+  movk x15, #11030, lsl 48
+  add.2d v7, v7, v12
+  mov x16, #13689
+  ucvtf.2d v4, v4
+  mov x17, #34724
+  movk x16, #8159, lsl 16
+  movk x17, #40393, lsl 16
+  movk x16, #215, lsl 32
+  movk x17, #23752, lsl 32
+  movk x17, #17184, lsl 48
+  movk x16, #4913, lsl 48
+  dup.2d v8, x17
+  mul x17, x13, x9
+  mov.16b v10, v5
+  umulh x20, x13, x9
+  fmla.2d v10, v4, v8
+  fsub.2d v11, v6, v10
+  adds x11, x17, x11
+  cinc x17, x20, hs
+  fmla.2d v11, v4, v8
+  mul x20, x14, x9
+  add.2d v0, v0, v10
+  add.2d v8, v9, v11
+  umulh x21, x14, x9
+  mov x22, #25532
+  adds x17, x20, x17
+  cinc x20, x21, hs
+  movk x22, #31025, lsl 16
+  adds x12, x17, x12
+  cinc x17, x20, hs
+  movk x22, #10002, lsl 32
+  movk x22, #17199, lsl 48
+  mul x20, x15, x9
+  dup.2d v9, x22
+  umulh x21, x15, x9
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  adds x17, x20, x17
+  cinc x20, x21, hs
+  fsub.2d v11, v6, v10
+  adds x4, x17, x4
+  cinc x17, x20, hs
+  fmla.2d v11, v4, v9
+  mul x20, x16, x9
+  add.2d v1, v1, v10
+  add.2d v0, v0, v11
+  umulh x9, x16, x9
+  mov x21, #18830
+  adds x17, x20, x17
+  cinc x9, x9, hs
+  movk x21, #2465, lsl 16
+  movk x21, #36348, lsl 32
+  adds x5, x17, x5
+  cinc x9, x9, hs
+  movk x21, #17194, lsl 48
+  adds x6, x6, x9
+  cinc x7, x7, hs
+  dup.2d v9, x21
+  mul x9, x13, x10
+  mov.16b v10, v5
+  fmla.2d v10, v4, v9
+  umulh x13, x13, x10
+  fsub.2d v11, v6, v10
+  adds x9, x9, x12
+  cinc x12, x13, hs
+  fmla.2d v11, v4, v9
+  add.2d v2, v2, v10
+  mul x13, x14, x10
+  add.2d v1, v1, v11
+  umulh x14, x14, x10
+  mov x17, #21566
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  movk x17, #43708, lsl 16
+  movk x17, #57685, lsl 32
+  adds x4, x12, x4
+  cinc x12, x13, hs
+  movk x17, #17185, lsl 48
+  mul x13, x15, x10
+  dup.2d v9, x17
+  mov.16b v10, v5
+  umulh x14, x15, x10
+  fmla.2d v10, v4, v9
+  adds x12, x13, x12
+  cinc x13, x14, hs
+  fsub.2d v11, v6, v10
+  adds x5, x12, x5
+  cinc x12, x13, hs
+  fmla.2d v11, v4, v9
+  add.2d v7, v7, v10
+  mul x13, x16, x10
+  add.2d v2, v2, v11
+  umulh x10, x16, x10
+  mov x14, #3072
+  movk x14, #8058, lsl 16
+  adds x12, x13, x12
+  cinc x10, x10, hs
+  movk x14, #46097, lsl 32
+  adds x6, x12, x6
+  cinc x10, x10, hs
+  movk x14, #17047, lsl 48
+  dup.2d v9, x14
+  add x7, x7, x10
+  mov.16b v10, v5
+  mov x10, #61005
+  fmla.2d v10, v4, v9
+  movk x10, #58262, lsl 16
+  fsub.2d v11, v6, v10
+  fmla.2d v11, v4, v9
+  movk x10, #32851, lsl 32
+  add.2d v3, v3, v10
+  movk x10, #11582, lsl 48
+  add.2d v4, v7, v11
+  mov x12, #65535
+  mov x13, #37581
+  movk x12, #61439, lsl 16
+  movk x13, #43836, lsl 16
+  movk x12, #62867, lsl 32
+  movk x13, #36286, lsl 32
+  movk x12, #1, lsl 48
+  umov x14, v8.d[0]
+  movk x13, #51783, lsl 48
+  umov x15, v8.d[1]
+  mov x16, #10899
+  mul x14, x14, x12
+  mul x12, x15, x12
+  movk x16, #30709, lsl 16
+  and x14, x14, x8
+  movk x16, #61551, lsl 32
+  and x8, x12, x8
+  movk x16, #45784, lsl 48
+  ins v7.d[0], x14
+  ins v7.d[1], x8
+  ucvtf.2d v7, v7
+  mov x8, #36612
+  mov x12, #16
+  movk x8, #63402, lsl 16
+  movk x12, #22847, lsl 32
+  movk x12, #17151, lsl 48
+  movk x8, #47623, lsl 32
+  dup.2d v9, x12
+  movk x8, #9430, lsl 48
+  mov.16b v10, v5
+  mul x12, x10, x11
+  fmla.2d v10, v7, v9
+  fsub.2d v11, v6, v10
+  umulh x10, x10, x11
+  fmla.2d v11, v7, v9
+  adds x9, x12, x9
+  cinc x10, x10, hs
+  add.2d v0, v0, v10
+  add.2d v8, v8, v11
+  mul x12, x13, x11
+  mov x14, #20728
+  umulh x13, x13, x11
+  movk x14, #23588, lsl 16
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  movk x14, #7790, lsl 32
+  movk x14, #17170, lsl 48
+  adds x4, x10, x4
+  cinc x10, x12, hs
+  dup.2d v9, x14
+  mul x12, x16, x11
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  umulh x13, x16, x11
+  fsub.2d v11, v6, v10
+  adds x10, x12, x10
+  cinc x12, x13, hs
+  fmla.2d v11, v7, v9
+  adds x5, x10, x5
+  cinc x10, x12, hs
+  add.2d v1, v1, v10
+  add.2d v0, v0, v11
+  mul x12, x8, x11
+  mov x13, #16000
+  umulh x8, x8, x11
+  movk x13, #53891, lsl 16
+  movk x13, #5509, lsl 32
+  adds x10, x12, x10
+  cinc x8, x8, hs
+  movk x13, #17144, lsl 48
+  adds x6, x10, x6
+  cinc x8, x8, hs
+  dup.2d v9, x13
+  add x7, x7, x8
+  mov.16b v10, v5
+  fmla.2d v10, v7, v9
+  mov x8, #65535
+  fsub.2d v11, v6, v10
+  movk x8, #61439, lsl 16
+  fmla.2d v11, v7, v9
+  add.2d v2, v2, v10
+  movk x8, #62867, lsl 32
+  add.2d v1, v1, v11
+  movk x8, #49889, lsl 48
+  mov x10, #46800
+  mul x8, x8, x9
+  movk x10, #2568, lsl 16
+  movk x10, #1335, lsl 32
+  mov x11, #1
+  movk x10, #17188, lsl 48
+  movk x11, #61440, lsl 16
+  dup.2d v9, x10
+  mov.16b v10, v5
+  movk x11, #62867, lsl 32
+  fmla.2d v10, v7, v9
+  movk x11, #17377, lsl 48
+  fsub.2d v11, v6, v10
+  mov x10, #28817
+  fmla.2d v11, v7, v9
+  add.2d v4, v4, v10
+  movk x10, #31161, lsl 16
+  add.2d v2, v2, v11
+  movk x10, #59464, lsl 32
+  mov x12, #39040
+  movk x12, #14704, lsl 16
+  movk x10, #10291, lsl 48
+  movk x12, #12839, lsl 32
+  mov x13, #22621
+  movk x12, #17096, lsl 48
+  movk x13, #33153, lsl 16
+  dup.2d v9, x12
+  mov.16b v5, v5
+  movk x13, #17846, lsl 32
+  fmla.2d v5, v7, v9
+  movk x13, #47184, lsl 48
+  fsub.2d v6, v6, v5
+  fmla.2d v6, v7, v9
+  mov x12, #41001
+  add.2d v3, v3, v5
+  movk x12, #57649, lsl 16
+  add.2d v4, v4, v6
+  movk x12, #20082, lsl 32
+  mov x14, #140737488355328
+  dup.2d v5, x14
+  movk x12, #12388, lsl 48
+  and.16b v5, v3, v5
+  mul x14, x11, x8
+  cmeq.2d v5, v5, #0
+  mov x15, #2
+  umulh x11, x11, x8
+  movk x15, #57344, lsl 16
+  cmn x14, x9
+  cinc x11, x11, hs
+  movk x15, #60199, lsl 32
+  mul x9, x10, x8
+  movk x15, #3, lsl 48
+  dup.2d v6, x15
+  umulh x10, x10, x8
+  bic.16b v6, v6, v5
+  adds x9, x9, x11
+  cinc x10, x10, hs
+  mov x11, #10364
+  movk x11, #11794, lsl 16
+  adds x4, x9, x4
+  cinc x9, x10, hs
+  movk x11, #3895, lsl 32
+  mul x10, x13, x8
+  movk x11, #9, lsl 48
+  umulh x13, x13, x8
+  dup.2d v7, x11
+  bic.16b v7, v7, v5
+  adds x9, x10, x9
+  cinc x10, x13, hs
+  mov x11, #26576
+  adds x5, x9, x5
+  cinc x9, x10, hs
+  movk x11, #47696, lsl 16
+  movk x11, #688, lsl 32
+  mul x10, x12, x8
+  movk x11, #3, lsl 48
+  umulh x8, x12, x8
+  dup.2d v9, x11
+  adds x9, x10, x9
+  cinc x8, x8, hs
+  bic.16b v9, v9, v5
+  mov x10, #46800
+  adds x6, x9, x6
+  cinc x8, x8, hs
+  movk x10, #2568, lsl 16
+  add x7, x7, x8
+  movk x10, #1335, lsl 32
+  movk x10, #4, lsl 48
+  mov x8, #2
+  dup.2d v10, x10
+  movk x8, #57344, lsl 16
+  bic.16b v10, v10, v5
+  movk x8, #60199, lsl 32
+  mov x9, #49763
+  movk x9, #40165, lsl 16
+  movk x8, #34755, lsl 48
+  movk x9, #24776, lsl 32
+  mov x10, #57634
+  dup.2d v11, x9
+  bic.16b v5, v11, v5
+  movk x10, #62322, lsl 16
+  sub.2d v0, v0, v6
+  movk x10, #53392, lsl 32
+  ssra.2d v0, v8, #52
+  movk x10, #20583, lsl 48
+  sub.2d v6, v1, v7
+  ssra.2d v6, v0, #52
+  mov x9, #45242
+  sub.2d v7, v2, v9
+  movk x9, #770, lsl 16
+  ssra.2d v7, v6, #52
+  sub.2d v4, v4, v10
+  movk x9, #35693, lsl 32
+  ssra.2d v4, v7, #52
+  movk x9, #28832, lsl 48
+  sub.2d v5, v3, v5
+  mov x11, #16467
+  ssra.2d v5, v4, #52
+  ushr.2d v1, v6, #12
+  movk x11, #49763, lsl 16
+  ushr.2d v2, v7, #24
+  movk x11, #40165, lsl 32
+  ushr.2d v3, v4, #36
+  sli.2d v0, v6, #52
+  movk x11, #24776, lsl 48
+  sli.2d v1, v7, #40
+  subs x8, x4, x8
+  sbcs x10, x5, x10
+  sbcs x9, x6, x9
+  sbcs x11, x7, x11
+  sli.2d v2, v4, #28
+  sli.2d v3, v5, #16
+  tst x7, #9223372036854775808
+  csel x4, x8, x4, mi
+  csel x5, x10, x5, mi
+  csel x6, x9, x6, mi
+  csel x7, x11, x7, mi

--- a/block-multiplier/src/lib.rs
+++ b/block-multiplier/src/lib.rs
@@ -12,7 +12,8 @@ mod utils;
 pub use crate::{
     aarch64::{
         montgomery_interleaved_3, montgomery_interleaved_4, montgomery_square_interleaved_3,
-        montgomery_square_interleaved_4,
+        montgomery_square_interleaved_4, montgomery_square_log_interleaved_3,
+        montgomery_square_log_interleaved_4,
     },
     block_simd::{block_mul, block_sqr},
     portable_simd::{simd_mul, simd_sqr},

--- a/skyscraper/src/block3.rs
+++ b/skyscraper/src/block3.rs
@@ -21,7 +21,7 @@ fn compress(guard: &RoundingGuard<Zero>, input: [[[u64; 4]; 2]; 3]) -> [[u64; 4]
 fn square(guard: &RoundingGuard<Zero>, n: [[u64; 4]; 3]) -> [[u64; 4]; 3] {
     let [a, b, c] = n;
     let v = array::from_fn(|i| std::simd::u64x2::from_array([b[i], c[i]]));
-    let (a, v) = block_multiplier::montgomery_square_interleaved_3(guard, a, v);
+    let (a, v) = block_multiplier::montgomery_square_log_interleaved_3(guard, a, v);
     let b = v.map(|e| e[0]);
     let c = v.map(|e| e[1]);
     [a, b, c]

--- a/skyscraper/src/block4.rs
+++ b/skyscraper/src/block4.rs
@@ -21,7 +21,7 @@ fn compress(guard: &RoundingGuard<Zero>, input: [[[u64; 4]; 2]; 4]) -> [[u64; 4]
 fn square(guard: &RoundingGuard<Zero>, n: [[u64; 4]; 4]) -> [[u64; 4]; 4] {
     let [a, b, c, d] = n;
     let v = array::from_fn(|i| std::simd::u64x2::from_array([c[i], d[i]]));
-    let (a, b, v) = block_multiplier::montgomery_square_interleaved_4(guard, a, b, v);
+    let (a, b, v) = block_multiplier::montgomery_square_log_interleaved_4(guard, a, b, v);
     let c = v.map(|e| e[0]);
     let d = v.map(|e| e[1]);
     [a, b, c, d]


### PR DESCRIPTION
This PR removes the reduction step from the scalar and SIMD codegenerators. This gives the caller freedom to choose what kind of reduction strategy to employ. 

Additionally, this adds code generators for a 2-round (log jump) Montgomery multiplier and squarer. Without the reducer, the output of the single-step squarer is too high to be used in the square operation of Skyscraper. 