### PR TITLE
Bump CodSpeed to v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 base64 = "0.22.1"
-divan = { package = "codspeed-divan-compat", version = "2.10.1" }
+divan = { package = "codspeed-divan-compat", version = "3.0.1" }
 ruint = { version = "1.12.3", features = ["num-traits", "rand"] }
 seq-macro = "0.3.6"
 primitive-types = "0.13.1"


### PR DESCRIPTION

As explained in the [`codspeed-rust` v3 release notes](https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/v3.0.0), there was an issue with the `divan` walltime metrics for some benchmarks.

A performance increase of the following benchmarks is expected, as now the correct metric will be used.

```
      "block-multiplier/benches/bench.rs::mul::ark_ff",
      "block-multiplier/benches/bench.rs::mul::block_mul",
      "block-multiplier/benches/bench.rs::mul::montgomery_interleaved_3",
      "block-multiplier/benches/bench.rs::mul::montgomery_interleaved_4",
      "block-multiplier/benches/bench.rs::mul::scalar_mul",
      "block-multiplier/benches/bench.rs::mul::simd_mul",
      "block-multiplier/benches/bench.rs::sqr::ark_ff",
      "block-multiplier/benches/bench.rs::sqr::block_sqr",
      "block-multiplier/benches/bench.rs::sqr::montgomery_square_interleaved_3",
      "block-multiplier/benches/bench.rs::sqr::montgomery_square_interleaved_4",
      "block-multiplier/benches/bench.rs::sqr::montgomery_square_log_interleaved_3",
      "block-multiplier/benches/bench.rs::sqr::montgomery_square_log_interleaved_4",
      "block-multiplier/benches/bench.rs::sqr::scalar_sqr",
      "block-multiplier/benches/bench.rs::sqr::simd_sqr",
      "fp-rounding/benches/main.rs::wrm_overhead",
      "skyscraper/benches/bench.rs::parts::bar",
      "skyscraper/benches/bench.rs::parts::sbox",
      "skyscraper/benches/bench.rs::parts::sbox_16",
      "skyscraper/benches/bench.rs::parts::sbox_8",
      "skyscraper/benches/bench.rs::parts::square",
      "skyscraper/benches/bench.rs::reduce::reduce",
      "skyscraper/benches/bench.rs::reduce::reduce_1",
      "skyscraper/benches/bench.rs::reduce::reduce_1_partial",
      "skyscraper/benches/bench.rs::reduce::reduce_add_rc",
      "skyscraper/benches/bench.rs::reduce::reduce_partial",
```

Once this is merged, we will update the historic data of the affected benchmark on the CodSpeed UI, so that no false positives will appear.
