### PR TITLE
Reduce allocations in `solve_witness_vec`

### DIFF
--- a/provekit/common/Cargo.toml
+++ b/provekit/common/Cargo.toml
@@ -41,6 +41,7 @@ tracing.workspace = true
 zerocopy.workspace = true
 zeroize.workspace = true
 zstd.workspace = true
+itertools = "0.14.0"
 
 [lints]
 workspace = true

--- a/provekit/common/src/witness/digits.rs
+++ b/provekit/common/src/witness/digits.rs
@@ -1,7 +1,6 @@
 use {
     crate::FieldElement,
     ark_ff::{BigInt, BitIteratorLE, PrimeField},
-    ark_std::Zero,
     itertools::Itertools,
     serde::{Deserialize, Serialize},
 };
@@ -29,7 +28,7 @@ pub struct DigitalDecompositionWitnesses {
 /// Compute a mixed-base decomposition of a field element into its digits, using
 /// the given log bases. Decomposition is little-endian.
 /// Panics if the value provided can not be represented in the given bases.
-// TODO(xrvdg): stronger constraints on log_bases will allow us to remove the
+// TODO: with stronger constraints on log_bases will allow us to remove the
 // remaining allocation
 pub fn decompose_into_digits(value: FieldElement, log_bases: &[usize]) -> Vec<FieldElement> {
     let num_digits = log_bases.len();

--- a/provekit/common/src/witness/digits.rs
+++ b/provekit/common/src/witness/digits.rs
@@ -4,6 +4,7 @@ use {
     ark_std::Zero,
     itertools::Itertools,
     serde::{Deserialize, Serialize},
+    std::iter::Take,
 };
 
 /// Allocates witnesses for the digital decomposition of the given witnesses
@@ -50,27 +51,34 @@ pub fn decompose_into_digits(value: FieldElement, log_bases: &[usize]) -> Vec<Fi
 }
 
 /// Decomposes a field element into its bits, in little-endian order.
-/// Probably a lot of allocation because it goes to bits, but for little-endian
-/// and big endian is on byte level not on bit level
-pub fn field_to_le_bits(value: FieldElement) -> BitIteratorLE<BigInt<4>> {
+fn field_to_le_bits(value: FieldElement) -> BitIteratorLE<BigInt<4>> {
     BitIteratorLE::new(value.into_bigint())
 }
 
 /// Given the binary representation of a field element in little-endian order,
 /// convert it to a field element. The input is padded to the next multiple of 8
 /// bits.
-pub fn le_bits_to_field(bits: impl Iterator<Item = bool>) -> FieldElement {
-    let le_byte_vec: Vec<u8> = bits
-        .chunks(8)
+///
+/// # Note
+/// Only the first 32 bytes (256 bits) of the input will be used. Any additional
+/// bits will be ignored.
+fn le_bits_to_field<I>(bits: I) -> FieldElement
+where
+    I: Iterator<Item = bool>,
+{
+    const LEN: usize = size_of::<<FieldElement as PrimeField>::BigInt>();
+    let mut le_bytes = [0; LEN];
+    bits.chunks(8)
         .into_iter()
-        .map(|chunk_in_bits| {
-            chunk_in_bits
+        .take(LEN)
+        .zip(le_bytes.iter_mut())
+        .for_each(|(chunk_in_bits, le_byte)| {
+            *le_byte = chunk_in_bits
                 .into_iter()
                 .enumerate()
                 .fold(0u8, |acc, (i, bit)| acc | ((bit as u8) << i))
-        })
-        .collect();
-    FieldElement::from_le_bytes_mod_order(&le_byte_vec)
+        });
+    FieldElement::from_le_bytes_mod_order(&le_bytes)
 }
 
 #[cfg(test)]
@@ -104,6 +112,6 @@ fn test_field_to_le_bits() {
 #[test]
 fn test_le_bits_to_field() {
     let bits = vec![true, false, true, false, false];
-    let value = le_bits_to_field(bits.into_iter());
+    let value = le_bits_to_field(bits.into_iter().take(64));
     assert_eq!(value.into_bigint().0[0], 5);
 }

--- a/provekit/common/src/witness/digits.rs
+++ b/provekit/common/src/witness/digits.rs
@@ -68,16 +68,12 @@ where
 {
     const LEN: usize = size_of::<<FieldElement as PrimeField>::BigInt>();
     let mut le_bytes = [0; LEN];
-    bits.chunks(8)
-        .into_iter()
-        .take(LEN)
-        .zip(le_bytes.iter_mut())
-        .for_each(|(chunk_in_bits, le_byte)| {
-            *le_byte = chunk_in_bits
-                .into_iter()
-                .enumerate()
-                .fold(0u8, |acc, (i, bit)| acc | ((bit as u8) << i))
-        });
+    for (i, chunk_in_bits) in bits.chunks(8).into_iter().take(LEN).enumerate() {
+        le_bytes[i] = chunk_in_bits
+            .into_iter()
+            .enumerate()
+            .fold(0u8, |acc, (i, bit)| acc | ((bit as u8) << i))
+    }
     FieldElement::from_le_bytes_mod_order(&le_bytes)
 }
 

--- a/provekit/common/src/witness/digits.rs
+++ b/provekit/common/src/witness/digits.rs
@@ -1,4 +1,9 @@
-use serde::{Deserialize, Serialize};
+use {
+    crate::FieldElement,
+    ark_ff::{BigInt, BitIteratorLE, PrimeField},
+    ark_std::Zero,
+    serde::{Deserialize, Serialize},
+};
 
 /// Allocates witnesses for the digital decomposition of the given witnesses
 /// into its digits in the given bases.  A log base is specified for each digit
@@ -18,4 +23,85 @@ pub struct DigitalDecompositionWitnesses {
     pub first_witness_idx:          usize,
     /// The number of witnesses written to
     pub num_witnesses:              usize,
+}
+
+/// Compute a mixed-base decomposition of a field element into its digits, using
+/// the given log bases. Decomposition is little-endian.
+/// Panics if the value provided can not be represented in the given bases.
+pub fn decompose_into_digits(value: FieldElement, log_bases: &[usize]) -> Vec<FieldElement> {
+    let num_digits = log_bases.len();
+    let mut digits = vec![FieldElement::zero(); num_digits];
+    let mut value_bits = field_to_le_bits(value);
+    let ref mut ref_value_bits = value_bits;
+    // Grab the bits of the element that we need for each digit, and turn them back
+    // into field elements.
+    for (i, log_base) in log_bases.iter().enumerate() {
+        let digit_bits = ref_value_bits.take(*log_base).collect::<Vec<bool>>();
+        digits[i] = le_bits_to_field(&digit_bits);
+    }
+
+    let mut remaining_bits = value_bits;
+    assert!(
+        remaining_bits.all(|bit| !bit),
+        "Higher order bits are not zero"
+    );
+    digits
+}
+
+/// Decomposes a field element into its bits, in little-endian order.
+/// Probably a lot of allocation because it goes to bits, but for little-endian
+/// and big endian is on byte level not on bit level
+pub fn field_to_le_bits(value: FieldElement) -> BitIteratorLE<BigInt<4>> {
+    BitIteratorLE::new(value.into_bigint())
+}
+
+/// Given the binary representation of a field element in little-endian order,
+/// convert it to a field element. The input is padded to the next multiple of 8
+/// bits.
+pub fn le_bits_to_field(bits: &[bool]) -> FieldElement {
+    let le_byte_vec: Vec<u8> = bits
+        .chunks(8)
+        .map(|chunk_in_bits| {
+            chunk_in_bits
+                .iter()
+                .enumerate()
+                .fold(0u8, |acc, (i, bit)| acc | ((*bit as u8) << i))
+        })
+        .collect();
+    FieldElement::from_le_bytes_mod_order(&le_byte_vec)
+}
+
+#[cfg(test)]
+#[test]
+fn test_decompose_into_digits() {
+    let value = FieldElement::from(3 + 2u32 * 256 + 256 * 256);
+    let log_bases = vec![8, 8, 4];
+    let digits = decompose_into_digits(value, &log_bases);
+    assert_eq!(digits.len(), log_bases.len());
+    assert_eq!(digits[0], FieldElement::from(3u32));
+    assert_eq!(digits[1], FieldElement::from(2u32));
+    assert_eq!(digits[2], FieldElement::from(1u32));
+}
+
+#[cfg(test)]
+#[test]
+// Changing from FieldElement :: from_be to from_le didn't negate this test. So
+// this needs to be extended
+fn test_field_to_le_bits() {
+    let value = FieldElement::from(5u32);
+    let bits: Vec<bool> = field_to_le_bits(value).collect();
+    assert_eq!(bits.len(), 256);
+    assert!(bits[0]);
+    assert!(!bits[1]);
+    assert!(bits[2]);
+    assert!(!bits[254]);
+    assert!(!bits[255]);
+}
+
+#[cfg(test)]
+#[test]
+fn test_le_bits_to_field() {
+    let bits = vec![true, false, true, false, false];
+    let value = le_bits_to_field(&bits);
+    assert_eq!(value.into_bigint().0[0], 5);
 }

--- a/provekit/common/src/witness/mod.rs
+++ b/provekit/common/src/witness/mod.rs
@@ -11,7 +11,7 @@ use {
 };
 pub use {
     binops::{BINOP_ATOMIC_BITS, BINOP_BITS, NUM_DIGITS},
-    digits::DigitalDecompositionWitnesses,
+    digits::{decompose_into_digits, DigitalDecompositionWitnesses},
     ram::{SpiceMemoryOperation, SpiceWitnesses},
     witness_builder::{
         ConstantTerm, ProductLinearTerm, SumTerm, WitnessBuilder, WitnessCoefficient,

--- a/provekit/prover/src/r1cs.rs
+++ b/provekit/prover/src/r1cs.rs
@@ -21,6 +21,7 @@ pub trait R1CSSolver {
 }
 
 impl R1CSSolver for R1CS {
+    #[instrument(skip_all)]
     fn solve_witness_vec(
         &self,
         witness_builder_vec: &[WitnessBuilder],

--- a/provekit/prover/src/witness/digits.rs
+++ b/provekit/prover/src/witness/digits.rs
@@ -1,7 +1,6 @@
-use {
-    ark_ff::{BigInteger, PrimeField},
-    ark_std::Zero,
-    provekit_common::{witness::DigitalDecompositionWitnesses, FieldElement},
+use provekit_common::{
+    witness::{decompose_into_digits, DigitalDecompositionWitnesses},
+    FieldElement,
 };
 
 pub(crate) trait DigitalDecompositionWitnessesSolver {
@@ -26,88 +25,4 @@ impl DigitalDecompositionWitnessesSolver for DigitalDecompositionWitnesses {
                     });
             });
     }
-}
-
-/// Compute a mixed-base decomposition of a field element into its digits, using
-/// the given log bases. Decomposition is little-endian.
-/// Panics if the value provided can not be represented in the given bases.
-pub(crate) fn decompose_into_digits(value: FieldElement, log_bases: &[usize]) -> Vec<FieldElement> {
-    let num_digits = log_bases.len();
-    let mut digits = vec![FieldElement::zero(); num_digits];
-    let value_bits = field_to_le_bits(value);
-    // Grab the bits of the element that we need for each digit, and turn them back
-    // into field elements.
-    let mut start_bit = 0;
-    for digit_idx in 0..num_digits {
-        let log_base = log_bases[digit_idx];
-        let digit_bits = &value_bits[start_bit..start_bit + log_base];
-        let digit_value = le_bits_to_field(digit_bits);
-        digits[digit_idx] = digit_value;
-        start_bit += log_base;
-    }
-    let remaining_bits = &value_bits[start_bit..];
-    assert!(
-        remaining_bits.iter().all(|&bit| !bit),
-        "Higher order bits are not zero"
-    );
-    digits
-}
-
-/// Decomposes a field element into its bits, in little-endian order.
-pub(crate) fn field_to_le_bits(value: FieldElement) -> Vec<bool> {
-    value.into_bigint().to_bits_le()
-}
-
-/// Given the binary representation of a field element in little-endian order,
-/// convert it to a field element. The input is padded to the next multiple of 8
-/// bits.
-pub(crate) fn le_bits_to_field(bits: &[bool]) -> FieldElement {
-    let next_multiple_of_8 = bits.len().div_ceil(8) * 8;
-    let padding_amt = next_multiple_of_8 - bits.len();
-    let mut padded_bits_le = vec![false; next_multiple_of_8];
-    padded_bits_le[..(next_multiple_of_8 - padding_amt)].copy_from_slice(bits);
-    let be_byte_vec: Vec<u8> = padded_bits_le
-        .chunks(8)
-        .map(|chunk_in_bits| {
-            chunk_in_bits
-                .iter()
-                .enumerate()
-                .fold(0u8, |acc, (i, bit)| acc | ((*bit as u8) << i))
-        })
-        .rev()
-        .collect();
-    FieldElement::from_be_bytes_mod_order(&be_byte_vec)
-}
-
-#[cfg(test)]
-#[test]
-fn test_decompose_into_digits() {
-    let value = FieldElement::from(3 + 2u32 * 256 + 256 * 256);
-    let log_bases = vec![8, 8, 4];
-    let digits = decompose_into_digits(value, &log_bases);
-    assert_eq!(digits.len(), log_bases.len());
-    assert_eq!(digits[0], FieldElement::from(3u32));
-    assert_eq!(digits[1], FieldElement::from(2u32));
-    assert_eq!(digits[2], FieldElement::from(1u32));
-}
-
-#[cfg(test)]
-#[test]
-fn test_field_to_le_bits() {
-    let value = FieldElement::from(5u32);
-    let bits = field_to_le_bits(value);
-    assert_eq!(bits.len(), 256);
-    assert!(bits[0]);
-    assert!(!bits[1]);
-    assert!(bits[2]);
-    assert!(!bits[254]);
-    assert!(!bits[255]);
-}
-
-#[cfg(test)]
-#[test]
-fn test_le_bits_to_field() {
-    let bits = vec![true, false, true, false, false];
-    let value = le_bits_to_field(&bits);
-    assert_eq!(value.into_bigint().0[0], 5);
 }

--- a/provekit/r1cs-compiler/src/binops.rs
+++ b/provekit/r1cs-compiler/src/binops.rs
@@ -1,13 +1,14 @@
 use {
     crate::{
-        digits::{
-            add_digital_decomposition, decompose_into_digits, DigitalDecompositionWitnessesBuilder,
-        },
+        digits::{add_digital_decomposition, DigitalDecompositionWitnessesBuilder},
         noir_to_r1cs::NoirToR1CSCompiler,
     },
     ark_std::One,
     provekit_common::{
-        witness::{ConstantOrR1CSWitness, SumTerm, WitnessBuilder, BINOP_ATOMIC_BITS, NUM_DIGITS},
+        witness::{
+            decompose_into_digits, ConstantOrR1CSWitness, SumTerm, WitnessBuilder,
+            BINOP_ATOMIC_BITS, NUM_DIGITS,
+        },
         FieldElement,
     },
     std::ops::Neg,

--- a/provekit/r1cs-compiler/src/binops.rs
+++ b/provekit/r1cs-compiler/src/binops.rs
@@ -52,57 +52,54 @@ pub(crate) fn add_binop(
     // associating the digit witnesses with the original witnesses).
     let mut witness_dd_counter = 0;
     for (lh, rh, _output) in inputs_and_outputs {
-        let lh_atoms = match lh {
+        let lh_atoms: Box<dyn Iterator<Item = ConstantOrR1CSWitness>> = match lh {
             ConstantOrR1CSWitness::Witness(_) => {
-                let digit_witnesses = (0..NUM_DIGITS)
-                    .map(|digit_place| {
-                        dd_struct.get_digit_witness_index(digit_place, witness_dd_counter)
-                    })
-                    .collect::<Vec<_>>();
+                let counter = witness_dd_counter;
+                let ref dd = dd_struct;
+
                 witness_dd_counter += 1;
-                digit_witnesses
-                    .iter()
-                    .map(|witness| ConstantOrR1CSWitness::Witness(*witness))
-                    .collect::<Vec<_>>()
+
+                Box::new(
+                    (0..NUM_DIGITS)
+                        .map(move |digit_place| dd.get_digit_witness_index(digit_place, counter))
+                        .map(ConstantOrR1CSWitness::Witness),
+                )
             }
-            ConstantOrR1CSWitness::Constant(value) => {
-                let digits = decompose_into_digits(value, &log_bases);
-                digits
-                    .iter()
-                    .map(|digit| ConstantOrR1CSWitness::Constant(*digit))
-                    .collect::<Vec<_>>()
-            }
+            ConstantOrR1CSWitness::Constant(value) => Box::new(
+                decompose_into_digits(value, &log_bases)
+                    .into_iter()
+                    .map(ConstantOrR1CSWitness::Constant),
+            ),
         };
-        let rh_atoms = match rh {
+        let rh_atoms: Box<dyn Iterator<Item = ConstantOrR1CSWitness>> = match rh {
             ConstantOrR1CSWitness::Witness(_) => {
-                let digit_witnesses = (0..NUM_DIGITS)
-                    .map(|digit_place| {
-                        dd_struct.get_digit_witness_index(digit_place, witness_dd_counter)
-                    })
-                    .collect::<Vec<_>>();
+                let counter = witness_dd_counter;
+                let ref dd = dd_struct;
+
                 witness_dd_counter += 1;
-                digit_witnesses
-                    .iter()
-                    .map(|witness| ConstantOrR1CSWitness::Witness(*witness))
-                    .collect::<Vec<_>>()
+
+                Box::new(
+                    (0..NUM_DIGITS)
+                        .map(move |digit_place| dd.get_digit_witness_index(digit_place, counter))
+                        .map(ConstantOrR1CSWitness::Witness),
+                )
             }
-            ConstantOrR1CSWitness::Constant(value) => {
-                let digits = decompose_into_digits(value, &log_bases);
-                digits
-                    .iter()
-                    .map(|digit| ConstantOrR1CSWitness::Constant(*digit))
-                    .collect::<Vec<_>>()
-            }
+            ConstantOrR1CSWitness::Constant(value) => Box::new(
+                decompose_into_digits(value, &log_bases)
+                    .into_iter()
+                    .map(ConstantOrR1CSWitness::Constant),
+            ),
         };
-        let output_atoms = (0..NUM_DIGITS)
-            .map(|digit_place| dd_struct.get_digit_witness_index(digit_place, witness_dd_counter))
-            .collect::<Vec<_>>();
+        let output_atoms = {
+            let counter = witness_dd_counter;
+            let ref dd = dd_struct;
+            (0..NUM_DIGITS).map(move |digit_place| dd.get_digit_witness_index(digit_place, counter))
+        };
         witness_dd_counter += 1;
 
         lh_atoms
-            .into_iter()
-            .zip(rh_atoms.into_iter())
-            .zip(output_atoms.into_iter())
+            .zip(rh_atoms)
+            .zip(output_atoms)
             .for_each(|((lh, rh), output)| {
                 inputs_and_outputs_atomic.push((lh, rh, output));
             });

--- a/provekit/r1cs-compiler/src/binops.rs
+++ b/provekit/r1cs-compiler/src/binops.rs
@@ -56,13 +56,15 @@ pub(crate) fn add_binop(
         let lh_atoms: Box<dyn Iterator<Item = ConstantOrR1CSWitness>> = match lh {
             ConstantOrR1CSWitness::Witness(_) => {
                 let counter = witness_dd_counter;
-                let ref dd = dd_struct;
+                let r#struct = &dd_struct;
 
                 witness_dd_counter += 1;
 
                 Box::new(
                     (0..NUM_DIGITS)
-                        .map(move |digit_place| dd.get_digit_witness_index(digit_place, counter))
+                        .map(move |digit_place| {
+                            r#struct.get_digit_witness_index(digit_place, counter)
+                        })
                         .map(ConstantOrR1CSWitness::Witness),
                 )
             }
@@ -75,13 +77,15 @@ pub(crate) fn add_binop(
         let rh_atoms: Box<dyn Iterator<Item = ConstantOrR1CSWitness>> = match rh {
             ConstantOrR1CSWitness::Witness(_) => {
                 let counter = witness_dd_counter;
-                let ref dd = dd_struct;
+                let r#struct = &dd_struct;
 
                 witness_dd_counter += 1;
 
                 Box::new(
                     (0..NUM_DIGITS)
-                        .map(move |digit_place| dd.get_digit_witness_index(digit_place, counter))
+                        .map(move |digit_place| {
+                            r#struct.get_digit_witness_index(digit_place, counter)
+                        })
                         .map(ConstantOrR1CSWitness::Witness),
                 )
             }

--- a/provekit/r1cs-compiler/src/digits.rs
+++ b/provekit/r1cs-compiler/src/digits.rs
@@ -132,11 +132,7 @@ pub(crate) fn field_to_le_bits(value: FieldElement) -> Vec<bool> {
 /// convert it to a field element. The input is padded to the next multiple of 8
 /// bits.
 pub(crate) fn le_bits_to_field(bits: &[bool]) -> FieldElement {
-    let next_multiple_of_8 = bits.len().div_ceil(8) * 8;
-    let padding_amt = next_multiple_of_8 - bits.len();
-    let mut padded_bits_le = vec![false; next_multiple_of_8];
-    padded_bits_le[..(next_multiple_of_8 - padding_amt)].copy_from_slice(bits);
-    let be_byte_vec: Vec<u8> = padded_bits_le
+    let le_byte_vec: Vec<u8> = bits
         .chunks(8)
         .map(|chunk_in_bits| {
             chunk_in_bits
@@ -145,7 +141,7 @@ pub(crate) fn le_bits_to_field(bits: &[bool]) -> FieldElement {
                 .fold(0u8, |acc, (i, bit)| acc | ((*bit as u8) << i))
         })
         .collect();
-    FieldElement::from_le_bytes_mod_order(&be_byte_vec)
+    FieldElement::from_le_bytes_mod_order(&le_byte_vec)
 }
 
 #[cfg(test)]

--- a/provekit/r1cs-compiler/src/digits.rs
+++ b/provekit/r1cs-compiler/src/digits.rs
@@ -1,7 +1,6 @@
 use {
     crate::noir_to_r1cs::NoirToR1CSCompiler,
-    ark_ff::{BigInt, BigInteger, BitIteratorLE, PrimeField},
-    ark_std::{One, Zero},
+    ark_std::One,
     provekit_common::{
         witness::{DigitalDecompositionWitnesses, WitnessBuilder},
         FieldElement,
@@ -90,85 +89,4 @@ pub(crate) fn add_digital_decomposition(
             );
         });
     dd_struct
-}
-
-/// Compute a mixed-base decomposition of a field element into its digits, using
-/// the given log bases. Decomposition is little-endian.
-/// Panics if the value provided can not be represented in the given bases.
-pub(crate) fn decompose_into_digits(value: FieldElement, log_bases: &[usize]) -> Vec<FieldElement> {
-    let num_digits = log_bases.len();
-    let mut digits = vec![FieldElement::zero(); num_digits];
-    let mut value_bits = field_to_le_bits(value);
-    let ref mut ref_value_bits = value_bits;
-    // Grab the bits of the element that we need for each digit, and turn them back
-    // into field elements.
-    for (i, log_base) in log_bases.iter().enumerate() {
-        let digit_bits = ref_value_bits.take(*log_base).collect::<Vec<bool>>();
-        digits[i] = le_bits_to_field(&digit_bits);
-    }
-
-    let mut remaining_bits = value_bits;
-    assert!(
-        remaining_bits.all(|bit| !bit),
-        "Higher order bits are not zero"
-    );
-    digits
-}
-
-/// Decomposes a field element into its bits, in little-endian order.
-/// Probably a lot of allocation because it goes to bits, but for little-endian
-/// and big endian is on byte level not on bit level
-pub(crate) fn field_to_le_bits(value: FieldElement) -> BitIteratorLE<BigInt<4>> {
-    BitIteratorLE::new(value.into_bigint())
-}
-
-/// Given the binary representation of a field element in little-endian order,
-/// convert it to a field element. The input is padded to the next multiple of 8
-/// bits.
-pub(crate) fn le_bits_to_field(bits: &[bool]) -> FieldElement {
-    let le_byte_vec: Vec<u8> = bits
-        .chunks(8)
-        .map(|chunk_in_bits| {
-            chunk_in_bits
-                .iter()
-                .enumerate()
-                .fold(0u8, |acc, (i, bit)| acc | ((*bit as u8) << i))
-        })
-        .collect();
-    FieldElement::from_le_bytes_mod_order(&le_byte_vec)
-}
-
-#[cfg(test)]
-#[test]
-fn test_decompose_into_digits() {
-    let value = FieldElement::from(3 + 2u32 * 256 + 256 * 256);
-    let log_bases = vec![8, 8, 4];
-    let digits = decompose_into_digits(value, &log_bases);
-    assert_eq!(digits.len(), log_bases.len());
-    assert_eq!(digits[0], FieldElement::from(3u32));
-    assert_eq!(digits[1], FieldElement::from(2u32));
-    assert_eq!(digits[2], FieldElement::from(1u32));
-}
-
-#[cfg(test)]
-#[test]
-// Changing from FieldElement :: from_be to from_le didn't negate this test. So
-// this needs to be extended
-fn test_field_to_le_bits() {
-    let value = FieldElement::from(5u32);
-    let bits: Vec<bool> = field_to_le_bits(value).collect();
-    assert_eq!(bits.len(), 256);
-    assert!(bits[0]);
-    assert!(!bits[1]);
-    assert!(bits[2]);
-    assert!(!bits[254]);
-    assert!(!bits[255]);
-}
-
-#[cfg(test)]
-#[test]
-fn test_le_bits_to_field() {
-    let bits = vec![true, false, true, false, false];
-    let value = le_bits_to_field(&bits);
-    assert_eq!(value.into_bigint().0[0], 5);
 }

--- a/provekit/r1cs-compiler/src/digits.rs
+++ b/provekit/r1cs-compiler/src/digits.rs
@@ -102,15 +102,9 @@ pub(crate) fn decompose_into_digits(value: FieldElement, log_bases: &[usize]) ->
     let ref mut ref_value_bits = value_bits;
     // Grab the bits of the element that we need for each digit, and turn them back
     // into field elements.
-
-    // log bases acts as slices into value bits. Take ownership of that.
-    // Once that works try to use the iterator directly from field_to_le_bits
-
-    for digit_idx in 0..num_digits {
-        let log_base = log_bases[digit_idx];
-        let digit_bits = ref_value_bits.take(log_base).collect::<Vec<bool>>();
-        let digit_value = le_bits_to_field(&digit_bits);
-        digits[digit_idx] = digit_value;
+    for (i, log_base) in log_bases.iter().enumerate() {
+        let digit_bits = ref_value_bits.take(*log_base).collect::<Vec<bool>>();
+        digits[i] = le_bits_to_field(&digit_bits);
     }
 
     let mut remaining_bits = value_bits;

--- a/provekit/r1cs-compiler/src/range_check.rs
+++ b/provekit/r1cs-compiler/src/range_check.rs
@@ -51,8 +51,7 @@ pub(crate) fn add_range_checks(
                 if logbase_of_remainder_digit != 0 {
                     log_bases.push(logbase_of_remainder_digit as usize);
                 }
-                let dd_struct =
-                    add_digital_decomposition(r1cs, log_bases.clone(), values_to_lookup.clone());
+                let dd_struct = add_digital_decomposition(r1cs, log_bases, values_to_lookup);
 
                 // Add the witness indices for the digits to the atomic range checks
                 dd_struct


### PR DESCRIPTION
38% of the allocations in the prover is was due to `solve_witness_vec` and this PR brings that down to under 3%. The total amount of allocations is reduced by 5 million and `decompose_into_digits` now runs twice as fast. 