### PR TITLE
chore: comment out noisy range check log

### DIFF
--- a/provekit/r1cs-compiler/src/noir_to_r1cs.rs
+++ b/provekit/r1cs-compiler/src/noir_to_r1cs.rs
@@ -342,10 +342,10 @@ impl NoirToR1CSCompiler {
                                 self.fetch_r1cs_witness_index(witness)
                             }
                         };
-                        println!(
-                            "RANGE CHECK of witness {} to {} bits",
-                            input_witness, num_bits
-                        );
+                        // println!(
+                        //     "RANGE CHECK of witness {} to {} bits",
+                        //     input_witness, num_bits
+                        // );
                         // Add the entry into the range blocks.
                         range_checks
                             .entry(num_bits)


### PR DESCRIPTION
Running 
`cargo run --release --bin provekit-cli prepare ./target/basic.json -o ./noir-proof-scheme.nps`
on complete-age-check spams this out:

<img width="791" height="774" alt="Screenshot 2025-09-10 at 13 36 04" src="https://github.com/user-attachments/assets/1611d618-6d69-4a25-a2b3-8f2a223e6d34" />
