### PR TITLE
Fix: missing file handling and speed up execution

### DIFF
--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -1,6 +1,8 @@
 # Run this in the `noir-r1cs` directory!
 
+shopt -s nullglob
+cargo build --release --bin circuit_stats
 for file in noir-passport-examples/*.json; do
   echo "$file"
-  cargo run --bin circuit_stats -- "$file" noir-examples/basic/target/basic.gz
+  ./target/release/circuit_stats "$file" noir-examples/basic/target/basic.gz
 done


### PR DESCRIPTION
1. Made sure the loop doesn’t choke on `noir-passport-examples/*.json` when there are no files by turning on `shopt -s nullglob`.
2. Switched to building `circuit_stats` once (`cargo build --release --bin circuit_stats`) and just running the compiled binary after that - way faster than rebuilding on each iteration.
