### PR TITLE
feat: Implement layered witness solving with batch inversion optimization

### DIFF
--- a/provekit/common/src/noir_proof_scheme.rs
+++ b/provekit/common/src/noir_proof_scheme.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         whir_r1cs::{WhirR1CSProof, WhirR1CSScheme},
-        witness::{NoirWitnessGenerator, WitnessBuilder},
+        witness::{LayeredWitnessBuilders, NoirWitnessGenerator},
         NoirElement, R1CS,
     },
     acir::circuit::Program,
@@ -15,11 +15,11 @@ use {
 /// A scheme for proving a Noir program.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NoirProofScheme {
-    pub program:           Program<NoirElement>,
-    pub r1cs:              R1CS,
-    pub witness_builders:  Vec<WitnessBuilder>,
-    pub witness_generator: NoirWitnessGenerator,
-    pub whir_for_witness:  WhirR1CSScheme,
+    pub program:                  Program<NoirElement>,
+    pub r1cs:                     R1CS,
+    pub layered_witness_builders: LayeredWitnessBuilders,
+    pub witness_generator:        NoirWitnessGenerator,
+    pub whir_for_witness:         WhirR1CSScheme,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/provekit/common/src/utils/mod.rs
+++ b/provekit/common/src/utils/mod.rs
@@ -127,7 +127,7 @@ pub fn human(value: f64) -> impl Display {
 /// Computes multiplicative inverses using Montgomery's batch inversion trick.
 ///
 /// Reduces N field inversions to 1 inversion + 3N multiplications.
-/// See: https://encrypt.a41.io/primitives/abstract-algebra/group/batch-inverse
+/// See: <https://encrypt.a41.io/primitives/abstract-algebra/group/batch-inverse>
 pub fn batch_inverse_montgomery(values: &[FieldElement]) -> Vec<FieldElement> {
     let batch_size = values.len();
     if batch_size == 0 {

--- a/provekit/common/src/witness/layer_scheduler.rs
+++ b/provekit/common/src/witness/layer_scheduler.rs
@@ -1,0 +1,388 @@
+use {
+    super::WitnessBuilder, crate::witness::{ConstantOrR1CSWitness, ConstantTerm, ProductLinearTerm, SumTerm, WitnessCoefficient, BINOP_ATOMIC_BITS}, std::{
+        collections::{BTreeMap, BTreeSet, VecDeque},
+        mem,
+    }
+};
+
+/// Layered plan for serial batched-inversion solving.
+///
+/// Semantics:
+/// - `pre_builders` contains only non-`Inverse` builders, concatenated
+///   segment-by-segment.
+/// - For segment i, the PRE slice is `pre_builders[pre_segment_starts[i] ..
+///   pre_segment_starts[i+1] or end]`.
+/// - Immediately after PRE[i], batch-invert all denominators listed in
+///   `inverse_batches[i]`.
+/// - Each `inverse_batches[i]` contains only `WitnessBuilder::Inverse(out,
+///   denom)` elements.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct LayeredWitnessBuilders {
+    pub pre_builders:       Vec<WitnessBuilder>,
+    pub pre_segment_starts: Vec<usize>,
+    pub inverse_batches:    Vec<Vec<WitnessBuilder>>,
+}
+
+impl LayeredWitnessBuilders {
+    pub fn layers_len(&self) -> usize {
+        self.pre_segment_starts.len()
+    }
+
+    pub fn layer_range(&self, seg_idx: usize) -> (usize, usize) {
+        let start = self.pre_segment_starts[seg_idx];
+        let end = self
+            .pre_segment_starts
+            .get(seg_idx + 1)
+            .copied()
+            .unwrap_or(self.pre_builders.len());
+        (start, end)
+    }
+}
+
+/// Internal state manager for the layer scheduling algorithm.
+///
+/// Encapsulates the complex state tracking needed for frontier-based
+/// topological sorting with deferred inverse batching.
+pub struct LayerScheduler<'a> {
+    witness_builders: &'a [WitnessBuilder],
+    adjacency_list:   Vec<Vec<usize>>,
+    in_degrees:       Vec<usize>,
+
+    // Processing state
+    frontier:        VecDeque<usize>,
+    processed:       Vec<bool>,
+    processed_count: usize,
+
+    // Layer building state
+    pre_layers:          Vec<Vec<usize>>,
+    inverse_batches:     Vec<Vec<WitnessBuilder>>,
+    current_pre_segment: Vec<usize>,
+
+    // Inverse tracking state
+    pending_inverse_nodes:    Vec<usize>,
+    pending_inverse_builders: Vec<WitnessBuilder>,
+    pending_inverse_outputs:  BTreeSet<usize>,
+}
+
+impl<'a> LayerScheduler<'a> {
+    pub fn new(witness_builders: &'a [WitnessBuilder]) -> Self {
+        let builder_count = witness_builders.len();
+        let (adjacency_list, in_degrees) = Self::build_dependency_graph(witness_builders);
+
+        let frontier = (0..builder_count).filter(|&i| in_degrees[i] == 0).collect();
+
+        Self {
+            witness_builders,
+            adjacency_list,
+            in_degrees,
+            frontier,
+            processed: vec![false; builder_count],
+            processed_count: 0,
+            pre_layers: Vec::new(),
+            inverse_batches: Vec::new(),
+            current_pre_segment: Vec::new(),
+            pending_inverse_nodes: Vec::new(),
+            pending_inverse_builders: Vec::new(),
+            pending_inverse_outputs: BTreeSet::new(),
+        }
+    }
+
+    /// Returns the witness indices written by this builder.
+    fn writes_of(wb: &WitnessBuilder) -> Vec<usize> {
+        match wb {
+            WitnessBuilder::Constant(ConstantTerm(idx, _)) => vec![*idx],
+            WitnessBuilder::Acir(idx, _) => vec![*idx],
+            WitnessBuilder::Sum(idx, _) => vec![*idx],
+            WitnessBuilder::Product(idx, ..) => vec![*idx],
+            WitnessBuilder::MultiplicitiesForRange(start, range, _) => {
+                (*start..*start + *range).collect()
+            }
+            WitnessBuilder::Challenge(idx) => vec![*idx],
+            WitnessBuilder::IndexedLogUpDenominator(idx, ..) => vec![*idx],
+            WitnessBuilder::Inverse(idx, _) => vec![*idx],
+            WitnessBuilder::ProductLinearOperation(idx, ..) => vec![*idx],
+            WitnessBuilder::LogUpDenominator(idx, ..) => vec![*idx],
+            WitnessBuilder::DigitalDecomposition(dd) => {
+                (dd.first_witness_idx..dd.first_witness_idx + dd.num_witnesses).collect()
+            }
+            WitnessBuilder::SpiceMultisetFactor(idx, ..) => vec![*idx],
+            WitnessBuilder::SpiceWitnesses(sw) => {
+                (sw.first_witness_idx..sw.first_witness_idx + sw.num_witnesses).collect()
+            }
+            WitnessBuilder::BinOpLookupDenominator(idx, ..) => vec![*idx],
+            WitnessBuilder::MultiplicitiesForBinOp(start, ..) => {
+                let n = (2usize).pow(2 * (BINOP_ATOMIC_BITS as u32));
+                (*start..*start + n).collect()
+            }
+        }
+    }
+
+    /// Returns the witness indices read by this builder.
+    fn reads_of(wb: &WitnessBuilder) -> Vec<usize> {
+        match wb {
+            WitnessBuilder::Constant(_) => vec![],
+            WitnessBuilder::Acir(..) => vec![],
+            WitnessBuilder::Sum(_, ops) => ops.iter().map(|SumTerm(_, idx)| *idx).collect(),
+            WitnessBuilder::Product(_, a, b) => vec![*a, *b],
+            WitnessBuilder::MultiplicitiesForRange(_, _, values) => values.clone(),
+            WitnessBuilder::Challenge(_) => vec![],
+            WitnessBuilder::IndexedLogUpDenominator(
+                _,
+                sz,
+                WitnessCoefficient(_, index),
+                rs,
+                value,
+            ) => {
+                vec![*sz, *index, *rs, *value]
+            }
+            WitnessBuilder::Inverse(_, x) => vec![*x],
+            WitnessBuilder::ProductLinearOperation(
+                _,
+                ProductLinearTerm(x, ..),
+                ProductLinearTerm(y, ..),
+            ) => {
+                vec![*x, *y]
+            }
+            WitnessBuilder::LogUpDenominator(_, sz, WitnessCoefficient(_, value)) => {
+                vec![*sz, *value]
+            }
+            WitnessBuilder::DigitalDecomposition(dd) => dd.witnesses_to_decompose.clone(),
+            WitnessBuilder::SpiceMultisetFactor(
+                _,
+                sz,
+                rs,
+                WitnessCoefficient(_, addr_w),
+                value,
+                WitnessCoefficient(_, timer_w),
+            ) => {
+                vec![*sz, *rs, *addr_w, *value, *timer_w]
+            }
+            WitnessBuilder::SpiceWitnesses(sw) => {
+                let mut v: Vec<usize> =
+                    (sw.initial_values_start..sw.initial_values_start + sw.memory_length).collect();
+                for op in &sw.memory_operations {
+                    match op {
+                        crate::witness::SpiceMemoryOperation::Load(addr, value, _rt) => {
+                            v.push(*addr);
+                            v.push(*value);
+                        }
+                        crate::witness::SpiceMemoryOperation::Store(
+                            addr,
+                            _old_value,
+                            new_value,
+                            _rt,
+                        ) => {
+                            v.push(*addr);
+                            v.push(*new_value);
+                        }
+                    }
+                }
+                v
+            }
+            WitnessBuilder::BinOpLookupDenominator(_, sz, rs, rs2, lhs, rhs, output) => {
+                let mut v = vec![*sz, *rs, *rs2];
+                let mut push_w = |c: &ConstantOrR1CSWitness| {
+                    if let ConstantOrR1CSWitness::Witness(w) = c {
+                        v.push(*w)
+                    }
+                };
+                push_w(lhs);
+                push_w(rhs);
+                push_w(output);
+                v
+            }
+            WitnessBuilder::MultiplicitiesForBinOp(_, pairs) => {
+                let mut v = Vec::new();
+                for (lhs, rhs) in pairs {
+                    if let ConstantOrR1CSWitness::Witness(w) = lhs {
+                        v.push(*w);
+                    }
+                    if let ConstantOrR1CSWitness::Witness(w) = rhs {
+                        v.push(*w);
+                    }
+                }
+                v
+            }
+        }
+    }
+
+    /// Builds a dependency graph from witness builders.
+    ///
+    /// Returns (adjacency_list, in_degrees) where adjacency_list[i] contains
+    /// all builders that depend on builder i, and in_degrees[i] is the number
+    /// of dependencies for builder i.
+    fn build_dependency_graph(
+        witness_builders: &[WitnessBuilder],
+    ) -> (Vec<Vec<usize>>, Vec<usize>) {
+        let builder_count = witness_builders.len();
+
+        // Map each witness index to the builder that produces it
+        let mut witness_producer: BTreeMap<usize, usize> = BTreeMap::new();
+        for (builder_idx, builder) in witness_builders.iter().enumerate() {
+            for witness_idx in Self::writes_of(builder) {
+                witness_producer.insert(witness_idx, builder_idx);
+            }
+        }
+
+        // Build adjacency list and count incoming edges
+        let mut adjacency_list: Vec<Vec<usize>> = vec![Vec::new(); builder_count];
+        let mut in_degrees: Vec<usize> = vec![0; builder_count];
+
+        for (consumer_idx, builder) in witness_builders.iter().enumerate() {
+            for required_witness in Self::reads_of(builder) {
+                if let Some(&producer_idx) = witness_producer.get(&required_witness) {
+                    if producer_idx != consumer_idx {
+                        adjacency_list[producer_idx].push(consumer_idx);
+                        in_degrees[consumer_idx] += 1;
+                    }
+                }
+            }
+        }
+
+        (adjacency_list, in_degrees)
+    }
+
+    pub fn build_layers(mut self) -> LayeredWitnessBuilders {
+        while self.processed_count < self.witness_builders.len() {
+            if !self.try_process_frontier() {
+                if self.has_pending_inverses() {
+                    self.flush_current_layer();
+                } else if !self.frontier.is_empty() {
+                    // This should not happen in a valid DAG
+                    self.handle_deadlock();
+                } else {
+                    break; // All done
+                }
+            }
+        }
+
+        // Handle any remaining work
+        if !self.current_pre_segment.is_empty() || self.has_pending_inverses() {
+            self.flush_current_layer();
+        }
+
+        self.build_final_plan()
+    }
+
+    /// Attempts to process the current frontier, returning true if progress was
+    /// made.
+    fn try_process_frontier(&mut self) -> bool {
+        let mut any_progress = false;
+        let mut deferred_builders = VecDeque::new();
+        let frontier_size = self.frontier.len();
+
+        // Process each builder in the current frontier
+        for _ in 0..frontier_size {
+            let builder_idx = self.frontier.pop_front().unwrap();
+            if self.processed[builder_idx] {
+                continue;
+            }
+
+            if self.can_process_builder(builder_idx) {
+                self.process_builder(builder_idx);
+                any_progress = true;
+            } else {
+                deferred_builders.push_back(builder_idx);
+            }
+        }
+
+        // Restore deferred builders to frontier
+        self.frontier.extend(deferred_builders);
+        any_progress
+    }
+
+    /// Checks if a builder can be processed in the current PRE segment.
+    fn can_process_builder(&self, builder_idx: usize) -> bool {
+        match &self.witness_builders[builder_idx] {
+            WitnessBuilder::Inverse(..) => false, // Always defer inverses
+            _ => {
+                // Check if this builder reads any pending inverse outputs
+                !Self::reads_of(&self.witness_builders[builder_idx])
+                    .iter()
+                    .any(|witness| self.pending_inverse_outputs.contains(witness))
+            }
+        }
+    }
+
+    /// Processes a single builder, either adding to PRE segment or collecting
+    /// for inversion.
+    fn process_builder(&mut self, builder_idx: usize) {
+        match &self.witness_builders[builder_idx] {
+            WitnessBuilder::Inverse(out_witness, denom_witness) => {
+                // Collect inverse for batching
+                self.pending_inverse_nodes.push(builder_idx);
+                self.pending_inverse_builders
+                    .push(WitnessBuilder::Inverse(*out_witness, *denom_witness));
+                self.pending_inverse_outputs.insert(*out_witness);
+            }
+            _ => {
+                // Add to current PRE segment
+                self.current_pre_segment.push(builder_idx);
+                self.mark_processed(builder_idx);
+            }
+        }
+    }
+
+    /// Marks a builder as processed and updates the dependency graph.
+    fn mark_processed(&mut self, builder_idx: usize) {
+        self.processed[builder_idx] = true;
+        self.processed_count += 1;
+
+        // Update dependencies and frontier
+        for &dependent_idx in &self.adjacency_list[builder_idx] {
+            self.in_degrees[dependent_idx] -= 1;
+            if self.in_degrees[dependent_idx] == 0 {
+                self.frontier.push_back(dependent_idx);
+            }
+        }
+    }
+
+    /// Flushes the current PRE segment and inverse batch, then processes
+    /// pending inverses.
+    fn flush_current_layer(&mut self) {
+        // Emit current PRE segment and inverse batch
+        self.pre_layers
+            .push(mem::take(&mut self.current_pre_segment));
+        self.inverse_batches
+            .push(mem::take(&mut self.pending_inverse_builders));
+        self.pending_inverse_outputs.clear();
+
+        // Process all pending inverse nodes to unlock their dependencies
+        let pending_nodes: Vec<usize> = self.pending_inverse_nodes.drain(..).collect();
+        for inverse_idx in pending_nodes {
+            if !self.processed[inverse_idx] {
+                self.mark_processed(inverse_idx);
+            }
+        }
+    }
+
+    fn has_pending_inverses(&self) -> bool {
+        !self.pending_inverse_builders.is_empty()
+    }
+
+    fn handle_deadlock(&self) -> ! {
+        panic!(
+            "Layer scheduling deadlock: {} builders remain unprocessed with no valid progress path",
+            self.witness_builders.len() - self.processed_count
+        );
+    }
+
+    /// Builds the final LayeredWitnessBuilders from the computed layers.
+    fn build_final_plan(self) -> LayeredWitnessBuilders {
+        let mut pre_builders = Vec::new();
+        let mut pre_segment_starts = Vec::with_capacity(self.pre_layers.len());
+
+        for pre_layer in &self.pre_layers {
+            pre_segment_starts.push(pre_builders.len());
+            for &builder_idx in pre_layer {
+                pre_builders.push(self.witness_builders[builder_idx].clone());
+            }
+        }
+
+        LayeredWitnessBuilders {
+            pre_builders,
+            pre_segment_starts,
+            inverse_batches: self.inverse_batches,
+        }
+    }
+}

--- a/provekit/common/src/witness/layer_scheduler.rs
+++ b/provekit/common/src/witness/layer_scheduler.rs
@@ -17,7 +17,7 @@ use {
 ///   segment-by-segment.
 /// - For segment i, the PRE slice is `pre_builders[pre_segment_starts[i] ..
 ///   pre_segment_starts[i+1] or end]`.
-/// - Immediately after PRE[i], batch-invert all denominators listed in
+/// - Immediately after PRE[\i], batch-invert all denominators listed in
 ///   `inverse_batches[i]`.
 /// - Each `inverse_batches[i]` contains only `WitnessBuilder::Inverse(out,
 ///   denom)` elements.
@@ -213,8 +213,8 @@ impl<'a> LayerScheduler<'a> {
 
     /// Builds a dependency graph from witness builders.
     ///
-    /// Returns (adjacency_list, in_degrees) where adjacency_list[i] contains
-    /// all builders that depend on builder i, and in_degrees[i] is the number
+    /// Returns (adjacency_list, in_degrees) where adjacency_list[\i] contains
+    /// all builders that depend on builder i, and in_degrees[\i] is the number
     /// of dependencies for builder i.
     fn build_dependency_graph(
         witness_builders: &[WitnessBuilder],

--- a/provekit/common/src/witness/layer_scheduler.rs
+++ b/provekit/common/src/witness/layer_scheduler.rs
@@ -5,132 +5,112 @@ use {
         BINOP_ATOMIC_BITS,
     },
     std::{
-        collections::{BTreeMap, BTreeSet, VecDeque},
+        collections::{HashMap, HashSet, VecDeque},
         mem,
     },
 };
 
 /// Layered plan for serial batched-inversion solving.
 ///
-/// Semantics:
-/// - `pre_builders` contains only non-`Inverse` builders, concatenated
-///   segment-by-segment.
-/// - For segment i, the PRE slice is `pre_builders[pre_segment_starts[i] ..
-///   pre_segment_starts[i+1] or end]`.
-/// - Immediately after PRE[\i], batch-invert all denominators listed in
-///   `inverse_batches[i]`.
-/// - Each `inverse_batches[i]` contains only `WitnessBuilder::Inverse(out,
-///   denom)` elements.
+/// Optimized single-array design:
+/// - `builders` contains ALL builders in execution order: [pre1, pre2, ...,
+///   inv1, inv2, ..., pre3, ...]
+/// - For layer i: PRE slice is `builders[pre_starts[i] .. inverse_starts[i]]`
+/// - For layer i: INVERSE slice is `builders[inverse_starts[i] ..
+///   pre_starts[i+1] or end]`
+/// - Perfect cache locality: execution order = memory order
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct LayeredWitnessBuilders {
-    pub pre_builders:       Vec<WitnessBuilder>,
-    pub pre_segment_starts: Vec<usize>,
-    pub inverse_batches:    Vec<Vec<WitnessBuilder>>,
+    pub builders:       Vec<WitnessBuilder>,
+    pub pre_starts:     Vec<usize>,
+    pub inverse_starts: Vec<usize>,
 }
 
 impl LayeredWitnessBuilders {
     pub fn layers_len(&self) -> usize {
-        self.pre_segment_starts.len()
+        self.pre_starts.len()
     }
 
-    pub fn layer_range(&self, seg_idx: usize) -> (usize, usize) {
-        let start = self.pre_segment_starts[seg_idx];
+    /// Returns pre-builders for the specified layer
+    pub fn pre_builders(&self, layer_idx: usize) -> &[WitnessBuilder] {
+        let start = self.pre_starts[layer_idx];
+        let end = self.inverse_starts[layer_idx];
+        &self.builders[start..end]
+    }
+
+    /// Returns inverse-builders for the specified layer
+    pub fn inverse_builders(&self, layer_idx: usize) -> &[WitnessBuilder] {
+        let start = self.inverse_starts[layer_idx];
         let end = self
-            .pre_segment_starts
-            .get(seg_idx + 1)
+            .pre_starts
+            .get(layer_idx + 1)
             .copied()
-            .unwrap_or(self.pre_builders.len());
+            .unwrap_or(self.builders.len());
+        &self.builders[start..end]
+    }
+
+    /// Legacy compatibility - returns (start, end) range for pre-builders
+    #[deprecated(note = "Use pre_builders() instead")]
+    pub fn layer_range(&self, layer_idx: usize) -> (usize, usize) {
+        let start = self.pre_starts[layer_idx];
+        let end = self.inverse_starts[layer_idx];
         (start, end)
     }
 }
 
-/// Internal state manager for the layer scheduling algorithm.
-///
-/// Encapsulates the complex state tracking needed for frontier-based
-/// topological sorting with deferred inverse batching.
-pub struct LayerScheduler<'a> {
-    witness_builders: &'a [WitnessBuilder],
-    adjacency_list:   Vec<Vec<usize>>,
-    in_degrees:       Vec<usize>,
-
-    // Processing state
-    frontier:        VecDeque<usize>,
-    processed:       Vec<bool>,
-    processed_count: usize,
-
-    // Layer building state
-    pre_layers:          Vec<Vec<usize>>,
-    inverse_batches:     Vec<Vec<WitnessBuilder>>,
-    current_pre_segment: Vec<usize>,
-
-    // Inverse tracking state
-    pending_inverse_nodes:    Vec<usize>,
-    pending_inverse_builders: Vec<WitnessBuilder>,
-    pending_inverse_outputs:  BTreeSet<usize>,
+/// Cached dependency information for efficient processing
+#[derive(Debug)]
+struct DependencyInfo {
+    reads:          Vec<Vec<usize>>,
+    adjacency_list: Vec<Vec<usize>>,
+    in_degrees:     Vec<usize>,
 }
 
-impl<'a> LayerScheduler<'a> {
-    pub fn new(witness_builders: &'a [WitnessBuilder]) -> Self {
+impl DependencyInfo {
+    fn new(witness_builders: &[WitnessBuilder]) -> Self {
         let builder_count = witness_builders.len();
-        let (adjacency_list, in_degrees) = Self::build_dependency_graph(witness_builders);
 
-        let frontier = (0..builder_count).filter(|&i| in_degrees[i] == 0).collect();
+        // Pre-compute all dependency information once
+        let reads: Vec<Vec<usize>> = witness_builders.iter().map(Self::extract_reads).collect();
+
+        // Build dependency graph using cached reads
+        let mut witness_producer = HashMap::with_capacity(builder_count * 2);
+        for (builder_idx, builder) in witness_builders.iter().enumerate() {
+            for witness_idx in Self::extract_writes(builder) {
+                witness_producer.insert(witness_idx, builder_idx);
+            }
+        }
+
+        let mut adjacency_list = vec![Vec::new(); builder_count];
+        let mut in_degrees = vec![0; builder_count];
+
+        for (consumer_idx, read_set) in reads.iter().enumerate() {
+            for &required_witness in read_set {
+                if let Some(&producer_idx) = witness_producer.get(&required_witness) {
+                    if producer_idx != consumer_idx {
+                        adjacency_list[producer_idx].push(consumer_idx);
+                        in_degrees[consumer_idx] += 1;
+                    }
+                }
+            }
+        }
 
         Self {
-            witness_builders,
+            reads,
             adjacency_list,
             in_degrees,
-            frontier,
-            processed: vec![false; builder_count],
-            processed_count: 0,
-            pre_layers: Vec::new(),
-            inverse_batches: Vec::new(),
-            current_pre_segment: Vec::new(),
-            pending_inverse_nodes: Vec::new(),
-            pending_inverse_builders: Vec::new(),
-            pending_inverse_outputs: BTreeSet::new(),
         }
     }
 
-    /// Returns the witness indices written by this builder.
-    fn writes_of(wb: &WitnessBuilder) -> Vec<usize> {
+    fn extract_reads(wb: &WitnessBuilder) -> Vec<usize> {
         match wb {
-            WitnessBuilder::Constant(ConstantTerm(idx, _)) => vec![*idx],
-            WitnessBuilder::Acir(idx, _) => vec![*idx],
-            WitnessBuilder::Sum(idx, _) => vec![*idx],
-            WitnessBuilder::Product(idx, ..) => vec![*idx],
-            WitnessBuilder::MultiplicitiesForRange(start, range, _) => {
-                (*start..*start + *range).collect()
-            }
-            WitnessBuilder::Challenge(idx) => vec![*idx],
-            WitnessBuilder::IndexedLogUpDenominator(idx, ..) => vec![*idx],
-            WitnessBuilder::Inverse(idx, _) => vec![*idx],
-            WitnessBuilder::ProductLinearOperation(idx, ..) => vec![*idx],
-            WitnessBuilder::LogUpDenominator(idx, ..) => vec![*idx],
-            WitnessBuilder::DigitalDecomposition(dd) => {
-                (dd.first_witness_idx..dd.first_witness_idx + dd.num_witnesses).collect()
-            }
-            WitnessBuilder::SpiceMultisetFactor(idx, ..) => vec![*idx],
-            WitnessBuilder::SpiceWitnesses(sw) => {
-                (sw.first_witness_idx..sw.first_witness_idx + sw.num_witnesses).collect()
-            }
-            WitnessBuilder::BinOpLookupDenominator(idx, ..) => vec![*idx],
-            WitnessBuilder::MultiplicitiesForBinOp(start, ..) => {
-                let n = (2usize).pow(2 * (BINOP_ATOMIC_BITS as u32));
-                (*start..*start + n).collect()
-            }
-        }
-    }
-
-    /// Returns the witness indices read by this builder.
-    fn reads_of(wb: &WitnessBuilder) -> Vec<usize> {
-        match wb {
-            WitnessBuilder::Constant(_) => vec![],
-            WitnessBuilder::Acir(..) => vec![],
+            WitnessBuilder::Constant(_)
+            | WitnessBuilder::Acir(..)
+            | WitnessBuilder::Challenge(_) => vec![],
             WitnessBuilder::Sum(_, ops) => ops.iter().map(|SumTerm(_, idx)| *idx).collect(),
             WitnessBuilder::Product(_, a, b) => vec![*a, *b],
             WitnessBuilder::MultiplicitiesForRange(_, _, values) => values.clone(),
-            WitnessBuilder::Challenge(_) => vec![],
+            WitnessBuilder::Inverse(_, x) => vec![*x],
             WitnessBuilder::IndexedLogUpDenominator(
                 _,
                 sz,
@@ -140,7 +120,6 @@ impl<'a> LayerScheduler<'a> {
             ) => {
                 vec![*sz, *index, *rs, *value]
             }
-            WitnessBuilder::Inverse(_, x) => vec![*x],
             WitnessBuilder::ProductLinearOperation(
                 _,
                 ProductLinearTerm(x, ..),
@@ -167,18 +146,11 @@ impl<'a> LayerScheduler<'a> {
                     (sw.initial_values_start..sw.initial_values_start + sw.memory_length).collect();
                 for op in &sw.memory_operations {
                     match op {
-                        crate::witness::SpiceMemoryOperation::Load(addr, value, _rt) => {
-                            v.push(*addr);
-                            v.push(*value);
+                        crate::witness::SpiceMemoryOperation::Load(addr, value, _) => {
+                            v.extend([*addr, *value]);
                         }
-                        crate::witness::SpiceMemoryOperation::Store(
-                            addr,
-                            _old_value,
-                            new_value,
-                            _rt,
-                        ) => {
-                            v.push(*addr);
-                            v.push(*new_value);
+                        crate::witness::SpiceMemoryOperation::Store(addr, _, new_value, _) => {
+                            v.extend([*addr, *new_value]);
                         }
                     }
                 }
@@ -186,24 +158,20 @@ impl<'a> LayerScheduler<'a> {
             }
             WitnessBuilder::BinOpLookupDenominator(_, sz, rs, rs2, lhs, rhs, output) => {
                 let mut v = vec![*sz, *rs, *rs2];
-                let mut push_w = |c: &ConstantOrR1CSWitness| {
+                for c in [lhs, rhs, output] {
                     if let ConstantOrR1CSWitness::Witness(w) = c {
-                        v.push(*w)
+                        v.push(*w);
                     }
-                };
-                push_w(lhs);
-                push_w(rhs);
-                push_w(output);
+                }
                 v
             }
             WitnessBuilder::MultiplicitiesForBinOp(_, pairs) => {
-                let mut v = Vec::new();
+                let mut v = Vec::with_capacity(pairs.len() * 2);
                 for (lhs, rhs) in pairs {
-                    if let ConstantOrR1CSWitness::Witness(w) = lhs {
-                        v.push(*w);
-                    }
-                    if let ConstantOrR1CSWitness::Witness(w) = rhs {
-                        v.push(*w);
+                    for c in [lhs, rhs] {
+                        if let ConstantOrR1CSWitness::Witness(w) = c {
+                            v.push(*w);
+                        }
                     }
                 }
                 v
@@ -211,183 +179,196 @@ impl<'a> LayerScheduler<'a> {
         }
     }
 
-    /// Builds a dependency graph from witness builders.
-    ///
-    /// Returns (adjacency_list, in_degrees) where adjacency_list[\i] contains
-    /// all builders that depend on builder i, and in_degrees[\i] is the number
-    /// of dependencies for builder i.
-    fn build_dependency_graph(
-        witness_builders: &[WitnessBuilder],
-    ) -> (Vec<Vec<usize>>, Vec<usize>) {
-        let builder_count = witness_builders.len();
+    fn extract_writes(wb: &WitnessBuilder) -> Vec<usize> {
+        match wb {
+            WitnessBuilder::Constant(ConstantTerm(idx, _))
+            | WitnessBuilder::Acir(idx, _)
+            | WitnessBuilder::Sum(idx, _)
+            | WitnessBuilder::Product(idx, ..)
+            | WitnessBuilder::Challenge(idx)
+            | WitnessBuilder::IndexedLogUpDenominator(idx, ..)
+            | WitnessBuilder::Inverse(idx, _)
+            | WitnessBuilder::ProductLinearOperation(idx, ..)
+            | WitnessBuilder::LogUpDenominator(idx, ..)
+            | WitnessBuilder::SpiceMultisetFactor(idx, ..)
+            | WitnessBuilder::BinOpLookupDenominator(idx, ..) => vec![*idx],
 
-        // Map each witness index to the builder that produces it
-        let mut witness_producer: BTreeMap<usize, usize> = BTreeMap::new();
-        for (builder_idx, builder) in witness_builders.iter().enumerate() {
-            for witness_idx in Self::writes_of(builder) {
-                witness_producer.insert(witness_idx, builder_idx);
+            WitnessBuilder::MultiplicitiesForRange(start, range, _) => {
+                (*start..*start + *range).collect()
+            }
+            WitnessBuilder::DigitalDecomposition(dd) => {
+                (dd.first_witness_idx..dd.first_witness_idx + dd.num_witnesses).collect()
+            }
+            WitnessBuilder::SpiceWitnesses(sw) => {
+                (sw.first_witness_idx..sw.first_witness_idx + sw.num_witnesses).collect()
+            }
+            WitnessBuilder::MultiplicitiesForBinOp(start, ..) => {
+                let n = (2usize).pow(2 * (BINOP_ATOMIC_BITS as u32));
+                (*start..*start + n).collect()
             }
         }
+    }
+}
 
-        // Build adjacency list and count incoming edges
-        let mut adjacency_list: Vec<Vec<usize>> = vec![Vec::new(); builder_count];
-        let mut in_degrees: Vec<usize> = vec![0; builder_count];
+/// Optimized layer scheduler with minimal state and cached dependencies
+pub struct LayerScheduler<'a> {
+    witness_builders: &'a [WitnessBuilder],
+    deps:             DependencyInfo,
 
-        for (consumer_idx, builder) in witness_builders.iter().enumerate() {
-            for required_witness in Self::reads_of(builder) {
-                if let Some(&producer_idx) = witness_producer.get(&required_witness) {
-                    if producer_idx != consumer_idx {
-                        adjacency_list[producer_idx].push(consumer_idx);
-                        in_degrees[consumer_idx] += 1;
-                    }
-                }
-                // Note: witnesses without producers (ACIR inputs, constants)
-                // are implicitly available so we don't add
-                // dependencies for them
-            }
+    // Mutable processing state
+    frontier:  VecDeque<usize>,
+    processed: Vec<bool>,
+
+    // Layer construction
+    pre_layers:              Vec<Vec<usize>>,
+    inverse_batches:         Vec<Vec<usize>>,
+    current_pre_segment:     Vec<usize>,
+    pending_inverse_outputs: HashSet<usize>,
+    pending_inverses:        Vec<usize>,
+}
+
+impl<'a> LayerScheduler<'a> {
+    pub fn new(witness_builders: &'a [WitnessBuilder]) -> Self {
+        let deps = DependencyInfo::new(witness_builders);
+        let frontier = (0..witness_builders.len())
+            .filter(|&i| deps.in_degrees[i] == 0)
+            .collect();
+
+        Self {
+            witness_builders,
+            deps,
+            frontier,
+            processed: vec![false; witness_builders.len()],
+            pre_layers: Vec::new(),
+            inverse_batches: Vec::new(),
+            current_pre_segment: Vec::new(),
+            pending_inverse_outputs: HashSet::new(),
+            pending_inverses: Vec::new(),
         }
-
-        (adjacency_list, in_degrees)
     }
 
     pub fn build_layers(mut self) -> LayeredWitnessBuilders {
-        while self.processed_count < self.witness_builders.len() {
-            if !self.try_process_frontier() {
-                if self.has_pending_inverses() {
-                    self.flush_current_layer();
-                } else if !self.frontier.is_empty() {
-                    // This should not happen in a valid DAG
-                    self.handle_deadlock();
+        while !self.frontier.is_empty() || !self.pending_inverses.is_empty() {
+            if !self.process_current_frontier() {
+                if !self.pending_inverses.is_empty() {
+                    self.flush_layer();
                 } else {
-                    break; // All done
+                    break;
                 }
             }
         }
 
-        // Handle any remaining work
-        if !self.current_pre_segment.is_empty() || self.has_pending_inverses() {
-            self.flush_current_layer();
+        if !self.current_pre_segment.is_empty() || !self.pending_inverses.is_empty() {
+            self.flush_layer();
         }
 
-        self.build_final_plan()
+        self.build_result()
     }
 
-    /// Attempts to process the current frontier, returning true if progress was
-    /// made.
-    fn try_process_frontier(&mut self) -> bool {
-        let mut any_progress = false;
-        let mut deferred_builders = VecDeque::new();
-        let frontier_size = self.frontier.len();
+    fn process_current_frontier(&mut self) -> bool {
+        let initial_frontier_size = self.frontier.len();
+        let mut deferred = VecDeque::new();
 
-        // Process each builder in the current frontier
-        for _ in 0..frontier_size {
-            let builder_idx = self.frontier.pop_front().unwrap();
-            if self.processed[builder_idx] {
+        // Process all ready nodes
+        while let Some(node_idx) = self.frontier.pop_front() {
+            if self.processed[node_idx] {
                 continue;
             }
 
-            if self.can_process_builder(builder_idx) {
-                self.process_builder(builder_idx);
-                any_progress = true;
+            if self.can_process_now(node_idx) {
+                self.process_node(node_idx);
             } else {
-                deferred_builders.push_back(builder_idx);
+                deferred.push_back(node_idx);
             }
         }
 
-        // Restore deferred builders to frontier
-        self.frontier.extend(deferred_builders);
-        any_progress
+        // Restore deferred nodes
+        self.frontier = deferred;
+
+        // Return true if we made progress
+        self.frontier.len() < initial_frontier_size
     }
 
-    /// Checks if a builder can be processed in the current PRE segment.
-    fn can_process_builder(&self, builder_idx: usize) -> bool {
-        // Check if this builder reads any pending inverse outputs
-        let reads_pending_inverse = Self::reads_of(&self.witness_builders[builder_idx])
+    #[inline]
+    fn can_process_now(&self, node_idx: usize) -> bool {
+        // Quick check: does this node read any pending inverse outputs?
+        !self.deps.reads[node_idx]
             .iter()
-            .any(|witness| self.pending_inverse_outputs.contains(witness));
-
-        !reads_pending_inverse
+            .any(|&witness| self.pending_inverse_outputs.contains(&witness))
     }
 
-    /// Processes a single builder, either adding to PRE segment or collecting
-    /// for inversion.
-    fn process_builder(&mut self, builder_idx: usize) {
-        match &self.witness_builders[builder_idx] {
-            WitnessBuilder::Inverse(out_witness, denom_witness) => {
-                // Collect inverse for batching
-                self.pending_inverse_nodes.push(builder_idx);
-                self.pending_inverse_builders
-                    .push(WitnessBuilder::Inverse(*out_witness, *denom_witness));
+    fn process_node(&mut self, node_idx: usize) {
+        match &self.witness_builders[node_idx] {
+            WitnessBuilder::Inverse(out_witness, _) => {
+                // Defer inverse for batching
+                self.pending_inverses.push(node_idx);
                 self.pending_inverse_outputs.insert(*out_witness);
             }
             _ => {
-                // Add to current PRE segment
-                self.current_pre_segment.push(builder_idx);
-                self.mark_processed(builder_idx);
+                // Process immediately
+                self.current_pre_segment.push(node_idx);
+                self.mark_processed(node_idx);
             }
         }
     }
 
-    /// Marks a builder as processed and updates the dependency graph.
-    fn mark_processed(&mut self, builder_idx: usize) {
-        self.processed[builder_idx] = true;
-        self.processed_count += 1;
+    fn mark_processed(&mut self, node_idx: usize) {
+        self.processed[node_idx] = true;
 
-        // Update dependencies and frontier
-        for &dependent_idx in &self.adjacency_list[builder_idx] {
-            self.in_degrees[dependent_idx] -= 1;
-            if self.in_degrees[dependent_idx] == 0 {
-                self.frontier.push_back(dependent_idx);
+        // Unlock dependent nodes
+        let dependents = self.deps.adjacency_list[node_idx].clone();
+        for dependent in dependents {
+            self.deps.in_degrees[dependent] -= 1;
+            if self.deps.in_degrees[dependent] == 0 {
+                self.frontier.push_back(dependent);
             }
         }
     }
 
-    /// Flushes the current PRE segment and inverse batch, then processes
-    /// pending inverses.
-    fn flush_current_layer(&mut self) {
-        // Emit current PRE segment and inverse batch
+    fn flush_layer(&mut self) {
+        // Save current segments
         self.pre_layers
             .push(mem::take(&mut self.current_pre_segment));
-        self.inverse_batches
-            .push(mem::take(&mut self.pending_inverse_builders));
-        self.pending_inverse_outputs.clear();
+        let inverse_batch = mem::take(&mut self.pending_inverses);
 
-        // Process all pending inverse nodes to unlock their dependencies
-        let pending_nodes: Vec<usize> = self.pending_inverse_nodes.drain(..).collect();
-        for inverse_idx in pending_nodes {
+        // Process pending inverses to unlock dependencies
+        for &inverse_idx in &inverse_batch {
             if !self.processed[inverse_idx] {
                 self.mark_processed(inverse_idx);
             }
         }
+
+        self.inverse_batches.push(inverse_batch);
+        self.pending_inverse_outputs.clear();
     }
 
-    fn has_pending_inverses(&self) -> bool {
-        !self.pending_inverse_builders.is_empty()
-    }
+    fn build_result(self) -> LayeredWitnessBuilders {
+        let mut builders = Vec::new();
+        let mut pre_starts = Vec::with_capacity(self.pre_layers.len());
+        let mut inverse_starts = Vec::with_capacity(self.inverse_batches.len());
 
-    fn handle_deadlock(&self) -> ! {
-        panic!(
-            "Layer scheduling deadlock: {} builders remain unprocessed with no valid progress path",
-            self.witness_builders.len() - self.processed_count
-        );
-    }
+        for (pre_layer, inverse_batch) in self.pre_layers.iter().zip(&self.inverse_batches) {
+            // Mark pre-segment start
+            pre_starts.push(builders.len());
 
-    /// Builds the final LayeredWitnessBuilders from the computed layers.
-    fn build_final_plan(self) -> LayeredWitnessBuilders {
-        let mut pre_builders = Vec::new();
-        let mut pre_segment_starts = Vec::with_capacity(self.pre_layers.len());
-
-        for pre_layer in &self.pre_layers {
-            pre_segment_starts.push(pre_builders.len());
+            // Add pre-builders
             for &builder_idx in pre_layer {
-                pre_builders.push(self.witness_builders[builder_idx].clone());
+                builders.push(self.witness_builders[builder_idx].clone());
+            }
+
+            // Mark inverse-segment start
+            inverse_starts.push(builders.len());
+
+            // Add inverse builders
+            for &inverse_idx in inverse_batch {
+                builders.push(self.witness_builders[inverse_idx].clone());
             }
         }
 
         LayeredWitnessBuilders {
-            pre_builders,
-            pre_segment_starts,
-            inverse_batches: self.inverse_batches,
+            builders,
+            pre_starts,
+            inverse_starts,
         }
     }
 }

--- a/provekit/common/src/witness/layer_scheduler.rs
+++ b/provekit/common/src/witness/layer_scheduler.rs
@@ -301,9 +301,9 @@ impl<'a> LayerScheduler<'a> {
 
     /// Checks if a builder can be processed in the current PRE segment.
     fn can_process_builder(&self, builder_idx: usize) -> bool {
-                // Check if this builder reads any pending inverse outputs
+        // Check if this builder reads any pending inverse outputs
         let reads_pending_inverse = Self::reads_of(&self.witness_builders[builder_idx])
-                    .iter()
+            .iter()
             .any(|witness| self.pending_inverse_outputs.contains(witness));
 
         !reads_pending_inverse

--- a/provekit/common/src/witness/layer_scheduler.rs
+++ b/provekit/common/src/witness/layer_scheduler.rs
@@ -1,8 +1,13 @@
 use {
-    super::WitnessBuilder, crate::witness::{ConstantOrR1CSWitness, ConstantTerm, ProductLinearTerm, SumTerm, WitnessCoefficient, BINOP_ATOMIC_BITS}, std::{
+    super::WitnessBuilder,
+    crate::witness::{
+        ConstantOrR1CSWitness, ConstantTerm, ProductLinearTerm, SumTerm, WitnessCoefficient,
+        BINOP_ATOMIC_BITS,
+    },
+    std::{
         collections::{BTreeMap, BTreeSet, VecDeque},
         mem,
-    }
+    },
 };
 
 /// Layered plan for serial batched-inversion solving.

--- a/provekit/common/src/witness/layer_scheduler.rs
+++ b/provekit/common/src/witness/layer_scheduler.rs
@@ -241,6 +241,9 @@ impl<'a> LayerScheduler<'a> {
                         in_degrees[consumer_idx] += 1;
                     }
                 }
+                // Note: witnesses without producers (ACIR inputs, constants)
+                // are implicitly available so we don't add
+                // dependencies for them
             }
         }
 
@@ -298,15 +301,12 @@ impl<'a> LayerScheduler<'a> {
 
     /// Checks if a builder can be processed in the current PRE segment.
     fn can_process_builder(&self, builder_idx: usize) -> bool {
-        match &self.witness_builders[builder_idx] {
-            WitnessBuilder::Inverse(..) => false, // Always defer inverses
-            _ => {
                 // Check if this builder reads any pending inverse outputs
-                !Self::reads_of(&self.witness_builders[builder_idx])
+        let reads_pending_inverse = Self::reads_of(&self.witness_builders[builder_idx])
                     .iter()
-                    .any(|witness| self.pending_inverse_outputs.contains(witness))
-            }
-        }
+            .any(|witness| self.pending_inverse_outputs.contains(witness));
+
+        !reads_pending_inverse
     }
 
     /// Processes a single builder, either adding to PRE segment or collecting

--- a/provekit/common/src/witness/layer_scheduler.rs
+++ b/provekit/common/src/witness/layer_scheduler.rs
@@ -4,76 +4,86 @@ use {
         ConstantOrR1CSWitness, ConstantTerm, ProductLinearTerm, SumTerm, WitnessCoefficient,
         BINOP_ATOMIC_BITS,
     },
+    serde::{Deserialize, Serialize},
     std::{
         collections::{HashMap, HashSet, VecDeque},
         mem,
     },
 };
 
-/// Layered plan for serial batched-inversion solving.
+/// Type of operations contained in a layer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum LayerType {
+    /// Regular operations (non-inverse).
+    Other,
+    /// Field inversion operations that should be batch computed.
+    Inverse,
+}
+
+/// A single layer in the execution plan.
 ///
-/// Optimized single-array design:
-/// - `builders` contains ALL builders in execution order: [pre1, pre2, ...,
-///   inv1, inv2, ..., pre3, ...]
-/// - For layer i: PRE slice is `builders[pre_starts[i] .. inverse_starts[i]]`
-/// - For layer i: INVERSE slice is `builders[inverse_starts[i] ..
-///   pre_starts[i+1] or end]`
-/// - Perfect cache locality: execution order = memory order
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+/// Each layer groups witness builders that should be executed together,
+/// either as regular operations or as a batch of field inversions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Layer {
+    /// The witness builders to execute in this layer.
+    pub witness_builders: Vec<WitnessBuilder>,
+    /// The type of operations in this layer.
+    pub typ:              LayerType,
+}
+
+/// Execution plan for witness computation with batched field inversions.
+///
+/// Organizes witness builders into layers where layers alternate between:
+/// 1. Regular operations (LayerType::Other)
+/// 2. Batched inverse operations (LayerType::Inverse)
+///
+/// This enables Montgomery's batch inversion trick: instead of computing n
+/// individual field inversions (expensive), we compute them in a batch using
+/// only 1 inversion and 3n multiplications.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LayeredWitnessBuilders {
-    pub builders:       Vec<WitnessBuilder>,
-    pub pre_starts:     Vec<usize>,
-    pub inverse_starts: Vec<usize>,
+    /// The layers of witness builders in execution order.
+    pub layers: Vec<Layer>,
 }
 
 impl LayeredWitnessBuilders {
+    /// Returns the total number of layers.
     pub fn layers_len(&self) -> usize {
-        self.pre_starts.len()
-    }
-
-    /// Returns pre-builders for the specified layer
-    pub fn pre_builders(&self, layer_idx: usize) -> &[WitnessBuilder] {
-        let start = self.pre_starts[layer_idx];
-        let end = self.inverse_starts[layer_idx];
-        &self.builders[start..end]
-    }
-
-    /// Returns inverse-builders for the specified layer
-    pub fn inverse_builders(&self, layer_idx: usize) -> &[WitnessBuilder] {
-        let start = self.inverse_starts[layer_idx];
-        let end = self
-            .pre_starts
-            .get(layer_idx + 1)
-            .copied()
-            .unwrap_or(self.builders.len());
-        &self.builders[start..end]
-    }
-
-    /// Legacy compatibility - returns (start, end) range for pre-builders
-    #[deprecated(note = "Use pre_builders() instead")]
-    pub fn layer_range(&self, layer_idx: usize) -> (usize, usize) {
-        let start = self.pre_starts[layer_idx];
-        let end = self.inverse_starts[layer_idx];
-        (start, end)
+        self.layers.len()
     }
 }
 
-/// Cached dependency information for efficient processing
+/// Pre-computed dependency graph for witness builder scheduling.
+///
+/// Caches three key pieces of information to avoid repeated traversals:
+/// - Which witness indices each builder reads (inputs)
+/// - Which builders depend on each builder's outputs (graph edges)
+/// - How many dependencies each builder has (in-degree for topological sort)
 #[derive(Debug)]
 struct DependencyInfo {
+    /// For each builder: the witness indices it reads.
     reads:          Vec<Vec<usize>>,
+    /// For each builder: the builders that depend on its outputs.
     adjacency_list: Vec<Vec<usize>>,
+    /// For each builder: the number of unprocessed dependencies (in-degree).
     in_degrees:     Vec<usize>,
 }
 
 impl DependencyInfo {
+    /// Constructs the dependency graph by analyzing all witness builders.
+    ///
+    /// This performs three passes:
+    /// 1. Extract which witnesses each builder reads
+    /// 2. Map each witness to its producer builder
+    /// 3. Build adjacency list and compute in-degrees for topological sorting
     fn new(witness_builders: &[WitnessBuilder]) -> Self {
         let builder_count = witness_builders.len();
 
-        // Pre-compute all dependency information once
+        // Pass 1: Extract read dependencies for each builder
         let reads: Vec<Vec<usize>> = witness_builders.iter().map(Self::extract_reads).collect();
 
-        // Build dependency graph using cached reads
+        // Pass 2: Build witness-to-producer mapping
         let mut witness_producer = HashMap::with_capacity(builder_count * 2);
         for (builder_idx, builder) in witness_builders.iter().enumerate() {
             for witness_idx in Self::extract_writes(builder) {
@@ -81,6 +91,7 @@ impl DependencyInfo {
             }
         }
 
+        // Pass 3: Construct dependency edges
         let mut adjacency_list = vec![Vec::new(); builder_count];
         let mut in_degrees = vec![0; builder_count];
 
@@ -102,6 +113,7 @@ impl DependencyInfo {
         }
     }
 
+    /// Extracts the witness indices that a builder reads as inputs.
     fn extract_reads(wb: &WitnessBuilder) -> Vec<usize> {
         match wb {
             WitnessBuilder::Constant(_)
@@ -179,6 +191,7 @@ impl DependencyInfo {
         }
     }
 
+    /// Extracts the witness indices that a builder writes as outputs.
     fn extract_writes(wb: &WitnessBuilder) -> Vec<usize> {
         match wb {
             WitnessBuilder::Constant(ConstantTerm(idx, _))
@@ -210,24 +223,45 @@ impl DependencyInfo {
     }
 }
 
-/// Optimized layer scheduler with minimal state and cached dependencies
+/// Schedules witness builders into layers using topological sorting.
+///
+/// The scheduler performs a modified BFS traversal of the dependency graph,
+/// grouping operations into layers. Each layer consists of:
+/// 1. Regular operations that can be computed in any order (pre-builders)
+/// 2. Inverse operations that should be batched together (inverse-builders)
+///
+/// The key optimization: when we encounter an inverse operation, we defer it
+/// and continue processing other ready operations. This maximizes the batch
+/// size for expensive field inversions. We only flush a layer when no more
+/// regular operations are ready and inverses are blocking progress.
 pub struct LayerScheduler<'a> {
     witness_builders: &'a [WitnessBuilder],
     deps:             DependencyInfo,
 
-    // Mutable processing state
+    // Topological sort state
+    /// Builders that are ready to process (all dependencies satisfied).
     frontier:  VecDeque<usize>,
+    /// Tracks which builders have been processed.
     processed: Vec<bool>,
 
-    // Layer construction
+    // Layer accumulation state
+    /// Completed layers of pre-builders.
     pre_layers:              Vec<Vec<usize>>,
+    /// Completed batches of inverse-builders.
     inverse_batches:         Vec<Vec<usize>>,
+    /// Pre-builders for the current layer being constructed.
     current_pre_segment:     Vec<usize>,
+    /// Witness indices that are outputs of pending inverses.
     pending_inverse_outputs: HashSet<usize>,
+    /// Inverse builders waiting to be flushed as a batch.
     pending_inverses:        Vec<usize>,
 }
 
 impl<'a> LayerScheduler<'a> {
+    /// Initializes the scheduler with the dependency graph and frontier.
+    ///
+    /// The frontier starts with all builders that have no dependencies
+    /// (in-degree 0).
     pub fn new(witness_builders: &'a [WitnessBuilder]) -> Self {
         let deps = DependencyInfo::new(witness_builders);
         let frontier = (0..witness_builders.len())
@@ -247,9 +281,16 @@ impl<'a> LayerScheduler<'a> {
         }
     }
 
+    /// Executes the scheduling algorithm and returns the layered execution
+    /// plan.
+    ///
+    /// Main loop: process ready builders from the frontier, deferring inverses.
+    /// When progress stalls, flush pending inverses as a batch to unblock the
+    /// next layer. Continue until all builders are scheduled.
     pub fn build_layers(mut self) -> LayeredWitnessBuilders {
         while !self.frontier.is_empty() || !self.pending_inverses.is_empty() {
             if !self.process_current_frontier() {
+                // No progress made; flush inverses to unblock
                 if !self.pending_inverses.is_empty() {
                     self.flush_layer();
                 } else {
@@ -258,6 +299,7 @@ impl<'a> LayerScheduler<'a> {
             }
         }
 
+        // Handle any remaining work
         if !self.current_pre_segment.is_empty() || !self.pending_inverses.is_empty() {
             self.flush_layer();
         }
@@ -265,11 +307,15 @@ impl<'a> LayerScheduler<'a> {
         self.build_result()
     }
 
+    /// Processes all builders in the current frontier, deferring those blocked
+    /// by pending inverse outputs.
+    ///
+    /// Returns true if progress was made (at least one builder was processed).
     fn process_current_frontier(&mut self) -> bool {
         let initial_frontier_size = self.frontier.len();
         let mut deferred = VecDeque::new();
 
-        // Process all ready nodes
+        // Try to process each ready builder
         while let Some(node_idx) = self.frontier.pop_front() {
             if self.processed[node_idx] {
                 continue;
@@ -278,25 +324,31 @@ impl<'a> LayerScheduler<'a> {
             if self.can_process_now(node_idx) {
                 self.process_node(node_idx);
             } else {
+                // Must wait for pending inverses
                 deferred.push_back(node_idx);
             }
         }
 
-        // Restore deferred nodes
+        // Put deferred builders back in the frontier
         self.frontier = deferred;
 
         // Return true if we made progress
         self.frontier.len() < initial_frontier_size
     }
 
+    /// Checks if a builder can be processed now, or if it must wait for
+    /// pending inverse operations to complete.
     #[inline]
     fn can_process_now(&self, node_idx: usize) -> bool {
-        // Quick check: does this node read any pending inverse outputs?
+        // Cannot process if it depends on a witness that will be produced by
+        // a pending inverse (those inverses haven't been flushed yet)
         !self.deps.reads[node_idx]
             .iter()
             .any(|&witness| self.pending_inverse_outputs.contains(&witness))
     }
 
+    /// Processes a single builder: inverses are deferred for batching,
+    /// others are added to the current layer immediately.
     fn process_node(&mut self, node_idx: usize) {
         match &self.witness_builders[node_idx] {
             WitnessBuilder::Inverse(out_witness, _) => {
@@ -305,17 +357,19 @@ impl<'a> LayerScheduler<'a> {
                 self.pending_inverse_outputs.insert(*out_witness);
             }
             _ => {
-                // Process immediately
+                // Add to current layer and mark as processed
                 self.current_pre_segment.push(node_idx);
                 self.mark_processed(node_idx);
             }
         }
     }
 
+    /// Marks a builder as processed and unlocks any builders that were waiting
+    /// for its outputs.
     fn mark_processed(&mut self, node_idx: usize) {
         self.processed[node_idx] = true;
 
-        // Unlock dependent nodes
+        // Decrement in-degree for all dependents and add to frontier if ready
         let dependents = self.deps.adjacency_list[node_idx].clone();
         for dependent in dependents {
             self.deps.in_degrees[dependent] -= 1;
@@ -325,13 +379,18 @@ impl<'a> LayerScheduler<'a> {
         }
     }
 
+    /// Completes the current layer by saving pre-builders and inverse batches.
+    ///
+    /// This marks all pending inverses as processed, which unlocks any builders
+    /// that were waiting for their outputs. This enables the next layer to
+    /// proceed.
     fn flush_layer(&mut self) {
-        // Save current segments
+        // Save the current pre-builders and inverse batch
         self.pre_layers
             .push(mem::take(&mut self.current_pre_segment));
         let inverse_batch = mem::take(&mut self.pending_inverses);
 
-        // Process pending inverses to unlock dependencies
+        // Mark all inverses as processed to unlock dependent builders
         for &inverse_idx in &inverse_batch {
             if !self.processed[inverse_idx] {
                 self.mark_processed(inverse_idx);
@@ -342,33 +401,39 @@ impl<'a> LayerScheduler<'a> {
         self.pending_inverse_outputs.clear();
     }
 
+    /// Assembles the final layered structure from the accumulated layers.
+    ///
+    /// Creates alternating layers of regular operations and inverse batches,
+    /// skipping any empty layers.
     fn build_result(self) -> LayeredWitnessBuilders {
-        let mut builders = Vec::new();
-        let mut pre_starts = Vec::with_capacity(self.pre_layers.len());
-        let mut inverse_starts = Vec::with_capacity(self.inverse_batches.len());
+        let mut layers = Vec::new();
 
         for (pre_layer, inverse_batch) in self.pre_layers.iter().zip(&self.inverse_batches) {
-            // Mark pre-segment start
-            pre_starts.push(builders.len());
-
-            // Add pre-builders
-            for &builder_idx in pre_layer {
-                builders.push(self.witness_builders[builder_idx].clone());
+            // Add pre-builders layer if non-empty
+            if !pre_layer.is_empty() {
+                let witness_builders = pre_layer
+                    .iter()
+                    .map(|&builder_idx| self.witness_builders[builder_idx].clone())
+                    .collect();
+                layers.push(Layer {
+                    witness_builders,
+                    typ: LayerType::Other,
+                });
             }
 
-            // Mark inverse-segment start
-            inverse_starts.push(builders.len());
-
-            // Add inverse builders
-            for &inverse_idx in inverse_batch {
-                builders.push(self.witness_builders[inverse_idx].clone());
+            // Add inverse batch layer if non-empty
+            if !inverse_batch.is_empty() {
+                let witness_builders = inverse_batch
+                    .iter()
+                    .map(|&inverse_idx| self.witness_builders[inverse_idx].clone())
+                    .collect();
+                layers.push(Layer {
+                    witness_builders,
+                    typ: LayerType::Inverse,
+                });
             }
         }
 
-        LayeredWitnessBuilders {
-            builders,
-            pre_starts,
-            inverse_starts,
-        }
+        LayeredWitnessBuilders { layers }
     }
 }

--- a/provekit/common/src/witness/mod.rs
+++ b/provekit/common/src/witness/mod.rs
@@ -1,5 +1,6 @@
 mod binops;
 mod digits;
+mod layer_scheduler;
 mod ram;
 mod witness_builder;
 mod witness_generator;
@@ -12,6 +13,7 @@ use {
 pub use {
     binops::{BINOP_ATOMIC_BITS, BINOP_BITS, NUM_DIGITS},
     digits::{decompose_into_digits, DigitalDecompositionWitnesses},
+    layer_scheduler::LayeredWitnessBuilders,
     ram::{SpiceMemoryOperation, SpiceWitnesses},
     witness_builder::{
         ConstantTerm, ProductLinearTerm, SumTerm, WitnessBuilder, WitnessCoefficient,

--- a/provekit/common/src/witness/mod.rs
+++ b/provekit/common/src/witness/mod.rs
@@ -13,7 +13,7 @@ use {
 pub use {
     binops::{BINOP_ATOMIC_BITS, BINOP_BITS, NUM_DIGITS},
     digits::{decompose_into_digits, DigitalDecompositionWitnesses},
-    layer_scheduler::LayeredWitnessBuilders,
+    layer_scheduler::{Layer, LayerType, LayeredWitnessBuilders},
     ram::{SpiceMemoryOperation, SpiceWitnesses},
     witness_builder::{
         ConstantTerm, ProductLinearTerm, SumTerm, WitnessBuilder, WitnessCoefficient,

--- a/provekit/common/src/witness/witness_builder.rs
+++ b/provekit/common/src/witness/witness_builder.rs
@@ -2,7 +2,10 @@ use {
     crate::{
         utils::{serde_ark, serde_ark_option},
         witness::{
-            binops::BINOP_ATOMIC_BITS, digits::DigitalDecompositionWitnesses, ram::SpiceWitnesses,
+            binops::BINOP_ATOMIC_BITS,
+            digits::DigitalDecompositionWitnesses,
+            layer_scheduler::{LayerScheduler, LayeredWitnessBuilders},
+            ram::SpiceWitnesses,
             ConstantOrR1CSWitness,
         },
         FieldElement,
@@ -123,5 +126,22 @@ impl WitnessBuilder {
             WitnessBuilder::MultiplicitiesForBinOp(..) => 2usize.pow(2 * BINOP_ATOMIC_BITS as u32),
             _ => 1,
         }
+    }
+
+    /// Constructs a layered execution plan optimized for batch inversion.
+    ///
+    /// Uses frontier-based scheduling to group operations and minimize
+    /// expensive field inversions via Montgomery's batch inversion trick.
+    pub fn prepare_layers(witness_builders: &[WitnessBuilder]) -> LayeredWitnessBuilders {
+        if witness_builders.is_empty() {
+            return LayeredWitnessBuilders {
+                pre_builders:       Vec::new(),
+                pre_segment_starts: Vec::new(),
+                inverse_batches:    Vec::new(),
+            };
+        }
+
+        let scheduler = LayerScheduler::new(witness_builders);
+        scheduler.build_layers()
     }
 }

--- a/provekit/common/src/witness/witness_builder.rs
+++ b/provekit/common/src/witness/witness_builder.rs
@@ -134,11 +134,7 @@ impl WitnessBuilder {
     /// expensive field inversions via Montgomery's batch inversion trick.
     pub fn prepare_layers(witness_builders: &[WitnessBuilder]) -> LayeredWitnessBuilders {
         if witness_builders.is_empty() {
-            return LayeredWitnessBuilders {
-                builders:       Vec::new(),
-                pre_starts:     Vec::new(),
-                inverse_starts: Vec::new(),
-            };
+            return LayeredWitnessBuilders { layers: Vec::new() };
         }
 
         let scheduler = LayerScheduler::new(witness_builders);

--- a/provekit/common/src/witness/witness_builder.rs
+++ b/provekit/common/src/witness/witness_builder.rs
@@ -135,9 +135,9 @@ impl WitnessBuilder {
     pub fn prepare_layers(witness_builders: &[WitnessBuilder]) -> LayeredWitnessBuilders {
         if witness_builders.is_empty() {
             return LayeredWitnessBuilders {
-                pre_builders:       Vec::new(),
-                pre_segment_starts: Vec::new(),
-                inverse_batches:    Vec::new(),
+                builders:       Vec::new(),
+                pre_starts:     Vec::new(),
+                inverse_starts: Vec::new(),
             };
         }
 

--- a/provekit/prover/src/noir_proof_scheme.rs
+++ b/provekit/prover/src/noir_proof_scheme.rs
@@ -70,7 +70,7 @@ impl NoirProofSchemeProver for NoirProofScheme {
         self.seed_witness_merlin(&mut witness_merlin, &acir_witness_idx_to_value_map)?;
 
         let partial_witness = self.r1cs.solve_witness_vec(
-            &self.witness_builders,
+            &self.layered_witness_builders,
             &acir_witness_idx_to_value_map,
             &mut witness_merlin,
         );
@@ -95,7 +95,8 @@ impl NoirProofSchemeProver for NoirProofScheme {
         let circuit = &self.program.functions[0];
         let public_idxs = circuit.public_inputs().indices();
         let num_challenges = self
-            .witness_builders
+            .layered_witness_builders
+            .pre_builders
             .iter()
             .filter(|b| matches!(b, WitnessBuilder::Challenge(_)))
             .count();

--- a/provekit/prover/src/noir_proof_scheme.rs
+++ b/provekit/prover/src/noir_proof_scheme.rs
@@ -96,8 +96,9 @@ impl NoirProofSchemeProver for NoirProofScheme {
         let public_idxs = circuit.public_inputs().indices();
         let num_challenges = self
             .layered_witness_builders
-            .builders
+            .layers
             .iter()
+            .flat_map(|layer| &layer.witness_builders)
             .filter(|b| matches!(b, WitnessBuilder::Challenge(_)))
             .count();
 

--- a/provekit/prover/src/noir_proof_scheme.rs
+++ b/provekit/prover/src/noir_proof_scheme.rs
@@ -96,7 +96,7 @@ impl NoirProofSchemeProver for NoirProofScheme {
         let public_idxs = circuit.public_inputs().indices();
         let num_challenges = self
             .layered_witness_builders
-            .pre_builders
+            .builders
             .iter()
             .filter(|b| matches!(b, WitnessBuilder::Challenge(_)))
             .count();

--- a/provekit/prover/src/r1cs.rs
+++ b/provekit/prover/src/r1cs.rs
@@ -53,16 +53,15 @@ impl R1CSSolver for R1CS {
     ) -> Vec<Option<FieldElement>> {
         let mut witness = vec![None; self.num_witnesses()];
 
-        for segment_index in 0..plan.layers_len() {
+        for layer_idx in 0..plan.layers_len() {
             // Execute PRE segment (non-inverse builders)
-            let (start, end) = plan.layer_range(segment_index);
-            let pre_builders = &plan.pre_builders[start..end];
+            let pre_builders = plan.pre_builders(layer_idx);
             for builder in pre_builders {
                 builder.solve(acir_map, &mut witness, transcript);
             }
 
             // Execute inverse batch using Montgomery batch inversion
-            let inverse_batch = &plan.inverse_batches[segment_index];
+            let inverse_batch = plan.inverse_builders(layer_idx);
             if !inverse_batch.is_empty() {
                 let batch_size = inverse_batch.len();
                 let mut output_witnesses = Vec::with_capacity(batch_size);

--- a/provekit/prover/src/witness/witness_builder.rs
+++ b/provekit/prover/src/witness/witness_builder.rs
@@ -61,9 +61,8 @@ impl WitnessBuilderSolver for WitnessBuilder {
                 let b: FieldElement = witness[*operand_idx_b].unwrap();
                 witness[*witness_idx] = Some(a * b);
             }
-            WitnessBuilder::Inverse(witness_idx, operand_idx) => {
-                let operand: FieldElement = witness[*operand_idx].unwrap();
-                witness[*witness_idx] = Some(operand.inverse().unwrap());
+            WitnessBuilder::Inverse(..) => {
+                unreachable!("Inverse should not be called")
             }
             WitnessBuilder::IndexedLogUpDenominator(
                 witness_idx,

--- a/provekit/r1cs-compiler/src/noir_proof_scheme.rs
+++ b/provekit/r1cs-compiler/src/noir_proof_scheme.rs
@@ -6,7 +6,9 @@ use {
     anyhow::{ensure, Context as _, Result},
     noirc_artifacts::program::ProgramArtifact,
     provekit_common::{
-        utils::PrintAbi, witness::NoirWitnessGenerator, NoirProofScheme, WhirR1CSScheme,
+        utils::PrintAbi,
+        witness::{NoirWitnessGenerator, WitnessBuilder},
+        NoirProofScheme, WhirR1CSScheme,
     },
     std::{fs::File, path::Path},
     tracing::{info, instrument},
@@ -58,6 +60,7 @@ impl NoirProofSchemeBuilder for NoirProofScheme {
             r1cs.b.num_entries(),
             r1cs.c.num_entries()
         );
+        let layered_witness_builders = WitnessBuilder::prepare_layers(&witness_builders);
 
         // Configure witness generator
         let witness_generator =
@@ -69,7 +72,7 @@ impl NoirProofSchemeBuilder for NoirProofScheme {
         Ok(Self {
             program: program.bytecode,
             r1cs,
-            witness_builders,
+            layered_witness_builders,
             witness_generator,
             whir_for_witness,
         })
@@ -111,7 +114,7 @@ mod tests {
         let proof_schema = NoirProofScheme::from_file(path).unwrap();
 
         test_serde(&proof_schema.r1cs);
-        test_serde(&proof_schema.witness_builders);
+        test_serde(&proof_schema.layered_witness_builders);
         test_serde(&proof_schema.witness_generator);
         test_serde(&proof_schema.whir_for_witness);
     }


### PR DESCRIPTION
## Description
Optimizes witness solving by grouping operations into layers and batching field inversions. Reduces N expensive field inversions to 1 inversion + 3N multiplications using [Montgomery's trick](https://medium.com/eryxcoop/montgomerys-trick-for-batch-galois-field-inversion-9b6d0f399da2).

## Implementation
1. **Dependency Analysis**: Build DAG from witness read/write relationships
2. **Layered Scheduling**: Use topological sort to group non-inverse operations into segments
3. **Deferred Inversion**: Collect inverse operations and batch them using Montgomery's trick
4. **Execution**: Alternate between PRE segments (non-inverse ops) and inverse batches

## Key Components
- LayerScheduler: Frontier-based algorithm to compute optimal execution layers
- LayeredWitnessBuilders: Execution plan with PRE segments + inverse batches
- batch_inverse_montgomery: Mathematical optimization for field inversions
- solve_witness_vec: New execution engine that processes layered plans

## Files Changed
- Added `layer_scheduler.rs` - Core scheduling algorithm
- Updated `witness_builder.rs` - Dependency analysis utilities
- Updated `r1cs.rs` - Layered execution engine
- Updated `utils/mod.rs` - Montgomery batch inversion
- Updated `noir_proof_scheme.rs` - Integration into compilation
