### PR TITLE
Ignore bin_ops constraints if there are no bin ops

### DIFF
--- a/provekit/r1cs-compiler/src/binops.rs
+++ b/provekit/r1cs-compiler/src/binops.rs
@@ -31,6 +31,9 @@ pub(crate) fn add_binop(
 ) {
     let log_bases = vec![BINOP_ATOMIC_BITS; NUM_DIGITS];
 
+    if inputs_and_outputs.is_empty() {
+        return;
+    }
     // Collect all witnesses that require digital decomposition (constants are
     // decomposed separately).
     let mut witnesses_to_decompose = vec![];

--- a/provekit/r1cs-compiler/src/whir_r1cs.rs
+++ b/provekit/r1cs-compiler/src/whir_r1cs.rs
@@ -42,7 +42,7 @@ impl WhirR1CSSchemeBuilder for WhirR1CSScheme {
             initial_statement: true,
             security_level: 128,
             pow_bits: default_max_pow(num_variables, 1),
-            folding_factor: FoldingFactor::Constant(4),
+            folding_factor: FoldingFactor::Constant(1),
             leaf_hash_params: (),
             two_to_one_params: (),
             soundness_type: SoundnessType::ConjectureList,


### PR DESCRIPTION
On basic-2 example:

Before: 

```│ ├─╮ provekit_r1cs_compiler::noir_proof_scheme::from_program start: 42.8 kB current, 118 allocations
│ │ │ 52.9 μs INFO Program noir version: 1.0.0-beta.11+fd3925aaaeb76c76319f44590d135498ef41ea6c
│ │ │ 98.8 μs INFO Program entry point: fn main(a: Field, b: Field, c: Field, d: Field);
│ │ │  107 μs INFO ACIR: 3 witnesses, 1 opcodes.
│ │ │ 89.9 ms INFO R1CS 393225 constraints, 524303 witnesses, A 524293 entries, B 393225 entries, C 786443 entries
```

after

```
│ │ │ 38.2 μs INFO Program noir version: 1.0.0-beta.11+fd3925aaaeb76c76319f44590d135498ef41ea6c
│ │ │ 69.2 μs INFO Program entry point: fn main(a: Field, b: Field, c: Field, d: Field);
│ │ │ 72.7 μs INFO ACIR: 3 witnesses, 1 opcodes.
and_ops: []
xor_ops: []
│ │ │  245 μs INFO R1CS 1 constraints, 5 witnesses, A 1 entries, B 1 entries, C 3 entries
```

but it needs some more work since for small Noir circuits it will bug out on the prove operation.