### PR TITLE
refactor: Migrate from .nps to .pkp/.pkv format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,28 +21,28 @@ cd noir-examples/poseidon-rounds
 nargo compile
 ```
 
-Generate the Noir Proof Scheme:
+Prepare the Noir program (generates prover and verifier files):
 
 ```sh
-cargo run --release --bin provekit-cli prepare ./target/basic.json -o ./noir-proof-scheme.nps
+cargo run --release --bin provekit-cli prepare ./target/basic.json --pkp ./prover.pkp --pkv ./verifier.pkv
 ```
 
 Generate the Noir Proof using the input Toml:
 
 ```sh
-cargo run --release --bin provekit-cli prove ./noir-proof-scheme.nps ./Prover.toml -o ./noir-proof.np
+cargo run --release --bin provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```
 
 Verify the Noir Proof:
 
 ```sh
-cargo run --release --bin provekit-cli verify ./noir-proof-scheme.nps ./noir-proof.np
+cargo run --release --bin provekit-cli verify ./verifier.pkv ./proof.np
 ```
 
 Generate inputs for Gnark circuit:
 
 ```sh
-cargo run --release --bin provekit-cli generate-gnark-inputs ./noir-proof-scheme.nps ./noir-proof.np
+cargo run --release --bin provekit-cli generate-gnark-inputs ./prover.pkp ./proof.np
 ```
 
 Recursively verify in a Gnark proof (reads the proof from `../ProveKit/prover/proof`):
@@ -62,8 +62,8 @@ Benchmark against Barretenberg:
 
 ```sh
 cd noir-examples/poseidon-rounds
-cargo run --release --bin provekit-cli prepare ./target/basic.json -o ./scheme.nps
-hyperfine 'nargo execute && bb prove -b ./target/basic.json -w ./target/basic.gz -o ./target' '../../target/release/provekit-cli prove ./scheme.nps ./Prover.toml'
+cargo run --release --bin provekit-cli prepare ./target/basic.json --pkp ./prover.pkp --pkv ./verifier.pkv
+hyperfine 'nargo execute && bb prove -b ./target/basic.json -w ./target/basic.gz -o ./target' '../../target/release/provekit-cli prove ./prover.pkp ./Prover.toml'
 ```
 
 ### Profiling
@@ -74,7 +74,7 @@ The `provekit-cli` application has written custom memory profiler that prints ba
 runs. To run binary with profiling enabled run it with cargo `--features profiling` param or compile with it.
 
 ```sh
-cargo run --release --bin provekit-cli --features profiling prove ./noir-proof-scheme.nps ./Prover.toml -o ./noir-proof.np
+cargo run --release --bin provekit-cli --features profiling prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```
 
 #### Using tracy (CPU and Memory usage)
@@ -112,7 +112,7 @@ cargo build --release --bin provekit-cli --features profiling
 ```
 5. Now start the application to profile:
 ```sh
-../../target/release/provekit-cli prove ./noir-proof-scheme.nps ./Prover.toml -o ./noir-proof.np
+../../target/release/provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```
 6. Go back to tracy tool. You should see that it receives data. App is interactive.
 
@@ -123,7 +123,7 @@ open a webpage with interactive app to view results. This does not require to ru
 with profiling enabled.
 
 ```sh
-samply record -r 10000 -- ./../../target/release/provekit-cli prove ./noir-proof-scheme.nps ./Prover.toml -o ./noir-proof.np
+samply record -r 10000 -- ./../../target/release/provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```
 
 #### Using instruments (Memory usage) - OSX only
@@ -132,7 +132,7 @@ Cargo instruments tool [website](https://crates.io/crates/cargo-instruments) wit
 results using built-in Instruments app. Results are interactive.
 
 ```sh
-cargo instruments --template Allocations --release --bin provekit-cli prove ./noir-proof-scheme.nps ./Prover.toml -o ./noir-proof.np
+cargo instruments --template Allocations --release --bin provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```
 
 Samply tool [website](https://github.com/mstange/samply/) with instructions to install. It will start local server and
@@ -140,7 +140,7 @@ open a webpage with interactive app to view results. This does not require to ru
 with profiling enabled.
 
 ```sh
-samply record -r 10000 -- ./../../target/release/provekit-cli prove ./noir-proof-scheme.nps ./Prover.toml -o ./noir-proof.np
+samply record -r 10000 -- ./../../target/release/provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```
 
 ## Benchmarking

--- a/tooling/verifier-server/README.md
+++ b/tooling/verifier-server/README.md
@@ -23,7 +23,7 @@ curl http://localhost:3000/health
 curl -X POST http://localhost:3000/verify \
   -H "Content-Type: application/json" \
   -d '{
-    "npsUrl": "https://example.com/scheme.nps",
+    "pkvUrl": "https://example.com/verifier.pkv",
     "r1csUrl": "https://example.com/r1cs.json", 
     "pkUrl": "https://example.com/proving_key.bin", (optional)
     "vkUrl": "https://example.com/verification_key.bin", (optional)

--- a/tooling/verifier-server/src/handlers.rs
+++ b/tooling/verifier-server/src/handlers.rs
@@ -24,7 +24,7 @@ pub async fn verify_handler(
 
     info!(
         request_id = %request_id.as_deref().unwrap_or("unknown"),
-        nps_url = %payload.nps_url,
+        pkv_url = %payload.pkv_url,
         r1cs_url = %payload.r1cs_url,
         pk_url = %payload.pk_url.as_deref().unwrap_or("not provided"),
         vk_url = %payload.vk_url.as_deref().unwrap_or("not provided"),
@@ -174,10 +174,10 @@ async fn verification(
     info!("Successfully decoded NoirProof from request");
 
     // Download and prepare artifacts
-    let (scheme, paths) = state
+    let (verifier, paths) = state
         .artifact_service
         .prepare_artifacts(
-            &request.nps_url,
+            &request.pkv_url,
             &request.r1cs_url,
             request.pk_url.as_deref(),
             request.vk_url.as_deref(),
@@ -187,6 +187,6 @@ async fn verification(
     // Perform verification
     state
         .verification_service
-        .verify_proof(request, &proof, &scheme, &paths, cancellation_token)
+        .verify_proof(request, &proof, &verifier, &paths, cancellation_token)
         .await
 }

--- a/tooling/verifier-server/src/models.rs
+++ b/tooling/verifier-server/src/models.rs
@@ -8,9 +8,9 @@ use {
 /// Request payload for proof verification
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VerifyRequest {
-    /// URL to the Noir Proof Scheme file (.nps)
-    #[serde(rename = "npsUrl")]
-    pub nps_url:             String,
+    /// URL to the ProveKit Verifier file (.pkv)
+    #[serde(rename = "pkvUrl")]
+    pub pkv_url:             String,
     /// JSON encoded NoirProof (.np file content)
     pub np:                  serde_json::Value,
     /// URL to the R1CS file
@@ -122,8 +122,8 @@ impl VerifyRequest {
         info!("Validating request");
 
         // Validate URLs
-        if self.nps_url.is_empty() {
-            return Err("nps_url cannot be empty".to_string());
+        if self.pkv_url.is_empty() {
+            return Err("pkv_url cannot be empty".to_string());
         }
 
         if self.r1cs_url.is_empty() {
@@ -134,7 +134,7 @@ impl VerifyRequest {
         // generate them
 
         // Validate URLs are properly formatted
-        self.validate_url("nps_url", &self.nps_url)?;
+        self.validate_url("pkv_url", &self.pkv_url)?;
         self.validate_url("r1cs_url", &self.r1cs_url)?;
 
         if let Some(ref pk_url) = self.pk_url {


### PR DESCRIPTION
## Summary
Migrates from monolithic `.nps` files to separate `.pkp` (prover) and `.pkv` (verifier) formats.

## Changes
- ✅ Update all CLI commands in README
- ✅ Update verifier-server API from `npsUrl` → `pkvUrl`
- ✅ Refactor verifier-server to use lightweight `Verifier` type

## Breaking Changes
- API: `npsUrl` → `pkvUrl` in verification requests
- CLI: `prepare` now outputs two files with `--pkp` and `--pkv` flags