### PR TITLE
Update outdated profiling instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,6 @@ results using built-in Instruments app. Results are interactive.
 cargo instruments --template Allocations --release --bin provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```
 
-Samply tool [website](https://github.com/mstange/samply/) with instructions to install. It will start local server and
-open a webpage with interactive app to view results. This does not require to run binary
-with profiling enabled.
-
-```sh
-samply record -r 10000 -- ./../../target/release/provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
-```
-
 ## Benchmarking
 
 Run the benchmark suite:

--- a/README.md
+++ b/README.md
@@ -76,12 +76,8 @@ hyperfine 'nargo execute && bb prove -b ./target/basic.json -w ./target/basic.gz
 
 #### Custom built-in profile (Memory usage)
 
-The `provekit-cli` application has written custom memory profiler that prints basic info about memory usage when application
-runs. To run binary with profiling enabled run it with cargo `--features profiling` param or compile with it.
-
-```sh
-cargo run --release --bin provekit-cli --features profiling prove ./prover.pkp ./Prover.toml -o ./proof.np
-```
+The `provekit-cli` application has written custom memory profiler that prints basic info about memory and time usage when application
+runs. The feature is enabled by default and is called `profiling-allocator`
 
 #### Using tracy (CPU and Memory usage)
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ tracy
 ```
 2. Leave all fields with defaults and just click `Connect` button. It will cause tracy to start listening on the
    localhost for incoming data.
-3.  Compile `noir-r1cs-profiled` binary.
+3.  Compile `provekit-cli` binary with Tracy support.
 ```sh
-cargo build --release --bin provekit-cli --features profiling
+cargo build --release --bin provekit-cli --features tracy
 ```
 4. (OSX only) If you want to check call stacks additional command needs to be run (base on tracy instruction). The
    command must be run against each binary that is being profiled by tracy. This will create directory next to the 
@@ -112,9 +112,14 @@ cargo build --release --bin provekit-cli --features profiling
 ```sh
  dsymutil ../../target/release/provekit-cli
 ```
-5. Now start the application to profile:
+5. Now start the application to profile. CPU only:
 ```sh
-../../target/release/provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
+../../target/release/provekit-cli --tracy prove ./prover.pkp ./Prover.toml -o ./proof.np
+```
+   With memory tracking (`--tracy-allocations <depth>` where depth is stack frame count, 0 for no stacks).
+   Use `--tracy-keepalive` to keep the process alive so Tracy can finish collecting data:
+```sh
+../../target/release/provekit-cli --tracy --tracy-allocations 0 --tracy-keepalive prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```
 6. Go back to tracy tool. You should see that it receives data. App is interactive.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ samply record -r 10000 -- ./../../target/release/provekit-cli prove ./prover.pkp
 Cargo instruments tool [website](https://crates.io/crates/cargo-instruments) with instructions to install. It will open
 results using built-in Instruments app. Results are interactive.
 
+> **Note**: Requires a full Xcode installation (not just Command Line Tools) as it depends on `xctrace`.
+
 ```sh
 cargo instruments --template Allocations --release --bin provekit-cli prove ./prover.pkp ./Prover.toml -o ./proof.np
 ```


### PR DESCRIPTION
## Summary
- Fix outdated profiling instructions in README: correct feature flag (`tracy` instead of `profiling`), add missing `--tracy` runtime flag, and document `--tracy-allocations` / `--tracy-keepalive` options
- Update stale binary name reference (`noir-r1cs-profiled` → `provekit-cli`)
- Add note that `cargo instruments` requires a full Xcode installation
- removed duplicated Samply instruction