### PR TITLE
Update nightly to fix multilimb subtraction bug

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-10-20"
+channel = "nightly-2026-03-04"
 components = ["rustfmt", "rust-analyzer", "clippy"]

--- a/skyscraper/bn254-multiplier/src/lib.rs
+++ b/skyscraper/bn254-multiplier/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(portable_simd)]
-#![feature(bigint_helper_methods)]
 //#![no_std] This crate can technically be no_std. However this requires
 // replacing StdFloat.mul_add with intrinsics.
 

--- a/skyscraper/bn254-multiplier/src/rne/batched.rs
+++ b/skyscraper/bn254-multiplier/src/rne/batched.rs
@@ -108,10 +108,7 @@ pub fn simd_sqr(v0_a: [u64; 4], v1_a: [u64; 4]) -> ([u64; 4], [u64; 4]) {
 /// limbs except the last one is 51 bits. The most significant limb can be
 /// larger than 51 bits as the input can be bigger 2^255-1.
 #[inline(always)]
-fn redundant_carry<const N: usize, const L: usize>(t: [Simd<i64, L>; N]) -> [Simd<u64, L>; N]
-where
-    std::simd::LaneCount<L>: std::simd::SupportedLaneCount,
-{
+fn redundant_carry<const N: usize, const L: usize>(t: [Simd<i64, L>; N]) -> [Simd<u64, L>; N] {
     let mut borrow = Simd::splat(0);
     let mut res = [Simd::splat(0); N];
     for i in 0..t.len() - 1 {

--- a/skyscraper/bn254-multiplier/src/rne/simd_utils.rs
+++ b/skyscraper/bn254-multiplier/src/rne/simd_utils.rs
@@ -14,7 +14,7 @@ use {
     },
     std::{
         array,
-        simd::{cmp::SimdPartialEq, LaneCount, SupportedLaneCount},
+        simd::{cmp::SimdPartialEq, Select},
     },
 };
 #[inline(always)]
@@ -24,10 +24,7 @@ use {
 ///
 /// Warning: due to Rust's limitations this can not be a const function.
 /// Therefore check your dependency path as this will not be optimised out.
-pub fn i2f<const N: usize>(a: Simd<u64, N>) -> Simd<f64, N>
-where
-    LaneCount<N>: SupportedLaneCount,
-{
+pub fn i2f<const N: usize>(a: Simd<u64, N>) -> Simd<f64, N> {
     // This function has no target gating as we want to verify this function with
     // kani and proptest on a different platform than wasm
 
@@ -95,10 +92,7 @@ pub fn transpose_simd_to_u256(limbs: [Simd<u64, 2>; 4]) -> [[u64; 4]; 2] {
 /// Convert 4×64-bit to 5×51-bit limb representation.
 /// Input must fit in 255 bits; no runtime checking.
 #[inline(always)]
-pub fn u256_to_u255_simd<const N: usize>(limbs: [Simd<u64, N>; 4]) -> [Simd<u64, N>; 5]
-where
-    LaneCount<N>: SupportedLaneCount,
-{
+pub fn u256_to_u255_simd<const N: usize>(limbs: [Simd<u64, N>; 4]) -> [Simd<u64, N>; 5] {
     for lane in 0..N {
         debug_assert!(limbs[3][lane] & (1 << 63) == 0);
     }
@@ -115,10 +109,7 @@ where
 
 /// Convert 5×51-bit back to 4×64-bit limb representation.
 #[inline(always)]
-pub fn u255_to_u256_simd<const N: usize>(limbs: [Simd<u64, N>; 5]) -> [Simd<u64, N>; 4]
-where
-    LaneCount<N>: SupportedLaneCount,
-{
+pub fn u255_to_u256_simd<const N: usize>(limbs: [Simd<u64, N>; 5]) -> [Simd<u64, N>; 4] {
     let [l0, l1, l2, l3, l4] = limbs;
     [
         l0 | (l1 << 51),
@@ -130,10 +121,7 @@ where
 
 /// Convert 5×51-bit to 4×64-bit with simultaneous division by 2.
 #[inline(always)]
-pub fn u255_to_u256_shr_1_simd<const N: usize>(limbs: [Simd<u64, N>; 5]) -> [Simd<u64, N>; 4]
-where
-    LaneCount<N>: SupportedLaneCount,
-{
+pub fn u255_to_u256_shr_1_simd<const N: usize>(limbs: [Simd<u64, N>; 5]) -> [Simd<u64, N>; 4] {
     let [l0, l1, l2, l3, l4] = limbs;
     [
         (l0 >> 1) | (l1 << 50),

--- a/skyscraper/bn254-multiplier/src/rtz/simd_utils.rs
+++ b/skyscraper/bn254-multiplier/src/rtz/simd_utils.rs
@@ -10,7 +10,7 @@ use {
             Simd,
         },
     },
-    std::simd::StdFloat,
+    std::simd::{Select, StdFloat},
 };
 
 // -- [SIMD UTILS]

--- a/skyscraper/core/src/lib.rs
+++ b/skyscraper/core/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(portable_simd)]
-#![feature(bigint_helper_methods)]
-#![feature(cold_path)]
+#![feature(const_unsigned_bigint_helpers)]
 
 pub mod arithmetic;
 pub mod bar;


### PR DESCRIPTION
On the old toolchain the carry logic in arkwork's ff (`ff/src/biginteger/arithmetic.rs`) gets incorrectly compiled under some circumstances. 

The error was in one of the later IR stages (after emit llvm from Rust). A borrow (-1) was turned into 2^64-1 in a i128 register and this interfered with the carry logic used by ark ff. On the latest stable this is -1. Given that the IR didn’t change any other way I’m fairly confident this issue has been resolved. 

