### PR TITLE
Add emoji acknowledgment for Claude workflow triggers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,6 +22,13 @@ jobs:
       issues: write
 
     steps:
+      - name: Acknowledge comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=eyes
+
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,6 +57,14 @@ jobs:
       issues: write
       actions: read
     steps:
+      - name: Acknowledge comment
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=eyes
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Adds 👀 (eyes) emoji reaction when `@claude` or `/claude-review` commands are detected
- Gives immediate feedback that the command was received before Claude starts processing

## Test plan
- [ ] Comment `@claude` on a PR — should see 👀 reaction immediately
- [ ] Comment `/claude-review` on a PR — should see 👀 reaction immediately