### PR TITLE
Fix: allow gh tools in /claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,6 +40,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "/claude-review"
+          claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(gh issue:*)" Read Glob Grep Agent'
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: |


### PR DESCRIPTION
Fixes 11 permission denials — Claude couldn't run gh pr diff/comment without Bash(gh pr:*) in allowed tools.