### PR TITLE
fix: handling public dead inputs

### DIFF
--- a/provekit/r1cs-compiler/src/noir_to_r1cs.rs
+++ b/provekit/r1cs-compiler/src/noir_to_r1cs.rs
@@ -736,3 +736,37 @@ impl NoirToR1CSCompiler {
         Ok(breakdown)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        acir::circuit::PublicInputs as AcirPublicInputs,
+        provekit_common::witness::WitnessBuilder,
+        std::collections::{BTreeSet, HashSet},
+    };
+
+    /// Regression: public inputs absent from all opcodes must still get
+    /// builders (case for unconstrained public inputs), otherwise
+    /// split_and_prepare_layers fails with NoBuilderForPublicInput.
+    #[test]
+    fn dead_public_input_compiles() {
+        let circuit = Circuit {
+            public_parameters: AcirPublicInputs(BTreeSet::from([NoirWitness(1)])),
+            opcodes: vec![],
+            ..Default::default()
+        };
+        let (r1cs, witness_map, witness_builders) =
+            noir_to_r1cs(&circuit).expect("noir_to_r1cs should succeed");
+
+        let acir_public_inputs: HashSet<u32> =
+            circuit.public_inputs().indices().iter().cloned().collect();
+        WitnessBuilder::split_and_prepare_layers(
+            &witness_builders,
+            r1cs,
+            witness_map,
+            acir_public_inputs,
+        )
+        .expect("split_and_prepare_layers should not fail with NoBuilderForPublicInput");
+    }
+}


### PR DESCRIPTION
fixes #335 

error : When running the OPRF circuit through `provekit-cli prepare`, compilation fails:

```
Error: while compiling Noir program

Caused by:
    no builder for public input ACIR index 10
```

root cause : Noir's ACIR `Circuit` struct stores public inputs in `public_parameters: PublicInputs` and constraints in `opcodes: Vec<Opcode>`. These are independent — a witness can be in `public_parameters` without appearing in any `Opcode` (e.g. inputs used only in Brillig). ProveKit's R1CS compiler walks `opcodes` to create witness builders but never reads `public_parameters`, so it misses any public input that no opcode references, hence never finding that public input builder later. This happens on unconstrained public inputs.

fix : After processing all opcodes in `add_circuit_with_breakdown`, call f`etch_r1cs_witness_index` for every witness in `circuit.public_inputs()`. This is idempotent, already-seen witnesses hit the map and return, unseen ones get a new `WitnessBuilder::Acir` entry.