### PR TITLE
fix: enforce end-of-transcript validation in WhirR1CS verifier [LA - F]

### DIFF
--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -247,7 +247,9 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
             "last sumcheck value does not match"
         );
 
-        Ok(())
+        arthur
+            .check_eof()
+            .map_err(|_| anyhow::anyhow!("Proof contains unparsed trailing bytes"))
     }
 }
 


### PR DESCRIPTION
## Summary
- Calls `VerifierState::check_eof` at the end of `WhirR1CSScheme::verify` to reject proofs with unparsed trailing bytes in `narg_string` or `hints`
- Addresses audit Issue F: missing end-of-transcript validation causes proof malleability

## Test plan
- [x] `cargo check -p provekit-verifier` passes