### PR TITLE
fix: R1CS binding in transcript [LA - I]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ seq-macro = "0.3.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.9"
+sha3 = "0.10.8"
 test-case = "3.3.1"
 tikv-jemallocator = "0.6"
 toml = "0.8.8"

--- a/provekit/common/Cargo.toml
+++ b/provekit/common/Cargo.toml
@@ -37,6 +37,7 @@ rayon.workspace = true
 ruint.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha3.workspace = true
 tracing.workspace = true
 xz2.workspace = true
 zerocopy.workspace = true

--- a/provekit/common/src/r1cs.rs
+++ b/provekit/common/src/r1cs.rs
@@ -1,6 +1,7 @@
 use {
     crate::{FieldElement, HydratedSparseMatrix, Interner, SparseMatrix},
     serde::{Deserialize, Serialize},
+    sha3::{Digest, Sha3_256},
 };
 
 /// Represents a R1CS constraint system.
@@ -55,6 +56,13 @@ impl R1CS {
     /// witness).
     pub const fn num_witnesses(&self) -> usize {
         self.a.num_cols
+    }
+
+    /// Hash of the R1CS
+    #[must_use]
+    pub fn hash(&self) -> [u8; 32] {
+        let bytes = postcard::to_stdvec(self).expect("R1CS serialization failed");
+        Sha3_256::digest(&bytes).into()
     }
 
     // Increase the size of the R1CS matrices to the specified dimensions.

--- a/provekit/common/src/whir_r1cs.rs
+++ b/provekit/common/src/whir_r1cs.rs
@@ -31,6 +31,7 @@ pub struct WhirR1CSScheme {
     pub num_challenges:    usize,
     pub has_public_inputs: bool,
     pub whir_witness:      WhirZkConfig,
+    pub r1cs_hash:         [u8; 32],
 }
 
 impl WhirR1CSScheme {

--- a/provekit/common/src/witness/mod.rs
+++ b/provekit/common/src/witness/mod.rs
@@ -10,7 +10,7 @@ use {
         utils::{serde_ark, serde_ark_vec},
         FieldElement,
     },
-    ark_ff::{BigInt, One, PrimeField},
+    ark_ff::{BigInt, BigInteger, One, PrimeField},
     serde::{Deserialize, Serialize},
 };
 pub use {
@@ -90,6 +90,16 @@ impl PublicInputs {
             1 => compress(self.0[0], FieldElement::from(0u64)),
             _ => self.0.iter().copied().reduce(compress).unwrap(),
         }
+    }
+
+    #[must_use]
+    pub fn hash_bytes(&self) -> [u8; 32] {
+        let hash = self.hash();
+        let bytes = hash.into_bigint().to_bytes_le();
+        let mut result = [0u8; 32];
+        let len = bytes.len().min(32);
+        result[..len].copy_from_slice(&bytes[..len]);
+        result
     }
 }
 

--- a/provekit/prover/src/lib.rs
+++ b/provekit/prover/src/lib.rs
@@ -5,18 +5,19 @@ use {
         r1cs::{CompressedLayers, CompressedR1CS},
         whir_r1cs::WhirR1CSProver,
     },
-    acir::native_types::WitnessMap,
+    acir::native_types::{Witness, WitnessMap},
     anyhow::{Context, Result},
     bn254_blackbox_solver::Bn254BlackBoxSolver,
     nargo::foreign_calls::DefaultForeignCallBuilder,
     noir_artifact_cli::fs::inputs::read_inputs_from_file,
     noirc_abi::InputMap,
     provekit_common::{
-        FieldElement, NoirElement, NoirProof, Prover, PublicInputs, TranscriptSponge,
+        utils::noir_to_native, FieldElement, NoirElement, NoirProof, Prover, PublicInputs,
+        TranscriptSponge,
     },
     std::{mem::size_of, path::Path},
     tracing::{debug, info_span, instrument},
-    whir::transcript::{codecs::Empty, ProverState},
+    whir::transcript::ProverState,
 };
 
 mod r1cs;
@@ -66,7 +67,21 @@ impl Prove for Prover {
             read_inputs_from_file(prover_toml.as_ref(), self.witness_generator.abi())?;
 
         let acir_witness_idx_to_value_map = self.generate_witness(input_map)?;
-        let num_public_inputs = self.program.functions[0].public_inputs().indices().len();
+
+        let mut public_input_indices = self.program.functions[0].public_inputs().indices();
+        public_input_indices.sort_unstable();
+        let public_inputs = PublicInputs::from_vec(
+            public_input_indices
+                .iter()
+                .map(|&idx| {
+                    acir_witness_idx_to_value_map
+                        .get(&Witness::from(idx))
+                        .map(|v| noir_to_native(*v))
+                        .ok_or_else(|| anyhow::anyhow!("Missing public input at index {idx}"))
+                })
+                .collect::<Result<Vec<_>>>()?,
+        );
+
         drop(self.program);
         drop(self.witness_generator);
 
@@ -77,11 +92,12 @@ impl Prove for Prover {
         let num_witnesses = compressed_r1cs.num_witnesses();
         let num_constraints = compressed_r1cs.num_constraints();
 
-        // Set up transcript
+        // Set up transcript with public inputs bound to the instance.
+        let instance = public_inputs.hash_bytes();
         let ds = self
             .whir_for_witness
             .create_domain_separator()
-            .instance(&Empty);
+            .instance(&instance);
         let mut merlin = ProverState::new(&ds, TranscriptSponge::default());
 
         let mut witness: Vec<Option<FieldElement>> = vec![None; num_witnesses];
@@ -116,6 +132,19 @@ impl Prove for Prover {
             witness_heap_bytes = witness.capacity() * size_of::<Option<FieldElement>>(),
             compressed_r1cs_blob_bytes = compressed_r1cs.blob_len(),
             "component sizes after solve_w1"
+        );
+
+        // Verify that ACIR-derived public inputs match the R1CS witness layout.
+        debug_assert!(
+            {
+                let n = public_inputs.0.len();
+                n == 0
+                    || witness[1..=n]
+                        .iter()
+                        .zip(public_inputs.0.iter())
+                        .all(|(w, pi)| w.map_or(false, |v| v == *pi))
+            },
+            "Public inputs from ACIR witness map do not match witness[1..=N]"
         );
 
         let w1 = {
@@ -174,17 +203,6 @@ impl Prove for Prover {
         #[cfg(test)]
         r1cs.test_witness_satisfaction(&witness.iter().map(|w| w.unwrap()).collect::<Vec<_>>())
             .context("While verifying R1CS instance")?;
-
-        let public_inputs = if num_public_inputs == 0 {
-            PublicInputs::new()
-        } else {
-            PublicInputs::from_vec(
-                witness[1..=num_public_inputs]
-                    .iter()
-                    .map(|w| w.ok_or_else(|| anyhow::anyhow!("Missing public input witness")))
-                    .collect::<Result<Vec<FieldElement>>>()?,
-            )
-        };
 
         let full_witness: Vec<FieldElement> = witness
             .into_iter()

--- a/provekit/r1cs-compiler/src/whir_r1cs.rs
+++ b/provekit/r1cs-compiler/src/whir_r1cs.rs
@@ -51,6 +51,7 @@ impl WhirR1CSSchemeBuilder for WhirR1CSScheme {
             num_challenges,
             whir_witness: Self::new_whir_zk_config_for_size(m_raw, 1),
             has_public_inputs,
+            r1cs_hash: r1cs.hash(),
         }
     }
 

--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -13,7 +13,7 @@ use {
     tracing::instrument,
     whir::{
         algebra::linear_form::LinearForm,
-        transcript::{codecs::Empty, Proof, VerifierMessage, VerifierState},
+        transcript::{Proof, VerifierMessage, VerifierState},
     },
 };
 
@@ -41,7 +41,8 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
         public_inputs: &PublicInputs,
         r1cs: &R1CS,
     ) -> Result<()> {
-        let ds = self.create_domain_separator().instance(&Empty);
+        let instance = public_inputs.hash_bytes();
+        let ds = self.create_domain_separator().instance(&instance);
         let whir_proof = Proof {
             narg_string: proof.narg_string.clone(),
             hints: proof.hints.clone(),


### PR DESCRIPTION
**Problem**
The Fiat-Shamir domain separator was initialized with an empty instance (`Empty`), so the transcript never absorbed a digest of the concrete R1CS or the public inputs being proven. In a setting where a verifier could be presented with different circuits or verification keys, challenges would be identical across them, allowing cross-circuit or cross-key confusion.

**Fix**
Added `R1CS::hash()` (SHA3-256 over the serialized R1CS) and stored the hash in `WhirR1CSScheme` at prepare time.

Changed the domain separator instance from `Empty` to `public_inputs.hash_bytes()` in both prover and verifier, binding the public statement to the transcript.

Added `PublicInputs::hash_bytes()` for the byte-level hash used as instance data.

Moved public input extraction earlier in the prover (derived from the ACIR witness map before witness solve) so it's available for transcript setup.