### PR TITLE
fix: bind evals to transcript [LA - K]

### DIFF
--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -163,7 +163,9 @@ impl WhirR1CSProver for WhirR1CSScheme {
             let (mut weights, evals) =
                 create_weights_and_evaluations::<3>(self.m, &commitment.polynomial, alphas);
 
-            merlin.prover_hint_ark(&evals);
+            for eval in &evals {
+                merlin.prover_message(eval);
+            }
 
             if !public_inputs.is_empty() {
                 let public_eval = compute_public_weight_evaluation(
@@ -171,7 +173,7 @@ impl WhirR1CSProver for WhirR1CSScheme {
                     &commitment.polynomial,
                     public_weight,
                 );
-                merlin.prover_hint_ark(&public_eval);
+                merlin.prover_message(&public_eval);
             }
 
             let mut evaluations = compute_evaluations(&weights, &commitment.polynomial);
@@ -212,12 +214,16 @@ impl WhirR1CSProver for WhirR1CSScheme {
 
             let evals_1 = compute_alpha_evals(&c1.polynomial, &alphas_1);
             let evals_2 = compute_alpha_evals(&c2.polynomial, &alphas_2);
-            merlin.prover_hint_ark(&evals_1);
-            merlin.prover_hint_ark(&evals_2);
+            for eval in &evals_1 {
+                merlin.prover_message(eval);
+            }
+            for eval in &evals_2 {
+                merlin.prover_message(eval);
+            }
 
             let public_1 = if !public_inputs.is_empty() {
                 let p1 = compute_public_eval(x, public_inputs.len(), &c1.polynomial);
-                merlin.prover_hint_ark(&p1);
+                merlin.prover_message(&p1);
                 Some(p1)
             } else {
                 None

--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -114,26 +114,36 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
                 .try_into()
                 .map_err(|_| anyhow::anyhow!("Expected 3 alpha vectors for commitment 2"))?;
 
-            let evals_1: Vec<FieldElement> = arthur
-                .prover_hint_ark()
-                .map_err(|_| anyhow::anyhow!("Failed to read evals_1 hint"))?;
-            let evals_2: Vec<FieldElement> = arthur
-                .prover_hint_ark()
-                .map_err(|_| anyhow::anyhow!("Failed to read evals_2 hint"))?;
-            let evals_1: [FieldElement; 3] = evals_1
-                .try_into()
-                .map_err(|_| anyhow::anyhow!("Expected 3 evaluation values for commitment 1"))?;
-            let evals_2: [FieldElement; 3] = evals_2
-                .try_into()
-                .map_err(|_| anyhow::anyhow!("Expected 3 evaluation values for commitment 2"))?;
+            let evals_1: [FieldElement; 3] = [
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals_1[0]"))?,
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals_1[1]"))?,
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals_1[2]"))?,
+            ];
+            let evals_2: [FieldElement; 3] = [
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals_2[0]"))?,
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals_2[1]"))?,
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals_2[2]"))?,
+            ];
 
             let mut weights_1 = build_prefix_covectors(self.m, alphas_1);
             let weights_2 = build_prefix_covectors(self.m, alphas_2);
 
             let mut evaluations_1 = if !public_inputs.is_empty() {
                 let public_1: FieldElement = arthur
-                    .prover_hint_ark()
-                    .map_err(|_| anyhow::anyhow!("Failed to read public_1 hint"))?;
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read public_1"))?;
                 weights_1.insert(0, make_public_weight(x, public_inputs.len(), self.m));
                 vec![public_1, evals_1[0], evals_1[1], evals_1[2]]
             } else {
@@ -166,19 +176,24 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
                 evals_1[2] + evals_2[2],
             )
         } else {
-            let evals: Vec<FieldElement> = arthur
-                .prover_hint_ark()
-                .map_err(|_| anyhow::anyhow!("Failed to read evals hint"))?;
-            let evals: [FieldElement; 3] = evals
-                .try_into()
-                .map_err(|_| anyhow::anyhow!("Expected 3 evaluation values"))?;
+            let evals: [FieldElement; 3] = [
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals[0]"))?,
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals[1]"))?,
+                arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read evals[2]"))?,
+            ];
 
             let mut weights = build_prefix_covectors(self.m, alphas);
 
             let mut evaluations = if !public_inputs.is_empty() {
                 let public_eval: FieldElement = arthur
-                    .prover_hint_ark()
-                    .map_err(|_| anyhow::anyhow!("Failed to read public eval hint"))?;
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read public eval"))?;
                 weights.insert(0, make_public_weight(x, public_inputs.len(), self.m));
                 vec![public_eval, evals[0], evals[1], evals[2]]
             } else {


### PR DESCRIPTION
**Problem**
Evaluation claims (`evals`, `evals_1`, `evals_2`, `public_eval`) were sent via `prover_hint_ark`, which writes to the hints buffer without absorbing into the Fiat-Shamir sponge. The verifier reads them back without affecting challenge generation. A prover could substitute these values without changing subsequent challenges.

Current downstream checks (the WHIR opening verification) happen to reject forged values, but the transcript boundary itself is non-binding for anything sent through the hint channel.

**Fix**
Replaced all `prover_hint_ark` calls with `prover_message` for evaluation claims in both prover and verifier, so the values are absorbed into the sponge and bound to subsequent Fiat-Shamir challenges.