### PR TITLE
test(msm): add negative/adversarial tests for MSM constraint satisfaction

### DIFF
--- a/tooling/provekit-bench/tests/msm_witness_solving.rs
+++ b/tooling/provekit-bench/tests/msm_witness_solving.rs
@@ -505,6 +505,33 @@ fn test_single_point_rejects_wrong_output_coordinate() {
     );
 }
 
+/// Corrupting an expected output y-limb must also violate the output equality
+/// constraints.
+#[test]
+fn test_single_point_rejects_wrong_output_y_coordinate() {
+    let curve = Secp256r1;
+    let gx = curve.generator().0;
+    let gy = curve.generator().1;
+    let scalar: [u64; 4] = [7, 0, 0, 0];
+    let (ex, ey) = ec_scalar_mul(
+        &gx,
+        &gy,
+        &scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+
+    assert_single_point_corruption_is_rejected(
+        fixture,
+        "wrong output y coordinate",
+        |layout, corrupted| {
+            let idx = layout.out_y_limbs[0];
+            corrupted[idx] = different_field_element(corrupted[idx]);
+        },
+    );
+}
+
 /// Corrupting the input y-coordinate must violate the curve-membership and
 /// consistency constraints.
 #[test]
@@ -563,6 +590,34 @@ fn test_single_point_rejects_wrong_scalar_output_pairing() {
         |layout, corrupted| {
             overwrite_witness_values(corrupted, &layout.out_x_limbs, &wrong_ex_fes);
             overwrite_witness_values(corrupted, &layout.out_y_limbs, &wrong_ey_fes);
+        },
+    );
+}
+
+/// Replacing the scalar input while keeping the original output must fail.
+#[test]
+fn test_single_point_rejects_scalar_corruption() {
+    let curve = Secp256r1;
+    let gx = curve.generator().0;
+    let gy = curve.generator().1;
+    let scalar: [u64; 4] = [7, 0, 0, 0];
+    let wrong_scalar: [u64; 4] = [5, 0, 0, 0];
+    let (wrong_lo, wrong_hi) = split_scalar(&wrong_scalar);
+    let (ex, ey) = ec_scalar_mul(
+        &gx,
+        &gy,
+        &scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+
+    assert_single_point_corruption_is_rejected(
+        fixture,
+        "scalar corruption",
+        |layout, corrupted| {
+            corrupted[layout.scalar_lo] = u256_to_fe(&wrong_lo);
+            corrupted[layout.scalar_hi] = u256_to_fe(&wrong_hi);
         },
     );
 }

--- a/tooling/provekit-bench/tests/msm_witness_solving.rs
+++ b/tooling/provekit-bench/tests/msm_witness_solving.rs
@@ -124,15 +124,98 @@ fn u256_to_limb_fes(v: &[u64; 4], limb_bits: u32, num_limbs: usize) -> Vec<Field
     decompose_to_limbs(v, limb_bits, num_limbs)
 }
 
-// ---------------------------------------------------------------------------
-// Single-point limbed MSM test runner
-// ---------------------------------------------------------------------------
+/// Increment a 256-bit little-endian integer by one.
+fn increment_u256(v: &[u64; 4]) -> [u64; 4] {
+    let mut out = *v;
+    for limb in &mut out {
+        let (next, carry) = limb.overflowing_add(1);
+        *limb = next;
+        if !carry {
+            break;
+        }
+    }
+    out
+}
 
-/// Compile and solve a single-point MSM circuit using the limbed API.
-///
-/// When `expected_inf` is true, the expected output is point at infinity
-/// (all output limbs zero, out_inf = 1).
-fn run_single_point_msm_test_limbed(
+/// Pick a different field element without relying on arithmetic traits.
+fn different_field_element(value: FieldElement) -> FieldElement {
+    if value == FieldElement::zero() {
+        FieldElement::from(1u64)
+    } else {
+        FieldElement::zero()
+    }
+}
+
+/// Overwrite specific witness slots with the supplied values.
+fn overwrite_witness_values(
+    witness: &mut [FieldElement],
+    indices: &[usize],
+    values: &[FieldElement],
+) {
+    assert_eq!(
+        indices.len(),
+        values.len(),
+        "indices and values must have the same length"
+    );
+    for (&idx, &value) in indices.iter().zip(values.iter()) {
+        witness[idx] = value;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FakeGlvWitnessIndices {
+    s1:   usize,
+    s2:   usize,
+    neg1: usize,
+    neg2: usize,
+}
+
+#[derive(Clone, Debug)]
+struct SinglePointMsmLayout {
+    point_x_limbs: Vec<usize>,
+    point_y_limbs: Vec<usize>,
+    point_inf:     usize,
+    scalar_lo:     usize,
+    scalar_hi:     usize,
+    out_x_limbs:   Vec<usize>,
+    out_y_limbs:   Vec<usize>,
+    out_inf:       usize,
+    fake_glv:      FakeGlvWitnessIndices,
+}
+
+struct SinglePointMsmFixture {
+    compiler:       NoirToR1CSCompiler,
+    num_witnesses:  usize,
+    initial_values: Vec<(usize, FieldElement)>,
+    layout:         SinglePointMsmLayout,
+}
+
+/// Locate the single FakeGLV hint used by the single-point MSM circuit.
+fn locate_single_point_fake_glv(builders: &[WitnessBuilder]) -> FakeGlvWitnessIndices {
+    let fake_glv_indices: Vec<FakeGlvWitnessIndices> = builders
+        .iter()
+        .filter_map(|builder| match builder {
+            WitnessBuilder::FakeGLVHint { output_start, .. } => Some(FakeGlvWitnessIndices {
+                s1:   *output_start,
+                s2:   *output_start + 1,
+                neg1: *output_start + 2,
+                neg2: *output_start + 3,
+            }),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        fake_glv_indices.len(),
+        1,
+        "single-point MSM circuit should contain exactly one FakeGLV hint"
+    );
+    fake_glv_indices[0]
+}
+
+/// Build the single-point secp256r1 MSM circuit together with stable witness
+/// metadata used by the negative tests.
+fn build_single_point_msm_fixture(
     px: &[u64; 4],
     py: &[u64; 4],
     inf: bool,
@@ -140,7 +223,7 @@ fn run_single_point_msm_test_limbed(
     expected_x: &[u64; 4],
     expected_y: &[u64; 4],
     expected_inf: bool,
-) {
+) -> SinglePointMsmFixture {
     let curve = Secp256r1;
     let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 1);
     let (s_lo, s_hi) = split_scalar(scalar);
@@ -158,14 +241,18 @@ fn run_single_point_msm_test_limbed(
     let total_input_wits = stride + 2 + stride;
     compiler.r1cs.add_witnesses(total_input_wits);
 
+    let point_x_limbs: Vec<usize> = (0..num_limbs).map(|j| base + j).collect();
+    let point_y_limbs: Vec<usize> = (0..num_limbs).map(|j| base + num_limbs + j).collect();
+    let point_inf = base + 2 * num_limbs;
+
     let points: Vec<ConstantOrR1CSWitness> = (0..stride)
         .map(|j| ConstantOrR1CSWitness::Witness(base + j))
         .collect();
-    let slo_w = base + stride;
-    let shi_w = base + stride + 1;
+    let scalar_lo = base + stride;
+    let scalar_hi = base + stride + 1;
     let scalars = vec![
-        ConstantOrR1CSWitness::Witness(slo_w),
-        ConstantOrR1CSWitness::Witness(shi_w),
+        ConstantOrR1CSWitness::Witness(scalar_lo),
+        ConstantOrR1CSWitness::Witness(scalar_hi),
     ];
 
     let out_base = base + stride + 2;
@@ -182,40 +269,106 @@ fn run_single_point_msm_test_limbed(
     add_msm_with_curve(&mut compiler, msm_ops, &mut range_checks, &curve);
     add_range_checks(&mut compiler, range_checks);
 
-    let num_witnesses = compiler.num_witnesses();
+    let layout = SinglePointMsmLayout {
+        point_x_limbs,
+        point_y_limbs,
+        point_inf,
+        scalar_lo,
+        scalar_hi,
+        out_x_limbs,
+        out_y_limbs,
+        out_inf,
+        fake_glv: locate_single_point_fake_glv(&compiler.witness_builders),
+    };
 
     // Set initial witness values
     let mut initial_values = vec![(0, FieldElement::from(1u64))];
     for (j, fe) in px_fes.iter().enumerate() {
-        initial_values.push((base + j, *fe));
+        initial_values.push((layout.point_x_limbs[j], *fe));
     }
     for (j, fe) in py_fes.iter().enumerate() {
-        initial_values.push((base + num_limbs + j, *fe));
+        initial_values.push((layout.point_y_limbs[j], *fe));
     }
     let inf_fe = if inf {
         FieldElement::from(1u64)
     } else {
         FieldElement::zero()
     };
-    initial_values.push((base + 2 * num_limbs, inf_fe));
-    initial_values.push((slo_w, u256_to_fe(&s_lo)));
-    initial_values.push((shi_w, u256_to_fe(&s_hi)));
+    initial_values.push((layout.point_inf, inf_fe));
+    initial_values.push((layout.scalar_lo, u256_to_fe(&s_lo)));
+    initial_values.push((layout.scalar_hi, u256_to_fe(&s_hi)));
     for (j, fe) in ex_fes.iter().enumerate() {
-        initial_values.push((out_x_limbs[j], *fe));
+        initial_values.push((layout.out_x_limbs[j], *fe));
     }
     for (j, fe) in ey_fes.iter().enumerate() {
-        initial_values.push((out_y_limbs[j], *fe));
+        initial_values.push((layout.out_y_limbs[j], *fe));
     }
     let out_inf_fe = if expected_inf {
         FieldElement::from(1u64)
     } else {
         FieldElement::zero()
     };
-    initial_values.push((out_inf, out_inf_fe));
+    initial_values.push((layout.out_inf, out_inf_fe));
 
-    let witness = solve_witnesses(&compiler.witness_builders, num_witnesses, &initial_values);
+    let num_witnesses = compiler.num_witnesses();
 
-    check_r1cs_satisfaction(&compiler.r1cs, &witness)
+    SinglePointMsmFixture {
+        compiler,
+        num_witnesses,
+        initial_values,
+        layout,
+    }
+}
+
+/// Solve the valid witness, then verify that a targeted corruption is rejected.
+fn assert_single_point_corruption_is_rejected(
+    fixture: SinglePointMsmFixture,
+    scenario: &str,
+    mutate: impl FnOnce(&SinglePointMsmLayout, &mut Vec<FieldElement>),
+) {
+    let witness = solve_witnesses(
+        &fixture.compiler.witness_builders,
+        fixture.num_witnesses,
+        &fixture.initial_values,
+    );
+    check_r1cs_satisfaction(&fixture.compiler.r1cs, &witness)
+        .unwrap_or_else(|err| panic!("valid witness should satisfy R1CS for {scenario}: {err}"));
+
+    let mut corrupted = witness.clone();
+    mutate(&fixture.layout, &mut corrupted);
+
+    assert!(
+        check_r1cs_satisfaction(&fixture.compiler.r1cs, &corrupted).is_err(),
+        "corrupted witness should fail R1CS satisfaction for {scenario}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Single-point limbed MSM test runner
+// ---------------------------------------------------------------------------
+
+/// Compile and solve a single-point MSM circuit using the limbed API.
+///
+/// When `expected_inf` is true, the expected output is point at infinity
+/// (all output limbs zero, out_inf = 1).
+fn run_single_point_msm_test_limbed(
+    px: &[u64; 4],
+    py: &[u64; 4],
+    inf: bool,
+    scalar: &[u64; 4],
+    expected_x: &[u64; 4],
+    expected_y: &[u64; 4],
+    expected_inf: bool,
+) {
+    let fixture =
+        build_single_point_msm_fixture(px, py, inf, scalar, expected_x, expected_y, expected_inf);
+    let witness = solve_witnesses(
+        &fixture.compiler.witness_builders,
+        fixture.num_witnesses,
+        &fixture.initial_values,
+    );
+
+    check_r1cs_satisfaction(&fixture.compiler.r1cs, &witness)
         .expect("R1CS satisfaction check failed (limbed)");
 }
 
@@ -323,6 +476,158 @@ fn test_arbitrary_point_and_scalar() {
     let (ex, ey) = ec_scalar_mul(&gx, &gy, &[34, 0, 0, 0], a, p);
 
     run_single_point_msm_test_limbed(&px, &py, false, &scalar, &ex, &ey, false);
+}
+
+/// Corrupting an expected output limb must violate the output equality
+/// constraints.
+#[test]
+fn test_single_point_rejects_wrong_output_coordinate() {
+    let curve = Secp256r1;
+    let gx = curve.generator().0;
+    let gy = curve.generator().1;
+    let scalar: [u64; 4] = [7, 0, 0, 0];
+    let (ex, ey) = ec_scalar_mul(
+        &gx,
+        &gy,
+        &scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+
+    assert_single_point_corruption_is_rejected(
+        fixture,
+        "wrong output coordinate",
+        |layout, corrupted| {
+            let idx = layout.out_x_limbs[0];
+            corrupted[idx] = different_field_element(corrupted[idx]);
+        },
+    );
+}
+
+/// Corrupting the input y-coordinate must violate the curve-membership and
+/// consistency constraints.
+#[test]
+fn test_single_point_rejects_off_curve_input() {
+    let curve = Secp256r1;
+    let gx = curve.generator().0;
+    let gy = curve.generator().1;
+    let scalar: [u64; 4] = [7, 0, 0, 0];
+    let (ex, ey) = ec_scalar_mul(
+        &gx,
+        &gy,
+        &scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+    let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 1);
+    let py_off_curve = increment_u256(&gy);
+    let py_off_curve_fes = u256_to_limb_fes(&py_off_curve, limb_bits, num_limbs);
+    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+
+    assert_single_point_corruption_is_rejected(fixture, "off-curve input", |layout, corrupted| {
+        overwrite_witness_values(corrupted, &layout.point_y_limbs, &py_off_curve_fes);
+    });
+}
+
+/// Replacing the expected output with a different scalar multiple must fail.
+#[test]
+fn test_single_point_rejects_wrong_scalar_output_pairing() {
+    let curve = Secp256r1;
+    let gx = curve.generator().0;
+    let gy = curve.generator().1;
+    let scalar: [u64; 4] = [7, 0, 0, 0];
+    let wrong_scalar: [u64; 4] = [5, 0, 0, 0];
+    let (ex, ey) = ec_scalar_mul(
+        &gx,
+        &gy,
+        &scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+    let (wrong_ex, wrong_ey) = ec_scalar_mul(
+        &gx,
+        &gy,
+        &wrong_scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+    let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 1);
+    let wrong_ex_fes = u256_to_limb_fes(&wrong_ex, limb_bits, num_limbs);
+    let wrong_ey_fes = u256_to_limb_fes(&wrong_ey, limb_bits, num_limbs);
+    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+
+    assert_single_point_corruption_is_rejected(
+        fixture,
+        "wrong scalar/output pairing",
+        |layout, corrupted| {
+            overwrite_witness_values(corrupted, &layout.out_x_limbs, &wrong_ex_fes);
+            overwrite_witness_values(corrupted, &layout.out_y_limbs, &wrong_ey_fes);
+        },
+    );
+}
+
+/// Zeroing s2 must violate the explicit s2 != 0 soundness check.
+#[test]
+fn test_single_point_rejects_zero_s2_forgery() {
+    let curve = Secp256r1;
+    let gx = curve.generator().0;
+    let gy = curve.generator().1;
+    let scalar: [u64; 4] = [17, 0, 0, 0];
+    let (ex, ey) = ec_scalar_mul(
+        &gx,
+        &gy,
+        &scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+
+    assert_single_point_corruption_is_rejected(fixture, "s2 forgery", |layout, corrupted| {
+        assert_ne!(
+            corrupted[layout.fake_glv.s1],
+            FieldElement::zero(),
+            "valid witness should produce a non-zero s1"
+        );
+        assert_ne!(
+            corrupted[layout.fake_glv.s2],
+            FieldElement::zero(),
+            "valid witness should produce a non-zero s2"
+        );
+        corrupted[layout.fake_glv.s2] = FieldElement::zero();
+    });
+}
+
+/// Flipping neg1 must violate the scalar relation tying the GLV decomposition
+/// back to the original scalar.
+#[test]
+fn test_single_point_rejects_flipped_neg1_bit() {
+    let curve = Secp256r1;
+    let gx = curve.generator().0;
+    let gy = curve.generator().1;
+    let scalar: [u64; 4] = [17, 0, 0, 0];
+    let (ex, ey) = ec_scalar_mul(
+        &gx,
+        &gy,
+        &scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+
+    assert_single_point_corruption_is_rejected(fixture, "flipped neg1 bit", |layout, corrupted| {
+        assert!(
+            corrupted[layout.fake_glv.neg1] == FieldElement::zero()
+                || corrupted[layout.fake_glv.neg1] == FieldElement::from(1u64),
+            "neg1 should be boolean"
+        );
+        assert!(
+            corrupted[layout.fake_glv.neg2] == FieldElement::zero()
+                || corrupted[layout.fake_glv.neg2] == FieldElement::from(1u64),
+            "neg2 should be boolean"
+        );
+        corrupted[layout.fake_glv.neg1] = different_field_element(corrupted[layout.fake_glv.neg1]);
+    });
 }
 
 /// Two-point MSM: s1·P1 + s2·P2 with arbitrary coordinates.

--- a/tooling/provekit-bench/tests/msm_witness_solving.rs
+++ b/tooling/provekit-bench/tests/msm_witness_solving.rs
@@ -356,21 +356,24 @@ fn build_default_two_point_msm_fixture() -> TwoPointMsmFixture {
 }
 
 /// Locate the single FakeGLV hint used by the single-point MSM circuit.
-  fn locate_single_point_fake_glv(builders: &[WitnessBuilder]) -> FakeGlvWitnessIndices {
-      let mut iter = builders.iter().filter_map(|builder| match builder {
-          WitnessBuilder::FakeGLVHint { output_start, .. } => Some(FakeGlvWitnessIndices {
-              s1:   *output_start,
-              s2:   *output_start + 1,
-              neg1: *output_start + 2,
-              neg2: *output_start + 3,
-          }),
-          _ => None,
-      });
+fn locate_single_point_fake_glv(builders: &[WitnessBuilder]) -> FakeGlvWitnessIndices {
+    let mut iter = builders.iter().filter_map(|builder| match builder {
+        WitnessBuilder::FakeGLVHint { output_start, .. } => Some(FakeGlvWitnessIndices {
+            s1:   *output_start,
+            s2:   *output_start + 1,
+            neg1: *output_start + 2,
+            neg2: *output_start + 3,
+        }),
+        _ => None,
+    });
 
-      let result = iter.next().expect("should have at least one FakeGLV hint");
-      assert!(iter.next().is_none(), "should have exactly one FakeGLV hint");
-      result
-  }
+    let result = iter.next().expect("should have at least one FakeGLV hint");
+    assert!(
+        iter.next().is_none(),
+        "should have exactly one FakeGLV hint"
+    );
+    result
+}
 
 /// Build the single-point secp256r1 MSM circuit together with stable witness
 /// metadata used by the negative tests.

--- a/tooling/provekit-bench/tests/msm_witness_solving.rs
+++ b/tooling/provekit-bench/tests/msm_witness_solving.rs
@@ -356,27 +356,21 @@ fn build_default_two_point_msm_fixture() -> TwoPointMsmFixture {
 }
 
 /// Locate the single FakeGLV hint used by the single-point MSM circuit.
-fn locate_single_point_fake_glv(builders: &[WitnessBuilder]) -> FakeGlvWitnessIndices {
-    let fake_glv_indices: Vec<FakeGlvWitnessIndices> = builders
-        .iter()
-        .filter_map(|builder| match builder {
-            WitnessBuilder::FakeGLVHint { output_start, .. } => Some(FakeGlvWitnessIndices {
-                s1:   *output_start,
-                s2:   *output_start + 1,
-                neg1: *output_start + 2,
-                neg2: *output_start + 3,
-            }),
-            _ => None,
-        })
-        .collect();
+  fn locate_single_point_fake_glv(builders: &[WitnessBuilder]) -> FakeGlvWitnessIndices {
+      let mut iter = builders.iter().filter_map(|builder| match builder {
+          WitnessBuilder::FakeGLVHint { output_start, .. } => Some(FakeGlvWitnessIndices {
+              s1:   *output_start,
+              s2:   *output_start + 1,
+              neg1: *output_start + 2,
+              neg2: *output_start + 3,
+          }),
+          _ => None,
+      });
 
-    assert_eq!(
-        fake_glv_indices.len(),
-        1,
-        "single-point MSM circuit should contain exactly one FakeGLV hint"
-    );
-    fake_glv_indices[0]
-}
+      let result = iter.next().expect("should have at least one FakeGLV hint");
+      assert!(iter.next().is_none(), "should have exactly one FakeGLV hint");
+      result
+  }
 
 /// Build the single-point secp256r1 MSM circuit together with stable witness
 /// metadata used by the negative tests.

--- a/tooling/provekit-bench/tests/msm_witness_solving.rs
+++ b/tooling/provekit-bench/tests/msm_witness_solving.rs
@@ -137,12 +137,19 @@ fn increment_u256(v: &[u64; 4]) -> [u64; 4] {
     out
 }
 
-/// Pick a different field element without relying on arithmetic traits.
-fn different_field_element(value: FieldElement) -> FieldElement {
+/// Return a field element guaranteed to differ from `value`.
+fn corrupt_field_element(value: FieldElement) -> FieldElement {
+    value + FieldElement::from(1u64)
+}
+
+/// Flip a boolean field element between 0 and 1.
+fn flip_boolean_field_element(value: FieldElement) -> FieldElement {
     if value == FieldElement::zero() {
         FieldElement::from(1u64)
-    } else {
+    } else if value == FieldElement::from(1u64) {
         FieldElement::zero()
+    } else {
+        panic!("expected boolean field element");
     }
 }
 
@@ -478,10 +485,10 @@ fn test_arbitrary_point_and_scalar() {
     run_single_point_msm_test_limbed(&px, &py, false, &scalar, &ex, &ey, false);
 }
 
-/// Corrupting an expected output limb must violate the output equality
-/// constraints.
+/// Corrupting an expected output x-limb or y-limb must violate the output
+/// equality constraints.
 #[test]
-fn test_single_point_rejects_wrong_output_coordinate() {
+fn test_single_point_rejects_wrong_output_coordinates() {
     let curve = Secp256r1;
     let gx = curve.generator().0;
     let gy = curve.generator().1;
@@ -493,22 +500,25 @@ fn test_single_point_rejects_wrong_output_coordinate() {
         &curve.curve_a(),
         &curve.field_modulus_p(),
     );
-    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
 
-    assert_single_point_corruption_is_rejected(
-        fixture,
-        "wrong output coordinate",
-        |layout, corrupted| {
-            let idx = layout.out_x_limbs[0];
-            corrupted[idx] = different_field_element(corrupted[idx]);
-        },
-    );
+    let get_x: fn(&SinglePointMsmLayout) -> usize = |l| l.out_x_limbs[0];
+    let get_y: fn(&SinglePointMsmLayout) -> usize = |l| l.out_y_limbs[0];
+    for (label, get_idx) in [("out_x", get_x), ("out_y", get_y)] {
+        let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+        assert_single_point_corruption_is_rejected(
+            fixture,
+            &format!("wrong output coordinate ({label})"),
+            |layout, corrupted| {
+                let idx = get_idx(layout);
+                corrupted[idx] = corrupt_field_element(corrupted[idx]);
+            },
+        );
+    }
 }
 
-/// Corrupting an expected output y-limb must also violate the output equality
-/// constraints.
+/// Corrupting the output infinity flag must violate the output constraints.
 #[test]
-fn test_single_point_rejects_wrong_output_y_coordinate() {
+fn test_single_point_rejects_wrong_output_inf() {
     let curve = Secp256r1;
     let gx = curve.generator().0;
     let gy = curve.generator().1;
@@ -524,10 +534,9 @@ fn test_single_point_rejects_wrong_output_y_coordinate() {
 
     assert_single_point_corruption_is_rejected(
         fixture,
-        "wrong output y coordinate",
+        "wrong output inf flag",
         |layout, corrupted| {
-            let idx = layout.out_y_limbs[0];
-            corrupted[idx] = different_field_element(corrupted[idx]);
+            corrupted[layout.out_inf] = corrupt_field_element(corrupted[layout.out_inf]);
         },
     );
 }
@@ -653,10 +662,10 @@ fn test_single_point_rejects_zero_s2_forgery() {
     });
 }
 
-/// Flipping neg1 must violate the scalar relation tying the GLV decomposition
-/// back to the original scalar.
+/// Flipping neg1 or neg2 must violate the scalar relation tying the GLV
+/// decomposition back to the original scalar.
 #[test]
-fn test_single_point_rejects_flipped_neg1_bit() {
+fn test_single_point_rejects_flipped_neg_bits() {
     let curve = Secp256r1;
     let gx = curve.generator().0;
     let gy = curve.generator().1;
@@ -668,21 +677,20 @@ fn test_single_point_rejects_flipped_neg1_bit() {
         &curve.curve_a(),
         &curve.field_modulus_p(),
     );
-    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
 
-    assert_single_point_corruption_is_rejected(fixture, "flipped neg1 bit", |layout, corrupted| {
-        assert!(
-            corrupted[layout.fake_glv.neg1] == FieldElement::zero()
-                || corrupted[layout.fake_glv.neg1] == FieldElement::from(1u64),
-            "neg1 should be boolean"
+    let get_neg1: fn(&FakeGlvWitnessIndices) -> usize = |g| g.neg1;
+    let get_neg2: fn(&FakeGlvWitnessIndices) -> usize = |g| g.neg2;
+    for (label, get_idx) in [("neg1", get_neg1), ("neg2", get_neg2)] {
+        let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+        assert_single_point_corruption_is_rejected(
+            fixture,
+            &format!("flipped {label} bit"),
+            |layout, corrupted| {
+                let idx = get_idx(&layout.fake_glv);
+                corrupted[idx] = flip_boolean_field_element(corrupted[idx]);
+            },
         );
-        assert!(
-            corrupted[layout.fake_glv.neg2] == FieldElement::zero()
-                || corrupted[layout.fake_glv.neg2] == FieldElement::from(1u64),
-            "neg2 should be boolean"
-        );
-        corrupted[layout.fake_glv.neg1] = different_field_element(corrupted[layout.fake_glv.neg1]);
-    });
+    }
 }
 
 /// Two-point MSM: s1·P1 + s2·P2 with arbitrary coordinates.
@@ -884,4 +892,109 @@ fn test_two_point_one_zero_scalar() {
 
     check_r1cs_satisfaction(&compiler.r1cs, &witness)
         .expect("R1CS satisfaction check failed for two-point MSM with one zero scalar");
+}
+
+/// Two-point MSM: corrupting the output must be rejected, exercising the
+/// multi-point accumulation and output-constraining path.
+#[test]
+fn test_two_point_msm_rejects_wrong_output() {
+    let curve = Secp256r1;
+    let gx = curve.generator().0;
+    let gy = curve.generator().1;
+    let a = &curve.curve_a();
+    let p = &curve.field_modulus_p();
+    let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 2);
+    let stride = 2 * num_limbs + 1;
+
+    // P1 = 3·G, P2 = 5·G
+    let (p1x, p1y) = ec_scalar_mul(&gx, &gy, &[3, 0, 0, 0], a, p);
+    let (p2x, p2y) = ec_scalar_mul(&gx, &gy, &[5, 0, 0, 0], a, p);
+    let s1: [u64; 4] = [2, 0, 0, 0];
+    let s2: [u64; 4] = [3, 0, 0, 0];
+    // Expected: 2·(3G) + 3·(5G) = 6G + 15G = 21G
+    let (ex, ey) = ec_scalar_mul(&gx, &gy, &[21, 0, 0, 0], a, p);
+
+    let (s1_lo, s1_hi) = split_scalar(&s1);
+    let (s2_lo, s2_hi) = split_scalar(&s2);
+
+    let p1x_fes = u256_to_limb_fes(&p1x, limb_bits, num_limbs);
+    let p1y_fes = u256_to_limb_fes(&p1y, limb_bits, num_limbs);
+    let p2x_fes = u256_to_limb_fes(&p2x, limb_bits, num_limbs);
+    let p2y_fes = u256_to_limb_fes(&p2y, limb_bits, num_limbs);
+    let ex_fes = u256_to_limb_fes(&ex, limb_bits, num_limbs);
+    let ey_fes = u256_to_limb_fes(&ey, limb_bits, num_limbs);
+
+    let mut compiler = NoirToR1CSCompiler::new();
+    let mut range_checks: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
+
+    let base = compiler.num_witnesses();
+    let total = 2 * stride + 4 + stride;
+    compiler.r1cs.add_witnesses(total);
+
+    let points: Vec<ConstantOrR1CSWitness> = (0..2 * stride)
+        .map(|j| ConstantOrR1CSWitness::Witness(base + j))
+        .collect();
+    let scalar_base = base + 2 * stride;
+    let scalars = vec![
+        ConstantOrR1CSWitness::Witness(scalar_base),
+        ConstantOrR1CSWitness::Witness(scalar_base + 1),
+        ConstantOrR1CSWitness::Witness(scalar_base + 2),
+        ConstantOrR1CSWitness::Witness(scalar_base + 3),
+    ];
+    let out_base = scalar_base + 4;
+    let out_x_limbs: Vec<usize> = (0..num_limbs).map(|j| out_base + j).collect();
+    let out_y_limbs: Vec<usize> = (0..num_limbs).map(|j| out_base + num_limbs + j).collect();
+    let out_inf = out_base + 2 * num_limbs;
+
+    let outputs = MsmLimbedOutputs {
+        out_x_limbs: out_x_limbs.clone(),
+        out_y_limbs: out_y_limbs.clone(),
+        out_inf,
+    };
+    let msm_ops = vec![(points, scalars, outputs)];
+    add_msm_with_curve(&mut compiler, msm_ops, &mut range_checks, &curve);
+    add_range_checks(&mut compiler, range_checks);
+
+    let num_witnesses = compiler.num_witnesses();
+
+    let mut initial_values = vec![(0, FieldElement::from(1u64))];
+    for (j, fe) in p1x_fes.iter().enumerate() {
+        initial_values.push((base + j, *fe));
+    }
+    for (j, fe) in p1y_fes.iter().enumerate() {
+        initial_values.push((base + num_limbs + j, *fe));
+    }
+    initial_values.push((base + 2 * num_limbs, FieldElement::zero()));
+    let p2_base = base + stride;
+    for (j, fe) in p2x_fes.iter().enumerate() {
+        initial_values.push((p2_base + j, *fe));
+    }
+    for (j, fe) in p2y_fes.iter().enumerate() {
+        initial_values.push((p2_base + num_limbs + j, *fe));
+    }
+    initial_values.push((p2_base + 2 * num_limbs, FieldElement::zero()));
+    initial_values.push((scalar_base, u256_to_fe(&s1_lo)));
+    initial_values.push((scalar_base + 1, u256_to_fe(&s1_hi)));
+    initial_values.push((scalar_base + 2, u256_to_fe(&s2_lo)));
+    initial_values.push((scalar_base + 3, u256_to_fe(&s2_hi)));
+    for (j, fe) in ex_fes.iter().enumerate() {
+        initial_values.push((out_x_limbs[j], *fe));
+    }
+    for (j, fe) in ey_fes.iter().enumerate() {
+        initial_values.push((out_y_limbs[j], *fe));
+    }
+    initial_values.push((out_inf, FieldElement::zero()));
+
+    let witness = solve_witnesses(&compiler.witness_builders, num_witnesses, &initial_values);
+    check_r1cs_satisfaction(&compiler.r1cs, &witness)
+        .expect("valid two-point MSM witness should satisfy R1CS");
+
+    // Corrupt the output x-limb
+    let mut corrupted = witness;
+    corrupted[out_x_limbs[0]] = corrupt_field_element(corrupted[out_x_limbs[0]]);
+
+    assert!(
+        check_r1cs_satisfaction(&compiler.r1cs, &corrupted).is_err(),
+        "corrupted two-point MSM output should fail R1CS satisfaction"
+    );
 }

--- a/tooling/provekit-bench/tests/msm_witness_solving.rs
+++ b/tooling/provekit-bench/tests/msm_witness_solving.rs
@@ -197,6 +197,20 @@ struct SinglePointMsmFixture {
     layout:         SinglePointMsmLayout,
 }
 
+/// Return the secp256r1 generator coordinates.
+fn secp256r1_generator() -> ([u64; 4], [u64; 4]) {
+    let curve = Secp256r1;
+    (curve.generator().0, curve.generator().1)
+}
+
+/// Return the secp256r1 generator together with curve parameters used by
+/// the local scalar-multiplication helpers in this test file.
+fn secp256r1_generator_params() -> ([u64; 4], [u64; 4], [u64; 4], [u64; 4]) {
+    let curve = Secp256r1;
+    let (gx, gy) = secp256r1_generator();
+    (gx, gy, curve.curve_a(), curve.field_modulus_p())
+}
+
 #[derive(Clone, Copy, Debug)]
 struct SinglePointGeneratorCase {
     point_x:    [u64; 4],
@@ -208,16 +222,9 @@ struct SinglePointGeneratorCase {
 
 /// Build a single-point secp256r1 generator case for the given scalar.
 fn secp256r1_generator_case(scalar: [u64; 4]) -> SinglePointGeneratorCase {
-    let curve = Secp256r1;
-    let point_x = curve.generator().0;
-    let point_y = curve.generator().1;
-    let (expected_x, expected_y) = ec_scalar_mul(
-        &point_x,
-        &point_y,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
+    let (point_x, point_y, curve_a, field_modulus_p) = secp256r1_generator_params();
+    let (expected_x, expected_y) =
+        ec_scalar_mul(&point_x, &point_y, &scalar, &curve_a, &field_modulus_p);
 
     SinglePointGeneratorCase {
         point_x,
@@ -239,6 +246,113 @@ fn build_generator_single_point_fixture(case: SinglePointGeneratorCase) -> Singl
         &case.expected_y,
         false,
     )
+}
+
+/// Build the single-point generator fixture directly from the scalar.
+fn generator_fixture(scalar: [u64; 4]) -> SinglePointMsmFixture {
+    build_generator_single_point_fixture(secp256r1_generator_case(scalar))
+}
+
+struct TwoPointMsmFixture {
+    compiler:    NoirToR1CSCompiler,
+    witness:     Vec<FieldElement>,
+    out_x_limbs: Vec<usize>,
+}
+
+/// Build the shared two-point generator-based MSM witness used by the
+/// positive and negative two-point tests.
+fn build_default_two_point_msm_fixture() -> TwoPointMsmFixture {
+    let (gx, gy, curve_a, field_modulus_p) = secp256r1_generator_params();
+    let curve = Secp256r1;
+    let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 2);
+    let stride = 2 * num_limbs + 1;
+
+    // P1 = 3·G, P2 = 5·G
+    let (p1x, p1y) = ec_scalar_mul(&gx, &gy, &[3, 0, 0, 0], &curve_a, &field_modulus_p);
+    let (p2x, p2y) = ec_scalar_mul(&gx, &gy, &[5, 0, 0, 0], &curve_a, &field_modulus_p);
+    let s1: [u64; 4] = [2, 0, 0, 0];
+    let s2: [u64; 4] = [3, 0, 0, 0];
+    // Expected: 2·(3G) + 3·(5G) = 6G + 15G = 21G
+    let (ex, ey) = ec_scalar_mul(&gx, &gy, &[21, 0, 0, 0], &curve_a, &field_modulus_p);
+
+    let (s1_lo, s1_hi) = split_scalar(&s1);
+    let (s2_lo, s2_hi) = split_scalar(&s2);
+
+    let p1x_fes = u256_to_limb_fes(&p1x, limb_bits, num_limbs);
+    let p1y_fes = u256_to_limb_fes(&p1y, limb_bits, num_limbs);
+    let p2x_fes = u256_to_limb_fes(&p2x, limb_bits, num_limbs);
+    let p2y_fes = u256_to_limb_fes(&p2y, limb_bits, num_limbs);
+    let ex_fes = u256_to_limb_fes(&ex, limb_bits, num_limbs);
+    let ey_fes = u256_to_limb_fes(&ey, limb_bits, num_limbs);
+
+    let mut compiler = NoirToR1CSCompiler::new();
+    let mut range_checks: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
+
+    let base = compiler.num_witnesses();
+    let total = 2 * stride + 4 + stride;
+    compiler.r1cs.add_witnesses(total);
+
+    let points: Vec<ConstantOrR1CSWitness> = (0..2 * stride)
+        .map(|j| ConstantOrR1CSWitness::Witness(base + j))
+        .collect();
+    let scalar_base = base + 2 * stride;
+    let scalars = vec![
+        ConstantOrR1CSWitness::Witness(scalar_base),
+        ConstantOrR1CSWitness::Witness(scalar_base + 1),
+        ConstantOrR1CSWitness::Witness(scalar_base + 2),
+        ConstantOrR1CSWitness::Witness(scalar_base + 3),
+    ];
+    let out_base = scalar_base + 4;
+    let out_x_limbs: Vec<usize> = (0..num_limbs).map(|j| out_base + j).collect();
+    let out_y_limbs: Vec<usize> = (0..num_limbs).map(|j| out_base + num_limbs + j).collect();
+    let out_inf = out_base + 2 * num_limbs;
+
+    let outputs = MsmLimbedOutputs {
+        out_x_limbs: out_x_limbs.clone(),
+        out_y_limbs: out_y_limbs.clone(),
+        out_inf,
+    };
+    let msm_ops = vec![(points, scalars, outputs)];
+    add_msm_with_curve(&mut compiler, msm_ops, &mut range_checks, &curve);
+    add_range_checks(&mut compiler, range_checks);
+
+    let num_witnesses = compiler.num_witnesses();
+
+    let mut initial_values = vec![(0, FieldElement::from(1u64))];
+    for (j, fe) in p1x_fes.iter().enumerate() {
+        initial_values.push((base + j, *fe));
+    }
+    for (j, fe) in p1y_fes.iter().enumerate() {
+        initial_values.push((base + num_limbs + j, *fe));
+    }
+    initial_values.push((base + 2 * num_limbs, FieldElement::zero()));
+    let p2_base = base + stride;
+    for (j, fe) in p2x_fes.iter().enumerate() {
+        initial_values.push((p2_base + j, *fe));
+    }
+    for (j, fe) in p2y_fes.iter().enumerate() {
+        initial_values.push((p2_base + num_limbs + j, *fe));
+    }
+    initial_values.push((p2_base + 2 * num_limbs, FieldElement::zero()));
+    initial_values.push((scalar_base, u256_to_fe(&s1_lo)));
+    initial_values.push((scalar_base + 1, u256_to_fe(&s1_hi)));
+    initial_values.push((scalar_base + 2, u256_to_fe(&s2_lo)));
+    initial_values.push((scalar_base + 3, u256_to_fe(&s2_hi)));
+    for (j, fe) in ex_fes.iter().enumerate() {
+        initial_values.push((out_x_limbs[j], *fe));
+    }
+    for (j, fe) in ey_fes.iter().enumerate() {
+        initial_values.push((out_y_limbs[j], *fe));
+    }
+    initial_values.push((out_inf, FieldElement::zero()));
+
+    let witness = solve_witnesses(&compiler.witness_builders, num_witnesses, &initial_values);
+
+    TwoPointMsmFixture {
+        compiler,
+        witness,
+        out_x_limbs,
+    }
 }
 
 /// Locate the single FakeGLV hint used by the single-point MSM circuit.
@@ -431,17 +545,9 @@ fn run_single_point_msm_test_limbed(
 /// The generator's x-coordinate exceeds BN254 Fr.
 #[test]
 fn test_single_point_generator() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
+    let (gx, gy, curve_a, field_modulus_p) = secp256r1_generator_params();
     let scalar: [u64; 4] = [7, 0, 0, 0];
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
+    let (ex, ey) = ec_scalar_mul(&gx, &gy, &scalar, &curve_a, &field_modulus_p);
 
     run_single_point_msm_test_limbed(&gx, &gy, false, &scalar, &ex, &ey, false);
 }
@@ -449,9 +555,7 @@ fn test_single_point_generator() {
 /// Scalar = 1: result should equal the input point.
 #[test]
 fn test_scalar_one() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
+    let (gx, gy) = secp256r1_generator();
     let scalar: [u64; 4] = [1, 0, 0, 0];
 
     // 1·G = G
@@ -461,17 +565,9 @@ fn test_scalar_one() {
 /// Large scalar spanning both lo and hi halves of the 256-bit representation.
 #[test]
 fn test_large_scalar() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
+    let (gx, gy, curve_a, field_modulus_p) = secp256r1_generator_params();
     let scalar: [u64; 4] = [0xcafebabe, 0x12345678, 0x42, 0];
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
+    let (ex, ey) = ec_scalar_mul(&gx, &gy, &scalar, &curve_a, &field_modulus_p);
 
     run_single_point_msm_test_limbed(&gx, &gy, false, &scalar, &ex, &ey, false);
 }
@@ -479,9 +575,7 @@ fn test_large_scalar() {
 /// Zero scalar: result should be point at infinity.
 #[test]
 fn test_zero_scalar() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
+    let (gx, gy) = secp256r1_generator();
     let zero_scalar: [u64; 4] = [0, 0, 0, 0];
     let zero_point: [u64; 4] = [0, 0, 0, 0];
 
@@ -500,10 +594,8 @@ fn test_zero_scalar() {
 /// of scalar.
 #[test]
 fn test_point_at_infinity_input() {
-    let curve = Secp256r1;
     // Use generator coords as placeholder (they're ignored due to inf=1 select)
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
+    let (gx, gy) = secp256r1_generator();
     let scalar: [u64; 4] = [42, 0, 0, 0];
     let zero_point: [u64; 4] = [0, 0, 0, 0];
 
@@ -514,17 +606,13 @@ fn test_point_at_infinity_input() {
 /// wNAF + FakeGLV pipeline.
 #[test]
 fn test_arbitrary_point_and_scalar() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let a = &curve.curve_a();
-    let p = &curve.field_modulus_p();
+    let (gx, gy, curve_a, field_modulus_p) = secp256r1_generator_params();
 
     // P = 2·G
-    let (px, py) = ec_scalar_mul(&gx, &gy, &[2, 0, 0, 0], a, p);
+    let (px, py) = ec_scalar_mul(&gx, &gy, &[2, 0, 0, 0], &curve_a, &field_modulus_p);
     let scalar: [u64; 4] = [17, 0, 0, 0];
     // Expected: 17·(2G) = 34G
-    let (ex, ey) = ec_scalar_mul(&gx, &gy, &[34, 0, 0, 0], a, p);
+    let (ex, ey) = ec_scalar_mul(&gx, &gy, &[34, 0, 0, 0], &curve_a, &field_modulus_p);
 
     run_single_point_msm_test_limbed(&px, &py, false, &scalar, &ex, &ey, false);
 }
@@ -533,12 +621,10 @@ fn test_arbitrary_point_and_scalar() {
 /// equality constraints.
 #[test]
 fn test_single_point_rejects_wrong_output_coordinates() {
-    let case = secp256r1_generator_case([7, 0, 0, 0]);
-
     let get_x: fn(&SinglePointMsmLayout) -> usize = |l| l.out_x_limbs[0];
     let get_y: fn(&SinglePointMsmLayout) -> usize = |l| l.out_y_limbs[0];
     for (label, get_idx) in [("out_x", get_x), ("out_y", get_y)] {
-        let fixture = build_generator_single_point_fixture(case);
+        let fixture = generator_fixture([7, 0, 0, 0]);
         assert_single_point_corruption_is_rejected(
             fixture,
             &format!("wrong output coordinate ({label})"),
@@ -553,8 +639,7 @@ fn test_single_point_rejects_wrong_output_coordinates() {
 /// Corrupting the output infinity flag must violate the output constraints.
 #[test]
 fn test_single_point_rejects_wrong_output_inf() {
-    let case = secp256r1_generator_case([7, 0, 0, 0]);
-    let fixture = build_generator_single_point_fixture(case);
+    let fixture = generator_fixture([7, 0, 0, 0]);
 
     assert_single_point_corruption_is_rejected(
         fixture,
@@ -603,10 +688,9 @@ fn test_single_point_rejects_wrong_scalar_output_pairing() {
 /// Replacing the scalar input while keeping the original output must fail.
 #[test]
 fn test_single_point_rejects_scalar_corruption() {
-    let case = secp256r1_generator_case([7, 0, 0, 0]);
     let wrong_scalar: [u64; 4] = [5, 0, 0, 0];
     let (wrong_lo, wrong_hi) = split_scalar(&wrong_scalar);
-    let fixture = build_generator_single_point_fixture(case);
+    let fixture = generator_fixture([7, 0, 0, 0]);
 
     assert_single_point_corruption_is_rejected(
         fixture,
@@ -621,8 +705,7 @@ fn test_single_point_rejects_scalar_corruption() {
 /// Zeroing s2 must violate the explicit s2 != 0 soundness check.
 #[test]
 fn test_single_point_rejects_zero_s2_forgery() {
-    let case = secp256r1_generator_case([17, 0, 0, 0]);
-    let fixture = build_generator_single_point_fixture(case);
+    let fixture = generator_fixture([17, 0, 0, 0]);
 
     assert_single_point_corruption_is_rejected(fixture, "s2 forgery", |layout, corrupted| {
         assert_ne!(
@@ -643,12 +726,10 @@ fn test_single_point_rejects_zero_s2_forgery() {
 /// decomposition back to the original scalar.
 #[test]
 fn test_single_point_rejects_flipped_neg_bits() {
-    let case = secp256r1_generator_case([17, 0, 0, 0]);
-
     let get_neg1: fn(&FakeGlvWitnessIndices) -> usize = |g| g.neg1;
     let get_neg2: fn(&FakeGlvWitnessIndices) -> usize = |g| g.neg2;
     for (label, get_idx) in [("neg1", get_neg1), ("neg2", get_neg2)] {
-        let fixture = build_generator_single_point_fixture(case);
+        let fixture = generator_fixture([17, 0, 0, 0]);
         assert_single_point_corruption_is_rejected(
             fixture,
             &format!("flipped {label} bit"),
@@ -663,101 +744,9 @@ fn test_single_point_rejects_flipped_neg_bits() {
 /// Two-point MSM: s1·P1 + s2·P2 with arbitrary coordinates.
 #[test]
 fn test_two_point_msm() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let a = &curve.curve_a();
-    let p = &curve.field_modulus_p();
-    let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 2);
-    let stride = 2 * num_limbs + 1;
+    let fixture = build_default_two_point_msm_fixture();
 
-    // P1 = 3·G, P2 = 5·G
-    let (p1x, p1y) = ec_scalar_mul(&gx, &gy, &[3, 0, 0, 0], a, p);
-    let (p2x, p2y) = ec_scalar_mul(&gx, &gy, &[5, 0, 0, 0], a, p);
-    let s1: [u64; 4] = [2, 0, 0, 0];
-    let s2: [u64; 4] = [3, 0, 0, 0];
-    // Expected: 2·(3G) + 3·(5G) = 6G + 15G = 21G
-    let (ex, ey) = ec_scalar_mul(&gx, &gy, &[21, 0, 0, 0], a, p);
-
-    let (s1_lo, s1_hi) = split_scalar(&s1);
-    let (s2_lo, s2_hi) = split_scalar(&s2);
-
-    let p1x_fes = u256_to_limb_fes(&p1x, limb_bits, num_limbs);
-    let p1y_fes = u256_to_limb_fes(&p1y, limb_bits, num_limbs);
-    let p2x_fes = u256_to_limb_fes(&p2x, limb_bits, num_limbs);
-    let p2y_fes = u256_to_limb_fes(&p2y, limb_bits, num_limbs);
-    let ex_fes = u256_to_limb_fes(&ex, limb_bits, num_limbs);
-    let ey_fes = u256_to_limb_fes(&ey, limb_bits, num_limbs);
-
-    let mut compiler = NoirToR1CSCompiler::new();
-    let mut range_checks: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
-
-    let base = compiler.num_witnesses();
-    let total = 2 * stride + 4 + stride;
-    compiler.r1cs.add_witnesses(total);
-
-    let points: Vec<ConstantOrR1CSWitness> = (0..2 * stride)
-        .map(|j| ConstantOrR1CSWitness::Witness(base + j))
-        .collect();
-    let scalar_base = base + 2 * stride;
-    let scalars = vec![
-        ConstantOrR1CSWitness::Witness(scalar_base),
-        ConstantOrR1CSWitness::Witness(scalar_base + 1),
-        ConstantOrR1CSWitness::Witness(scalar_base + 2),
-        ConstantOrR1CSWitness::Witness(scalar_base + 3),
-    ];
-    let out_base = scalar_base + 4;
-    let out_x_limbs: Vec<usize> = (0..num_limbs).map(|j| out_base + j).collect();
-    let out_y_limbs: Vec<usize> = (0..num_limbs).map(|j| out_base + num_limbs + j).collect();
-    let out_inf = out_base + 2 * num_limbs;
-
-    let outputs = MsmLimbedOutputs {
-        out_x_limbs: out_x_limbs.clone(),
-        out_y_limbs: out_y_limbs.clone(),
-        out_inf,
-    };
-    let msm_ops = vec![(points, scalars, outputs)];
-    add_msm_with_curve(&mut compiler, msm_ops, &mut range_checks, &curve);
-    add_range_checks(&mut compiler, range_checks);
-
-    let num_witnesses = compiler.num_witnesses();
-
-    let mut initial_values = vec![(0, FieldElement::from(1u64))];
-    for (j, fe) in p1x_fes.iter().enumerate() {
-        initial_values.push((base + j, *fe));
-    }
-    for (j, fe) in p1y_fes.iter().enumerate() {
-        initial_values.push((base + num_limbs + j, *fe));
-    }
-    initial_values.push((base + 2 * num_limbs, FieldElement::zero()));
-    let p2_base = base + stride;
-    for (j, fe) in p2x_fes.iter().enumerate() {
-        initial_values.push((p2_base + j, *fe));
-    }
-    for (j, fe) in p2y_fes.iter().enumerate() {
-        initial_values.push((p2_base + num_limbs + j, *fe));
-    }
-    initial_values.push((p2_base + 2 * num_limbs, FieldElement::zero()));
-    initial_values.push((scalar_base, u256_to_fe(&s1_lo)));
-    initial_values.push((scalar_base + 1, u256_to_fe(&s1_hi)));
-    initial_values.push((scalar_base + 2, u256_to_fe(&s2_lo)));
-    initial_values.push((scalar_base + 3, u256_to_fe(&s2_hi)));
-    for (j, fe) in ex_fes.iter().enumerate() {
-        initial_values.push((out_x_limbs[j], *fe));
-    }
-    for (j, fe) in ey_fes.iter().enumerate() {
-        initial_values.push((out_y_limbs[j], *fe));
-    }
-    initial_values.push((out_inf, FieldElement::zero()));
-
-    let witness = solve_witnesses(&compiler.witness_builders, num_witnesses, &initial_values);
-    println!(">>> number of witnesses : {:?}", witness.len());
-    println!(
-        ">>> number of constraints : {:?}",
-        compiler.r1cs.num_constraints()
-    );
-
-    check_r1cs_satisfaction(&compiler.r1cs, &witness)
+    check_r1cs_satisfaction(&fixture.compiler.r1cs, &fixture.witness)
         .expect("R1CS satisfaction check failed for two-point MSM");
 }
 
@@ -765,20 +754,17 @@ fn test_two_point_msm() {
 /// should contribute.
 #[test]
 fn test_two_point_one_zero_scalar() {
+    let (gx, gy, curve_a, field_modulus_p) = secp256r1_generator_params();
     let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let a = &curve.curve_a();
-    let p = &curve.field_modulus_p();
     let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 2);
     let stride = 2 * num_limbs + 1;
 
     // P1 = G (scalar=5), P2 = 2G (scalar=0)
-    let (p2x, p2y) = ec_scalar_mul(&gx, &gy, &[2, 0, 0, 0], a, p);
+    let (p2x, p2y) = ec_scalar_mul(&gx, &gy, &[2, 0, 0, 0], &curve_a, &field_modulus_p);
     let s1: [u64; 4] = [5, 0, 0, 0];
     let s2: [u64; 4] = [0, 0, 0, 0];
     // Expected: 5·G + 0·(2G) = 5G
-    let (ex, ey) = ec_scalar_mul(&gx, &gy, &[5, 0, 0, 0], a, p);
+    let (ex, ey) = ec_scalar_mul(&gx, &gy, &[5, 0, 0, 0], &curve_a, &field_modulus_p);
 
     let (s1_lo, s1_hi) = split_scalar(&s1);
     let (s2_lo, s2_hi) = split_scalar(&s2);
@@ -865,103 +851,16 @@ fn test_two_point_one_zero_scalar() {
 /// multi-point accumulation and output-constraining path.
 #[test]
 fn test_two_point_msm_rejects_wrong_output() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let a = &curve.curve_a();
-    let p = &curve.field_modulus_p();
-    let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 2);
-    let stride = 2 * num_limbs + 1;
-
-    // P1 = 3·G, P2 = 5·G
-    let (p1x, p1y) = ec_scalar_mul(&gx, &gy, &[3, 0, 0, 0], a, p);
-    let (p2x, p2y) = ec_scalar_mul(&gx, &gy, &[5, 0, 0, 0], a, p);
-    let s1: [u64; 4] = [2, 0, 0, 0];
-    let s2: [u64; 4] = [3, 0, 0, 0];
-    // Expected: 2·(3G) + 3·(5G) = 6G + 15G = 21G
-    let (ex, ey) = ec_scalar_mul(&gx, &gy, &[21, 0, 0, 0], a, p);
-
-    let (s1_lo, s1_hi) = split_scalar(&s1);
-    let (s2_lo, s2_hi) = split_scalar(&s2);
-
-    let p1x_fes = u256_to_limb_fes(&p1x, limb_bits, num_limbs);
-    let p1y_fes = u256_to_limb_fes(&p1y, limb_bits, num_limbs);
-    let p2x_fes = u256_to_limb_fes(&p2x, limb_bits, num_limbs);
-    let p2y_fes = u256_to_limb_fes(&p2y, limb_bits, num_limbs);
-    let ex_fes = u256_to_limb_fes(&ex, limb_bits, num_limbs);
-    let ey_fes = u256_to_limb_fes(&ey, limb_bits, num_limbs);
-
-    let mut compiler = NoirToR1CSCompiler::new();
-    let mut range_checks: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
-
-    let base = compiler.num_witnesses();
-    let total = 2 * stride + 4 + stride;
-    compiler.r1cs.add_witnesses(total);
-
-    let points: Vec<ConstantOrR1CSWitness> = (0..2 * stride)
-        .map(|j| ConstantOrR1CSWitness::Witness(base + j))
-        .collect();
-    let scalar_base = base + 2 * stride;
-    let scalars = vec![
-        ConstantOrR1CSWitness::Witness(scalar_base),
-        ConstantOrR1CSWitness::Witness(scalar_base + 1),
-        ConstantOrR1CSWitness::Witness(scalar_base + 2),
-        ConstantOrR1CSWitness::Witness(scalar_base + 3),
-    ];
-    let out_base = scalar_base + 4;
-    let out_x_limbs: Vec<usize> = (0..num_limbs).map(|j| out_base + j).collect();
-    let out_y_limbs: Vec<usize> = (0..num_limbs).map(|j| out_base + num_limbs + j).collect();
-    let out_inf = out_base + 2 * num_limbs;
-
-    let outputs = MsmLimbedOutputs {
-        out_x_limbs: out_x_limbs.clone(),
-        out_y_limbs: out_y_limbs.clone(),
-        out_inf,
-    };
-    let msm_ops = vec![(points, scalars, outputs)];
-    add_msm_with_curve(&mut compiler, msm_ops, &mut range_checks, &curve);
-    add_range_checks(&mut compiler, range_checks);
-
-    let num_witnesses = compiler.num_witnesses();
-
-    let mut initial_values = vec![(0, FieldElement::from(1u64))];
-    for (j, fe) in p1x_fes.iter().enumerate() {
-        initial_values.push((base + j, *fe));
-    }
-    for (j, fe) in p1y_fes.iter().enumerate() {
-        initial_values.push((base + num_limbs + j, *fe));
-    }
-    initial_values.push((base + 2 * num_limbs, FieldElement::zero()));
-    let p2_base = base + stride;
-    for (j, fe) in p2x_fes.iter().enumerate() {
-        initial_values.push((p2_base + j, *fe));
-    }
-    for (j, fe) in p2y_fes.iter().enumerate() {
-        initial_values.push((p2_base + num_limbs + j, *fe));
-    }
-    initial_values.push((p2_base + 2 * num_limbs, FieldElement::zero()));
-    initial_values.push((scalar_base, u256_to_fe(&s1_lo)));
-    initial_values.push((scalar_base + 1, u256_to_fe(&s1_hi)));
-    initial_values.push((scalar_base + 2, u256_to_fe(&s2_lo)));
-    initial_values.push((scalar_base + 3, u256_to_fe(&s2_hi)));
-    for (j, fe) in ex_fes.iter().enumerate() {
-        initial_values.push((out_x_limbs[j], *fe));
-    }
-    for (j, fe) in ey_fes.iter().enumerate() {
-        initial_values.push((out_y_limbs[j], *fe));
-    }
-    initial_values.push((out_inf, FieldElement::zero()));
-
-    let witness = solve_witnesses(&compiler.witness_builders, num_witnesses, &initial_values);
-    check_r1cs_satisfaction(&compiler.r1cs, &witness)
+    let fixture = build_default_two_point_msm_fixture();
+    check_r1cs_satisfaction(&fixture.compiler.r1cs, &fixture.witness)
         .expect("valid two-point MSM witness should satisfy R1CS");
 
     // Corrupt the output x-limb
-    let mut corrupted = witness;
-    corrupted[out_x_limbs[0]] = corrupt_field_element(corrupted[out_x_limbs[0]]);
+    let mut corrupted = fixture.witness;
+    corrupted[fixture.out_x_limbs[0]] = corrupt_field_element(corrupted[fixture.out_x_limbs[0]]);
 
     assert!(
-        check_r1cs_satisfaction(&compiler.r1cs, &corrupted).is_err(),
+        check_r1cs_satisfaction(&fixture.compiler.r1cs, &corrupted).is_err(),
         "corrupted two-point MSM output should fail R1CS satisfaction"
     );
 }

--- a/tooling/provekit-bench/tests/msm_witness_solving.rs
+++ b/tooling/provekit-bench/tests/msm_witness_solving.rs
@@ -197,6 +197,50 @@ struct SinglePointMsmFixture {
     layout:         SinglePointMsmLayout,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct SinglePointGeneratorCase {
+    point_x:    [u64; 4],
+    point_y:    [u64; 4],
+    scalar:     [u64; 4],
+    expected_x: [u64; 4],
+    expected_y: [u64; 4],
+}
+
+/// Build a single-point secp256r1 generator case for the given scalar.
+fn secp256r1_generator_case(scalar: [u64; 4]) -> SinglePointGeneratorCase {
+    let curve = Secp256r1;
+    let point_x = curve.generator().0;
+    let point_y = curve.generator().1;
+    let (expected_x, expected_y) = ec_scalar_mul(
+        &point_x,
+        &point_y,
+        &scalar,
+        &curve.curve_a(),
+        &curve.field_modulus_p(),
+    );
+
+    SinglePointGeneratorCase {
+        point_x,
+        point_y,
+        scalar,
+        expected_x,
+        expected_y,
+    }
+}
+
+/// Build the single-point generator fixture for a precomputed test case.
+fn build_generator_single_point_fixture(case: SinglePointGeneratorCase) -> SinglePointMsmFixture {
+    build_single_point_msm_fixture(
+        &case.point_x,
+        &case.point_y,
+        false,
+        &case.scalar,
+        &case.expected_x,
+        &case.expected_y,
+        false,
+    )
+}
+
 /// Locate the single FakeGLV hint used by the single-point MSM circuit.
 fn locate_single_point_fake_glv(builders: &[WitnessBuilder]) -> FakeGlvWitnessIndices {
     let fake_glv_indices: Vec<FakeGlvWitnessIndices> = builders
@@ -489,22 +533,12 @@ fn test_arbitrary_point_and_scalar() {
 /// equality constraints.
 #[test]
 fn test_single_point_rejects_wrong_output_coordinates() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let scalar: [u64; 4] = [7, 0, 0, 0];
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
+    let case = secp256r1_generator_case([7, 0, 0, 0]);
 
     let get_x: fn(&SinglePointMsmLayout) -> usize = |l| l.out_x_limbs[0];
     let get_y: fn(&SinglePointMsmLayout) -> usize = |l| l.out_y_limbs[0];
     for (label, get_idx) in [("out_x", get_x), ("out_y", get_y)] {
-        let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+        let fixture = build_generator_single_point_fixture(case);
         assert_single_point_corruption_is_rejected(
             fixture,
             &format!("wrong output coordinate ({label})"),
@@ -519,18 +553,8 @@ fn test_single_point_rejects_wrong_output_coordinates() {
 /// Corrupting the output infinity flag must violate the output constraints.
 #[test]
 fn test_single_point_rejects_wrong_output_inf() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let scalar: [u64; 4] = [7, 0, 0, 0];
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
-    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+    let case = secp256r1_generator_case([7, 0, 0, 0]);
+    let fixture = build_generator_single_point_fixture(case);
 
     assert_single_point_corruption_is_rejected(
         fixture,
@@ -545,21 +569,11 @@ fn test_single_point_rejects_wrong_output_inf() {
 /// consistency constraints.
 #[test]
 fn test_single_point_rejects_off_curve_input() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let scalar: [u64; 4] = [7, 0, 0, 0];
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
-    let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 1);
-    let py_off_curve = increment_u256(&gy);
+    let case = secp256r1_generator_case([7, 0, 0, 0]);
+    let (num_limbs, limb_bits) = msm_params_for_curve(&Secp256r1, 1);
+    let py_off_curve = increment_u256(&case.point_y);
     let py_off_curve_fes = u256_to_limb_fes(&py_off_curve, limb_bits, num_limbs);
-    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+    let fixture = build_generator_single_point_fixture(case);
 
     assert_single_point_corruption_is_rejected(fixture, "off-curve input", |layout, corrupted| {
         overwrite_witness_values(corrupted, &layout.point_y_limbs, &py_off_curve_fes);
@@ -569,29 +583,12 @@ fn test_single_point_rejects_off_curve_input() {
 /// Replacing the expected output with a different scalar multiple must fail.
 #[test]
 fn test_single_point_rejects_wrong_scalar_output_pairing() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let scalar: [u64; 4] = [7, 0, 0, 0];
-    let wrong_scalar: [u64; 4] = [5, 0, 0, 0];
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
-    let (wrong_ex, wrong_ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &wrong_scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
-    let (num_limbs, limb_bits) = msm_params_for_curve(&curve, 1);
-    let wrong_ex_fes = u256_to_limb_fes(&wrong_ex, limb_bits, num_limbs);
-    let wrong_ey_fes = u256_to_limb_fes(&wrong_ey, limb_bits, num_limbs);
-    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+    let case = secp256r1_generator_case([7, 0, 0, 0]);
+    let wrong_case = secp256r1_generator_case([5, 0, 0, 0]);
+    let (num_limbs, limb_bits) = msm_params_for_curve(&Secp256r1, 1);
+    let wrong_ex_fes = u256_to_limb_fes(&wrong_case.expected_x, limb_bits, num_limbs);
+    let wrong_ey_fes = u256_to_limb_fes(&wrong_case.expected_y, limb_bits, num_limbs);
+    let fixture = build_generator_single_point_fixture(case);
 
     assert_single_point_corruption_is_rejected(
         fixture,
@@ -606,20 +603,10 @@ fn test_single_point_rejects_wrong_scalar_output_pairing() {
 /// Replacing the scalar input while keeping the original output must fail.
 #[test]
 fn test_single_point_rejects_scalar_corruption() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let scalar: [u64; 4] = [7, 0, 0, 0];
+    let case = secp256r1_generator_case([7, 0, 0, 0]);
     let wrong_scalar: [u64; 4] = [5, 0, 0, 0];
     let (wrong_lo, wrong_hi) = split_scalar(&wrong_scalar);
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
-    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+    let fixture = build_generator_single_point_fixture(case);
 
     assert_single_point_corruption_is_rejected(
         fixture,
@@ -634,18 +621,8 @@ fn test_single_point_rejects_scalar_corruption() {
 /// Zeroing s2 must violate the explicit s2 != 0 soundness check.
 #[test]
 fn test_single_point_rejects_zero_s2_forgery() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let scalar: [u64; 4] = [17, 0, 0, 0];
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
-    let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+    let case = secp256r1_generator_case([17, 0, 0, 0]);
+    let fixture = build_generator_single_point_fixture(case);
 
     assert_single_point_corruption_is_rejected(fixture, "s2 forgery", |layout, corrupted| {
         assert_ne!(
@@ -666,22 +643,12 @@ fn test_single_point_rejects_zero_s2_forgery() {
 /// decomposition back to the original scalar.
 #[test]
 fn test_single_point_rejects_flipped_neg_bits() {
-    let curve = Secp256r1;
-    let gx = curve.generator().0;
-    let gy = curve.generator().1;
-    let scalar: [u64; 4] = [17, 0, 0, 0];
-    let (ex, ey) = ec_scalar_mul(
-        &gx,
-        &gy,
-        &scalar,
-        &curve.curve_a(),
-        &curve.field_modulus_p(),
-    );
+    let case = secp256r1_generator_case([17, 0, 0, 0]);
 
     let get_neg1: fn(&FakeGlvWitnessIndices) -> usize = |g| g.neg1;
     let get_neg2: fn(&FakeGlvWitnessIndices) -> usize = |g| g.neg2;
     for (label, get_idx) in [("neg1", get_neg1), ("neg2", get_neg2)] {
-        let fixture = build_single_point_msm_fixture(&gx, &gy, false, &scalar, &ex, &ey, false);
+        let fixture = build_generator_single_point_fixture(case);
         assert_single_point_corruption_is_rejected(
             fixture,
             &format!("flipped {label} bit"),


### PR DESCRIPTION
## Summary

Adds the negative/adversarial MSM constraint-satisfaction tests proposed in #348.

This PR is test-only and does not change MSM implementation behavior.

Closes #348.

## Included tests

- wrong output coordinate
- off-curve input point
- wrong scalar/output pairing
- `s2 = 0` forgery attempt
- flipped `neg1` sign bit

## Validation

- `cargo +nightly-2026-03-04 fmt --all --check`
- `cargo +nightly-2026-03-04 clippy --all-targets --all-features --verbose`
- `cargo +nightly-2026-03-04 test -p provekit-bench --test msm_witness_solving`
- `cargo +nightly-2026-03-04 test --no-fail-fast --all-features --verbose --lib --tests --bins`
