### PR TITLE
Preserve public-input equalities during Noir GE optimization

### DIFF
--- a/provekit/common/src/optimize.rs
+++ b/provekit/common/src/optimize.rs
@@ -1334,7 +1334,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(stats.eliminated, 0, "public input row must not be pivoted away");
+        assert_eq!(
+            stats.eliminated, 0,
+            "public input row must not be pivoted away"
+        );
         assert_eq!(
             r1cs.num_constraints(),
             1,

--- a/provekit/common/src/optimize.rs
+++ b/provekit/common/src/optimize.rs
@@ -80,14 +80,31 @@ pub fn optimize_r1cs(
     let constraints_before = r1cs.num_constraints();
     let witnesses_before = r1cs.num_witnesses();
 
+    // In raw Noir lowering, public-input builders may not yet be packed into
+    // columns 1..=num_public_inputs. Track the actual public-input columns so
+    // GE cannot pivot them away before the later canonical remap.
+    let public_input_cols: HashSet<usize> = witness_builders
+        .iter()
+        .filter_map(|builder| match builder {
+            WitnessBuilder::Acir(col, acir_idx)
+                if acir_public_inputs_indices_set.contains(&(*acir_idx as u32)) =>
+            {
+                Some(*col)
+            }
+            _ => None,
+        })
+        .collect();
+
     // Columns that must not be eliminated:
     // - Column 0: constant one
-    // - Columns 1..=num_public_inputs: public inputs
+    // - Columns 1..=num_public_inputs: canonical public inputs
+    // - Any actual public-input builder columns before canonical remap
     let mut forbidden: HashSet<usize> = HashSet::new();
     forbidden.insert(0);
     for i in 1..=r1cs.num_public_inputs {
         forbidden.insert(i);
     }
+    forbidden.extend(public_input_cols.iter().copied());
 
     // Phase 1: Identify all linear constraints
     let mut linear_rows: Vec<usize> = Vec::new();
@@ -413,7 +430,6 @@ fn remove_dead_columns(
             _ => None,
         })
         .collect();
-
     let mut dead_cols = vec![false; num_cols];
     let mut num_dead = 0usize;
     for col in 0..num_cols {
@@ -1291,6 +1307,40 @@ mod tests {
             r1cs.num_witnesses() + r1cs.num_virtual,
         );
         assert_r1cs_satisfied(&r1cs, &opt_witness);
+    }
+
+    #[test]
+    fn test_public_input_linear_constraint_is_not_eliminated_when_count_is_unset() {
+        let mut r1cs = R1CS::new();
+        let one = FieldElement::one();
+        let six = FieldElement::from(6u64);
+
+        // w0 = 1, w1 = public ACIR input
+        r1cs.add_witnesses(2);
+        // Public equality: w1 - 6 = 0
+        r1cs.add_constraint(&[(one, 0)], &[(one, 0)], &[(one, 1), (-six, 0)]);
+
+        let mut builders = vec![
+            WitnessBuilder::Constant(crate::witness::ConstantTerm(0, one)),
+            WitnessBuilder::Acir(1, 1),
+        ];
+        let mut witness_map = vec![None, std::num::NonZeroU32::new(1)];
+
+        let stats = optimize_r1cs(
+            &mut r1cs,
+            &mut builders,
+            &mut witness_map,
+            &HashSet::from([1u32]),
+        )
+        .unwrap();
+
+        assert_eq!(stats.eliminated, 0, "public input row must not be pivoted away");
+        assert_eq!(
+            r1cs.num_constraints(),
+            1,
+            "public-input equality must remain verifier-visible"
+        );
+        assert_eq!(r1cs.num_witnesses(), 2, "public input column must remain");
     }
 
     #[test]

--- a/provekit/common/src/optimize.rs
+++ b/provekit/common/src/optimize.rs
@@ -430,6 +430,7 @@ fn remove_dead_columns(
             _ => None,
         })
         .collect();
+
     let mut dead_cols = vec![false; num_cols];
     let mut num_dead = 0usize;
     for col in 0..num_cols {

--- a/provekit/r1cs-compiler/src/noir_proof_scheme.rs
+++ b/provekit/r1cs-compiler/src/noir_proof_scheme.rs
@@ -62,6 +62,7 @@ impl NoirCompiler {
 
         let acir_public_inputs_indices_set: HashSet<u32> =
             main.public_inputs().indices().iter().cloned().collect();
+        r1cs.num_public_inputs = acir_public_inputs_indices_set.len();
 
         // Gaussian elimination optimization pass
         let opt_stats = provekit_common::optimize::optimize_r1cs(


### PR DESCRIPTION
## Summary
Fix a Noir `prepare` bug where Gaussian elimination could remove a verifier-visible public-input equality.

## Root Cause
In the Noir path, GE ran before the raw R1CS had its public-input count set. That allowed a public-input column to be chosen as a pivot and the equality to be eliminated.

## Fix
- Set `r1cs.num_public_inputs` before GE in the Noir compiler path
- Treat actual public-input builder columns as non-pivotable before canonical remapping
- Add a regression test covering a public linear equality in the pre-remap case

## Result
A circuit like:

```nr
fn main(six_as_u32: pub u32) {
    assert(six_as_u32 == 6);
}
```

now keeps a verifier-visible constraint instead of collapsing to `0` constraints.

## Verification
- `cargo test -p provekit-common test_public_input_linear_constraint_is_not_eliminated_when_count_is_unset -- --nocapture`
- `cargo test -p provekit-r1cs-compiler --lib noir_proof_scheme -- --nocapture`
- `cargo run --bin provekit-cli -- prepare /Users/paradox/Desktop/random/noir/test_programs/execution_success/loop/target/loop.json`
