### PR TITLE
chore(release): bump workspace crates to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,13 +97,13 @@ ntt = { package = "provekit-ntt", version = "0.1.0" }
 
 # Workspace members - ProveKit
 provekit-bench = { path = "tooling/provekit-bench" }
-provekit-cli = { path = "tooling/cli", version = "0.1.2" }
-provekit-common = { path = "provekit/common", version = "0.1.4" }
+provekit-cli = { path = "tooling/cli", version = "1.0.0" }
+provekit-common = { path = "provekit/common", version = "1.0.0" }
 provekit-ffi = { path = "tooling/provekit-ffi" }
 provekit-gnark = { path = "tooling/provekit-gnark", version = "0.1.2" }
-provekit-prover = { path = "provekit/prover", version = "0.1.4" }
-provekit-r1cs-compiler = { path = "provekit/r1cs-compiler", version = "0.1.4" }
-provekit-verifier = { path = "provekit/verifier", version = "0.1.4" }
+provekit-prover = { path = "provekit/prover", version = "1.0.0" }
+provekit-r1cs-compiler = { path = "provekit/r1cs-compiler", version = "1.0.0" }
+provekit-verifier = { path = "provekit/verifier", version = "1.0.0" }
 provekit-verifier-server = { path = "tooling/verifier-server" }
 
 # 3rd party

--- a/provekit/common/Cargo.toml
+++ b/provekit/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-common"
-version = "0.1.4"
+version = "1.0.0"
 description = "Common types and utilities for the ProveKit proving system"
 edition.workspace = true
 rust-version.workspace = true

--- a/provekit/prover/Cargo.toml
+++ b/provekit/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-prover"
-version = "0.1.4"
+version = "1.0.0"
 description = "ProveKit prover for generating zero-knowledge proofs"
 edition.workspace = true
 rust-version.workspace = true

--- a/provekit/r1cs-compiler/Cargo.toml
+++ b/provekit/r1cs-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-r1cs-compiler"
-version = "0.1.4"
+version = "1.0.0"
 description = "R1CS compiler for ProveKit, translating Noir programs to R1CS constraints"
 edition.workspace = true
 rust-version.workspace = true

--- a/provekit/verifier/Cargo.toml
+++ b/provekit/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-verifier"
-version = "0.1.4"
+version = "1.0.0"
 description = "ProveKit verifier for zero-knowledge proofs"
 edition.workspace = true
 rust-version.workspace = true

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-cli"
-version = "0.1.5"
+version = "1.0.0"
 description = "ProveKit CLI for generating and verifying zero-knowledge proofs"
 edition.workspace = true
 rust-version.workspace = true

--- a/tooling/provekit-bench/Cargo.toml
+++ b/tooling/provekit-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-bench"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tooling/provekit-ffi/Cargo.toml
+++ b/tooling/provekit-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-ffi"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tooling/verifier-server/Cargo.toml
+++ b/tooling/verifier-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verifier-server"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Bumps the publishable workspace crates to `1.0.0` in preparation for the **ProveKit v1.0.0** release tag.

- `provekit-common`, `provekit-r1cs-compiler`, `provekit-prover`, `provekit-verifier`: `0.1.4 → 1.0.0`
- `provekit-cli`: `0.1.5 → 1.0.0`
- `provekit-bench`, `provekit-ffi`, `verifier-server`: `0.1.0 → 1.0.0`
- Root `[workspace.dependencies]` version pins for the five crates that publish to crates.io are bumped to `1.0.0`.
- `provekit-gnark` is intentionally **kept at 0.1.2** so `provekit-cli@1.0.0` resolves the existing `provekit-gnark@0.1.2` release on crates.io (gnark is not part of this publish wave).
- Skyscraper crates and `ntt` are excluded from the v1 workspace, so they are not touched.

After this merges, `v1.0.0` will be tagged on the merge commit and the five publishable crates will go to crates.io.

## Test plan

- [x] `cargo check --workspace --all-features` passes locally on this branch.
- [ ] CI green.
- [ ] Post-merge: `cargo publish --dry-run` for each of the 5 crates before the real publish.