### PR TITLE
chore(release): bump workspace crates to 1.0.0

### DIFF
--- a/provekit/common/Cargo.toml
+++ b/provekit/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-common"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/provekit/prover/Cargo.toml
+++ b/provekit/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-prover"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/provekit/r1cs-compiler/Cargo.toml
+++ b/provekit/r1cs-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-r1cs-compiler"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/provekit/verifier/Cargo.toml
+++ b/provekit/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-verifier"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-cli"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tooling/provekit-bench/Cargo.toml
+++ b/tooling/provekit-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-bench"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tooling/provekit-ffi/Cargo.toml
+++ b/tooling/provekit-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "provekit-ffi"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/tooling/verifier-server/Cargo.toml
+++ b/tooling/verifier-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verifier-server"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Mirrors the v1 branch v1.0.0 release bump onto `main` so version drift between the two branches stays minimal.

Bumped to `1.0.0`:
- `provekit-common`, `provekit-r1cs-compiler`, `provekit-prover`, `provekit-verifier`
- `provekit-cli`, `provekit-bench`, `provekit-ffi`, `verifier-server`

Intentionally **not** bumped:
- `provekit-gnark` (kept consistent with the v1 release decision)
- `skyscraper/*`, `ntt`, `poseidon2`, `provekit-wasm` (out of scope for this release)

Companion PR on `v1`: the actual v1.0.0 tag and crates.io publish happen from the v1 PR.

## Test plan

- [x] `cargo check --workspace --all-features` passes locally on this branch.
- [ ] CI green.