### PR TITLE
perf(prover): hold R1CS and w2 layers resident; remove unused compression

### DIFF
--- a/provekit/prover/src/lib.rs
+++ b/provekit/prover/src/lib.rs
@@ -1,10 +1,7 @@
 #[cfg(test)]
 use crate::r1cs::R1CSSolver;
 use {
-    crate::{
-        r1cs::{CompressedLayers, CompressedR1CS},
-        whir_r1cs::WhirR1CSProver,
-    },
+    crate::whir_r1cs::WhirR1CSProver,
     acir::native_types::{Witness, WitnessMap},
     anyhow::{Context, Result},
     provekit_common::{
@@ -122,12 +119,9 @@ impl Prove for Prover {
         drop(self.program);
         drop(self.witness_generator);
 
-        // R1CS matrices are only needed at sumcheck; compress to free memory during
-        // commits.
-        let compressed_r1cs =
-            CompressedR1CS::compress(self.r1cs).context("While compressing R1CS")?;
-        let num_witnesses = compressed_r1cs.num_witnesses();
-        let num_constraints = compressed_r1cs.num_constraints();
+        let r1cs = self.r1cs;
+        let num_witnesses = r1cs.num_witnesses();
+        let num_constraints = r1cs.num_constraints();
 
         // Set up transcript with public inputs bound to the instance.
         let instance = public_inputs.hash_bytes();
@@ -153,14 +147,10 @@ impl Prove for Prover {
             .context("While solving w1 witnesses")?;
         }
 
-        // Compress w2 layers to free memory during w1 commit (only when
-        // challenges exist; otherwise just drop them).
+        // Hold w2 layers across the w1 commit only when challenges exist.
         let has_challenges = self.whir_for_witness.num_challenges > 0;
-        let compressed_w2_layers = if has_challenges {
-            Some(
-                CompressedLayers::compress(self.split_witness_builders.w2_layers)
-                    .context("While compressing w2 layers")?,
-            )
+        let w2_layers = if has_challenges {
+            Some(self.split_witness_builders.w2_layers)
         } else {
             drop(self.split_witness_builders.w2_layers);
             None
@@ -168,7 +158,6 @@ impl Prove for Prover {
 
         debug!(
             witness_heap_bytes = witness.capacity() * size_of::<Option<FieldElement>>(),
-            compressed_r1cs_blob_bytes = compressed_r1cs.blob_len(),
             "component sizes after solve_w1"
         );
 
@@ -199,10 +188,7 @@ impl Prove for Prover {
             .context("While committing to w1")?;
 
         let commitments = if has_challenges {
-            let w2_layers = compressed_w2_layers
-                .unwrap()
-                .decompress()
-                .context("While decompressing w2 layers")?;
+            let w2_layers = w2_layers.expect("w2_layers is Some whenever has_challenges is true");
             {
                 let _s = info_span!("solve_w2").entered();
                 crate::r1cs::solve_witness_vec(
@@ -233,11 +219,6 @@ impl Prove for Prover {
             drop(acir_witness_idx_to_value_map);
             vec![commitment_1]
         };
-
-        // Decompress R1CS for the sumcheck and matrix operations.
-        let r1cs = compressed_r1cs
-            .decompress()
-            .context("While decompressing R1CS")?;
 
         #[cfg(test)]
         r1cs.test_witness_satisfaction(&witness.iter().map(|w| w.unwrap()).collect::<Vec<_>>())

--- a/provekit/prover/src/r1cs.rs
+++ b/provekit/prover/src/r1cs.rs
@@ -1,77 +1,17 @@
+#[cfg(test)]
+use provekit_common::R1CS;
 use {
     crate::witness::witness_builder::WitnessBuilderSolver,
     acir::native_types::WitnessMap,
-    anyhow::{Context, Result},
+    anyhow::Result,
     provekit_common::{
         utils::batch_inverse_montgomery,
         witness::{LayerType, LayeredWitnessBuilders, WitnessBuilder},
-        FieldElement, NoirElement, TranscriptSponge, R1CS,
+        FieldElement, NoirElement, TranscriptSponge,
     },
     tracing::instrument,
     whir::transcript::ProverState,
 };
-
-/// Serialized R1CS matrices held as a compact postcard blob.
-///
-/// The R1CS is only needed during the sumcheck phase. Compressing it
-/// into a serialized blob frees that memory during the commit phase,
-/// then decompresses when the sumcheck begins.
-pub struct CompressedR1CS {
-    num_constraints: usize,
-    num_witnesses:   usize,
-    blob:            Vec<u8>,
-}
-
-/// Serialized witness builder layers held as a compact postcard blob.
-///
-/// Same strategy as [`CompressedR1CS`]: the w2 layers are not needed
-/// until challenge-dependent witness solving, so we compress them to
-/// free memory during the w1 commit.
-pub struct CompressedLayers {
-    blob: Vec<u8>,
-}
-
-impl CompressedLayers {
-    pub fn compress(layers: LayeredWitnessBuilders) -> Result<Self> {
-        let blob = postcard::to_allocvec(&layers)
-            .context("LayeredWitnessBuilders serialization failed")?;
-        Ok(Self { blob })
-    }
-
-    pub fn decompress(self) -> Result<LayeredWitnessBuilders> {
-        postcard::from_bytes(&self.blob).context("LayeredWitnessBuilders deserialization failed")
-    }
-}
-
-impl CompressedR1CS {
-    pub fn compress(r1cs: R1CS) -> Result<Self> {
-        let num_constraints = r1cs.num_constraints();
-        let num_witnesses = r1cs.num_witnesses();
-        let blob = postcard::to_allocvec(&r1cs).context("R1CS serialization failed")?;
-        drop(r1cs);
-        Ok(Self {
-            num_constraints,
-            num_witnesses,
-            blob,
-        })
-    }
-
-    pub fn decompress(self) -> Result<R1CS> {
-        postcard::from_bytes(&self.blob).context("R1CS deserialization failed")
-    }
-
-    pub const fn num_constraints(&self) -> usize {
-        self.num_constraints
-    }
-
-    pub const fn num_witnesses(&self) -> usize {
-        self.num_witnesses
-    }
-
-    pub fn blob_len(&self) -> usize {
-        self.blob.len()
-    }
-}
 
 #[cfg(test)]
 pub trait R1CSSolver {


### PR DESCRIPTION
## Summary

Removes prover-state compression (postcard serialize/deserialize of R1CS and w2 layers during the commit phase). Introduced in 9291f2b3 to shrink commit-phase peak by ~270 MB; subsequent memory work made sumcheck phase dominate global peak, so the saving no longer reaches it. Today it is pure overhead.

## Measured impact

Median-of-5, interleaved v1 vs opt. Peak memory **identical** on every circuit; allocations drop deterministically on circuits using challenge-based witness builders.

| Circuit | v1 allocs | opt allocs | Δ |
|---|---:|---:|---:|
| basic-4 | 5190 | 5170 | 0% |
| poseidon2 | 9120 | 9100 | 0% |
| noir_sha256 | 50.5k | 35.8k | -29% |
| poseidon-rounds | 9.04M | 9.04M | 0% |
| t_attest | 414k | 246k | -41% |
| t_add_integrity_commit | 421k | 361k | -14% |
| t_add_id_data_1850 | 1.0M | 857k | -14% |
| t_add_dsc_1850 | 3.81M | 3.22M | -15% |
| complete_age_check | 4.25M | 3.56M | -16% |

Wall time trends -3% to -6% on big circuits but noisy; allocation count is the deterministic gain.

## Rollback

If a future circuit makes commit-phase peak exceed sumcheck-phase peak, restore compression from 9291f2b3.

## Test plan

- [x] `cargo test --release --workspace --exclude provekit-bench` — 62 passed
- [x] Cross-binary verification (v1 prove ↔ opt verify) passes
- [ ] CI green