### PR TITLE
perf(prover): drop R1CS after sumcheck to free memory during WHIR rounds

### DIFF
--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -152,6 +152,7 @@ impl WhirR1CSProver for WhirR1CSScheme {
         drop(full_witness);
 
         let alphas = calculate_external_row_of_r1cs_matrices(&alpha, &r1cs);
+        drop(r1cs);
         let (x, public_weight) = get_public_weights(public_inputs, &mut merlin, self.m);
 
         let blinding_offset = blinding.offset;


### PR DESCRIPTION
WhirR1CSScheme::prove takes the R1CS by value but only reads it twice: in run_zk_sumcheck_prover and in calculate_external_row_of_r1cs_matrices (immediately after). Without an explicit drop, the matrices stay resident through the entire WHIR commit + prove path that follows, even though nothing downstream touches them.

After PR #438 (24618492) made the sumcheck/commit phase the dominant memory consumer, R1CS lifetime extension became visible at the global peak. Dropping it on the spot frees ~80 MB of sparse-matrix storage before the WHIR rounds allocate their working buffers.

Measured on complete_age_check:

  - run peak memory: 880 MB -> 816 MB (-64 MB, -7.3%)
  - prove_with_toml / prove_with_witness peak: 880 MB -> 816 MB
  - new proof verifies (provekit-cli verify exits 0)

Proof bytes differ run-to-run as expected (zk-sumcheck samples a fresh blinding mask each invocation); verifier acceptance is the safety signal.