### PR TITLE
Drop unused r1cs after sumcheck and use par_iter in accumulate

### DIFF
--- a/provekit/common/src/prefix_covector.rs
+++ b/provekit/common/src/prefix_covector.rs
@@ -1,6 +1,7 @@
 use {
     crate::FieldElement,
     ark_std::{One, Zero},
+    rayon::prelude::*,
     whir::algebra::{dot, linear_form::LinearForm, multilinear_extend},
 };
 
@@ -76,11 +77,18 @@ impl LinearForm<FieldElement> for PrefixCovector {
     }
 
     fn accumulate(&self, accumulator: &mut [FieldElement], scalar: FieldElement) {
-        for (acc, val) in accumulator[..self.vector.len()]
-            .iter_mut()
-            .zip(&self.vector)
-        {
-            *acc += scalar * *val;
+        let accumulator = &mut accumulator[..self.vector.len()];
+        if self.vector.len() > whir::utils::workload_size::<FieldElement>() {
+            accumulator
+                .par_iter_mut()
+                .zip(self.vector.par_iter())
+                .for_each(|(acc, val)| {
+                    *acc += scalar * *val;
+                });
+        } else {
+            for (acc, val) in accumulator.iter_mut().zip(&self.vector) {
+                *acc += scalar * *val;
+            }
         }
     }
 }

--- a/provekit/common/src/utils/sumcheck.rs
+++ b/provekit/common/src/utils/sumcheck.rs
@@ -208,9 +208,9 @@ pub fn transpose_r1cs_matrices(r1cs: &R1CS) -> (SparseMatrix, SparseMatrix, Spar
 /// external row.
 #[instrument(skip_all)]
 pub fn multiply_transposed_by_eq_alpha(
-    at: &SparseMatrix,
-    bt: &SparseMatrix,
-    ct: &SparseMatrix,
+    at: SparseMatrix,
+    bt: SparseMatrix,
+    ct: SparseMatrix,
     alpha: &[FieldElement],
     r1cs: &R1CS,
 ) -> [Vec<FieldElement>; 3] {
@@ -237,8 +237,8 @@ pub fn multiply_transposed_by_eq_alpha(
 #[instrument(skip_all)]
 pub fn calculate_external_row_of_r1cs_matrices(
     alpha: &[FieldElement],
-    r1cs: &R1CS,
+    r1cs: R1CS,
 ) -> [Vec<FieldElement>; 3] {
-    let (at, bt, ct) = transpose_r1cs_matrices(r1cs);
-    multiply_transposed_by_eq_alpha(&at, &bt, &ct, alpha, r1cs)
+    let (at, bt, ct) = transpose_r1cs_matrices(&r1cs);
+    multiply_transposed_by_eq_alpha(at, bt, ct, alpha, &r1cs)
 }

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -152,6 +152,7 @@ impl WhirR1CSProver for WhirR1CSScheme {
         drop(full_witness);
 
         let alphas = calculate_external_row_of_r1cs_matrices(&alpha, &r1cs);
+        drop(r1cs);
         let (x, public_weight) = get_public_weights(public_inputs, &mut merlin, self.m);
 
         let blinding_offset = blinding.offset;

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -151,8 +151,7 @@ impl WhirR1CSProver for WhirR1CSScheme {
         );
         drop(full_witness);
 
-        let alphas = calculate_external_row_of_r1cs_matrices(&alpha, &r1cs);
-        drop(r1cs);
+        let alphas = calculate_external_row_of_r1cs_matrices(&alpha, r1cs);
         let (x, public_weight) = get_public_weights(public_inputs, &mut merlin, self.m);
 
         let blinding_offset = blinding.offset;

--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -91,14 +91,8 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
         );
         let x: FieldElement = arthur.verifier_message();
 
-        let alphas = multiply_transposed_by_eq_alpha(
-            &at,
-            &bt,
-            &ct,
-            &data_from_sumcheck_verifier.alpha,
-            r1cs,
-        );
-        drop((at, bt, ct));
+        let alphas =
+            multiply_transposed_by_eq_alpha(at, bt, ct, &data_from_sumcheck_verifier.alpha, r1cs);
 
         let blinding_eval = data_from_sumcheck_verifier.blinding_eval;
         let blinding_weights = expand_powers::<4>(&data_from_sumcheck_verifier.alpha);

--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -98,6 +98,7 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
             &data_from_sumcheck_verifier.alpha,
             r1cs,
         );
+        drop((at, bt, ct));
 
         let blinding_eval = data_from_sumcheck_verifier.blinding_eval;
         let blinding_weights = expand_powers::<4>(&data_from_sumcheck_verifier.alpha);


### PR DESCRIPTION
Two changes:

- Consumes R1CS/verifier matrices to reduce peak memory in prover and verifier.
- parallelized `PrefixCovector::accumulate` for large vectors

## prover

| metric | `before` avg | `after` avg | speedup |
|---|---:|---:|---:|
| Total time | `1.887 s` | `1.793 s` | `4.95% faster` |
| Total allocated memory | `880 MB` | `816 MB` | `7.27% lower` |

## verifier


metric | `before` verify avg | `after` verify avg | change
-- | -- | -- | --
Total time | `97.667 ms` | `93.533 ms` | `4.23% faster`
Total allocated memory | `365 MB` | `307 MB` | `15.89% lower`
