### PR TITLE
Add macro based NTT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,6 +3493,8 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -3614,7 +3616,7 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "provekit-bench"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "divan",
@@ -3633,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-cli"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "argh",
@@ -3662,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-common"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3676,6 +3678,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "postcard",
+ "provekit-ntt",
  "provekit-spongefish",
  "provekit-spongefish-pow",
  "provekit-whir",
@@ -3695,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-ffi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -3710,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-gnark"
-version = "0.1.2"
+version = "1.0.0"
 dependencies = [
  "ark-poly",
  "provekit-common",
@@ -3721,8 +3724,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "provekit-ntt"
+version = "0.1.0"
+dependencies = [
+ "ark-bn254",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "divan",
+ "proptest",
+ "rayon",
+]
+
+[[package]]
 name = "provekit-prover"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "ark-ff 0.5.0",
@@ -3741,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-r1cs-compiler"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3749,6 +3764,7 @@ dependencies = [
  "ark-std 0.5.0",
  "postcard",
  "provekit-common",
+ "provekit-ntt",
  "provekit-whir",
  "provekit_acir",
  "provekit_noirc_abi",
@@ -3792,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-verifier"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "ark-std 0.5.0",
@@ -4379,6 +4395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,6 +4952,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -6282,7 +6316,7 @@ dependencies = [
 
 [[package]]
 name = "verifier-server"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6312,6 +6346,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waitpid-any"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
   "tooling/provekit-ffi",
   "tooling/provekit-gnark",
   "tooling/verifier-server",
-  # "ntt",
+  "ntt",
 ]
 exclude = ["playground/passport-input-gen"]
 
@@ -93,7 +93,7 @@ bn254-multiplier-codegen = { package = "provekit-bn254-multiplier-codegen", vers
 fp-rounding = { package = "provekit-fp-rounding", version = "0.1.0" }
 hla = { package = "provekit-hla", version = "0.1.0" }
 skyscraper = { package = "provekit-skyscraper", version = "0.1.0" }
-ntt = { package = "provekit-ntt", version = "0.1.0" }
+provekit-ntt = { path = "ntt" }
 
 # Workspace members - ProveKit
 provekit-bench = { path = "tooling/provekit-bench" }

--- a/ntt/Cargo.toml
+++ b/ntt/Cargo.toml
@@ -9,19 +9,20 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
-[lib]
-name = "ntt"
-
 [dependencies]
 ark-bn254.workspace = true
 ark-ff.workspace = true
 rayon.workspace = true
 
 [dev-dependencies]
-proptest.workspace = true
 divan.workspace = true
+ark-std.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+proptest.workspace = true
 
 [lints]
+
 workspace = true
 
 [[bench]]

--- a/ntt/benches/ntt_engine.rs
+++ b/ntt/benches/ntt_engine.rs
@@ -1,6 +1,6 @@
 use divan;
 /// Benchmarks for NTTEngine with divan
-use ntt::{NTTEngine, Pow2};
+use provekit_ntt::NTTEngine;
 
 fn main() {
     // Initialize Rayon thread pool
@@ -14,5 +14,5 @@ const ORDER: usize = 1 << 24;
 /// Benchmark NTTEngine creation with order 1<<24
 #[divan::bench]
 fn create_engine() {
-    let _engine = divan::black_box(NTTEngine::with_order(Pow2::new(ORDER).unwrap()));
+    let _engine = divan::black_box(NTTEngine::with_order(ORDER));
 }

--- a/ntt/src/ark_interleaved.rs
+++ b/ntt/src/ark_interleaved.rs
@@ -1,0 +1,19 @@
+use {
+    crate::{define_ntt, extend_roots_table},
+    ark_bn254::Fr,
+};
+
+define_ntt!(interleaved_ntt_nr, Fr, ark_kernel);
+
+pub fn ntt_nr_ark(values: &mut [Fr], codeword_size: usize, num_groups: usize) {
+    let new_root = extend_roots_table(codeword_size);
+    interleaved_ntt_nr(new_root.roots(), values, codeword_size, num_groups)
+}
+
+#[inline(always)]
+fn ark_kernel(even: &mut Fr, odd: &mut Fr, omega: &Fr) {
+    let even_value = *even;
+    let odd_twiddled = omega * &*odd;
+    *even = even_value + odd_twiddled;
+    *odd = even_value - odd_twiddled;
+}

--- a/ntt/src/lib.rs
+++ b/ntt/src/lib.rs
@@ -1,108 +1,118 @@
 #![feature(vec_split_at_spare)]
 pub mod ntt;
 pub use ntt::*;
-use std::{
-    marker::PhantomData,
-    num::NonZero,
-    ops::{Deref, DerefMut},
-};
+pub mod ark_interleaved;
 
-pub trait NTTContainer<T>: AsRef<[T]> + AsMut<[T]> {}
-impl<T, C: AsRef<[T]> + AsMut<[T]>> NTTContainer<T> for C {}
-
-/// The NTT is optimized for NTTs of a power of two. Arbitrary sized NTTs are
-/// not supported. Note: empty vectors (size 0) are also supported as a special
-/// case.
+/// Generates an NTT for a given element type and butterfly
+/// kernel.
 ///
-/// NTTContainer can be a single polynomial or multiple polynomials that are
-/// interleaved. interleaved polynomials; `[a0, b0, c0, d0, a1, b1, c1, d1,
-/// ...]` for four polynomials `a`, `b`, `c`, and `d`. By operating on
-/// interleaved data, you can perform the NTT on all polynomials in-place
-/// without needing to first transpose the data
-#[derive(Debug, Clone, PartialEq)]
-pub struct NTT<T, C: NTTContainer<T>> {
-    container: C,
-    order:     Pow2<usize>,
-    _phantom:  PhantomData<T>,
-}
-
-impl<T, C: NTTContainer<T>> NTT<T, C> {
-    pub fn new(vec: C, number_of_polynomials: usize) -> Option<Self> {
-        let n = vec.as_ref().len();
-        // All polynomials of the same size
-        if number_of_polynomials == 0 || n % number_of_polynomials != 0 {
-            return None;
-        }
-
-        // The order of the individual polynomials needs to be a power of two
-        Pow2::new(n / number_of_polynomials).map(|order| Self {
-            container: vec,
-            order,
-            _phantom: PhantomData,
-        })
-    }
-
-    pub fn order(&self) -> Pow2<usize> {
-        self.order
-    }
-
-    pub fn into_inner(self) -> C {
-        self.container
-    }
-}
-
-impl<T, C: NTTContainer<T>> Deref for NTT<T, C> {
-    type Target = [T];
-
-    fn deref(&self) -> &Self::Target {
-        self.container.as_ref()
-    }
-}
-
-impl<T, C: NTTContainer<T>> DerefMut for NTT<T, C> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.container.as_mut()
-    }
-}
-
-/// Represents the valid length of an NTT (Number Theoretic Transform).
+/// Usage:
+/// ```ignore
+/// define_ntt_loops!(interleaved_ntt_nr, Fr, ark_kernel);
+/// ```
 ///
-/// The allowed values depend on the type parameter:
-/// - `Pow2<usize>`: length is 0 or a power of two (`{0} ∪ {2ⁿ : n ≥ 0}`).
-/// - `Pow2<NonZero<usize>>`: length is a nonzero power of two (`{2ⁿ : n ≥ 0}`).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Pow2<T = usize>(T);
+/// Expanding a macro rather than using a generic function avoids the ~2–3%
+/// regression caused by generic boundaries inhibiting LLVM's loop/vectorisation
+/// optimisations even when the kernel is monomorphised.
+#[macro_export]
+macro_rules! define_ntt {
+    ($ntt_fn:ident, $T:ty, $kernel:ident) => {
+        /// In-place Number Theoretic Transform (NTT) from normal order to
+        /// reverse bit order.
+        ///
+        /// Use when multiple polynomials are stored interleaved:
+        /// `[a0, b0, a1, b1, ...]`. Operates on all polynomials in-place
+        /// without a prior transpose.
+        ///
+        /// * `reversed_ordered_roots` — precomputed roots of unity in reverse bit
+        ///   order.
+        /// * `values` — coefficients transformed in place.
+        pub(crate) fn $ntt_fn(
+            reversed_ordered_roots: &[$T],
+            values: &mut [$T],
+            codeword_size: usize,
+            mut num_groups: usize,
+        ) {
+            use rayon::{
+                iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
+                slice::ParallelSliceMut,
+            };
 
-impl<T: InPowerOfTwoSet> Pow2<T> {
-    pub fn new(value: T) -> Option<Self> {
-        match value.in_set() {
-            true => Some(Self(value)),
-            false => None,
+            fn dit_nr_cache(
+                reverse_ordered_roots: &[$T],
+                segment: usize,
+                input: &mut [$T],
+                size: usize,
+            ) {
+                let mut elements_in_group = input.len();
+                let mut num_of_groups = 1;
+
+                debug_assert!(size.is_power_of_two());
+
+                while num_of_groups < size {
+                    let twiddle_base = segment * num_of_groups;
+                    for (k, group) in input.chunks_exact_mut(elements_in_group).enumerate() {
+                        let twiddle = twiddle_base + k;
+                        let omega = reverse_ordered_roots[twiddle];
+                        let (evens, odds) = group.split_at_mut(elements_in_group / 2);
+                        evens
+                            .iter_mut()
+                            .zip(odds)
+                            .for_each(|(even, odd)| $kernel(even, odd, &omega));
+                    }
+                    elements_in_group /= 2;
+                    num_of_groups *= 2;
+                }
+            }
+
+            if codeword_size <= 1 {
+                return;
+            }
+
+            assert!(codeword_size.is_power_of_two());
+
+            let mut elements_in_group = values.len() / num_groups;
+
+            while num_groups < 32.min(codeword_size)
+                && elements_in_group > $crate::workload_size::<$T>()
+            {
+                values
+                    .chunks_exact_mut(elements_in_group)
+                    .enumerate()
+                    .for_each(|(k, group)| {
+                        let omega = reversed_ordered_roots[k];
+                        let (evens, odds) = group.split_at_mut(elements_in_group / 2);
+                        evens
+                            .par_iter_mut()
+                            .zip(odds)
+                            .for_each(|(even, odd)| $kernel(even, odd, &omega));
+                    });
+                elements_in_group /= 2;
+                num_groups *= 2;
+            }
+
+            while num_groups < codeword_size && elements_in_group > $crate::workload_size::<$T>() {
+                values
+                    .par_chunks_exact_mut(elements_in_group)
+                    .enumerate()
+                    .for_each(|(k, group)| {
+                        let omega = reversed_ordered_roots[k];
+                        let (evens, odds) = group.split_at_mut(elements_in_group / 2);
+                        evens
+                            .iter_mut()
+                            .zip(odds)
+                            .for_each(|(even, odd)| $kernel(even, odd, &omega));
+                    });
+                elements_in_group /= 2;
+                num_groups *= 2;
+            }
+
+            values
+                .par_chunks_exact_mut(elements_in_group)
+                .enumerate()
+                .for_each(|(k, group)| {
+                    dit_nr_cache(reversed_ordered_roots, k, group, codeword_size / num_groups);
+                });
         }
-    }
-}
-
-// Only Deref is implement as DerefMut allows for breaking the proof.
-impl<T> Deref for Pow2<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-pub trait InPowerOfTwoSet {
-    fn in_set(&self) -> bool;
-}
-
-impl InPowerOfTwoSet for usize {
-    fn in_set(&self) -> bool {
-        usize::is_power_of_two(*self) || *self == 0
-    }
-}
-
-impl InPowerOfTwoSet for NonZero<usize> {
-    fn in_set(&self) -> bool {
-        self.get().is_power_of_two()
-    }
+    };
 }

--- a/ntt/src/main.rs
+++ b/ntt/src/main.rs
@@ -1,14 +1,11 @@
 /// Executable for profiling NTT
-use {
-    ark_bn254::Fr,
-    ntt::{ntt_nr, NTT},
-    std::hint::black_box,
-};
+use {ark_bn254::Fr, provekit_ntt::ntt_nr, std::hint::black_box};
 
 fn main() {
     rayon::ThreadPoolBuilder::new().build_global().unwrap();
 
-    let mut input = NTT::new(vec![Fr::from(1); 2_usize.pow(24)], 1).unwrap();
-    ntt_nr(&mut input);
+    let mut input = vec![Fr::from(1); 2_usize.pow(24)];
+    let codeword_size = input.len();
+    ntt_nr(&mut input, codeword_size, 1);
     black_box(input);
 }

--- a/ntt/src/ntt.rs
+++ b/ntt/src/ntt.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{NTTContainer, Pow2, NTT},
+    crate::ark_interleaved::ntt_nr_ark,
     ark_bn254::Fr,
     ark_ff::{FftField, Field},
     rayon::{
@@ -8,7 +8,7 @@ use {
     },
     std::{
         mem::size_of,
-        sync::{LazyLock, RwLock},
+        sync::{LazyLock, RwLock, RwLockReadGuard},
     },
 };
 
@@ -29,10 +29,7 @@ impl NTTEngine {
     ///
     /// Note: new will initialize half a L1 cache size worth of twiddle factors
     pub fn new() -> Self {
-        let init = init_roots_reverse_ordered(
-            Pow2::new(workload_size::<Fr>().next_power_of_two()).unwrap(),
-            None,
-        );
+        let init = init_roots_reverse_ordered(workload_size::<Fr>().next_power_of_two(), None);
         NTTEngine(init)
     }
 
@@ -40,11 +37,9 @@ impl NTTEngine {
     ///
     /// Note: with_order will initialise at least half a L1 cache size worth of
     /// twiddle factors.
-    pub fn with_order(order: Pow2<usize>) -> Self {
-        let init = init_roots_reverse_ordered(
-            Pow2::new(workload_size::<Fr>().next_power_of_two()).unwrap(),
-            Some(*order / 2),
-        );
+    pub fn with_order(order: usize) -> Self {
+        let init =
+            init_roots_reverse_ordered(workload_size::<Fr>().next_power_of_two(), Some(order / 2));
         let mut engine = NTTEngine(init);
         engine.extend_roots_table(order);
         engine
@@ -58,17 +53,18 @@ impl NTTEngine {
     ///
     /// The new roots are computed in parallel based on the old roots thus
     /// ensure a large enough initial root table for proper parallelization.
-    fn extend_roots_table(&mut self, order: Pow2<usize>) {
+    fn extend_roots_table(&mut self, order: usize) {
+        assert!(order.is_power_of_two());
         let table = &mut self.0;
 
         // The size of the twiddle factor table is half that of the order due to
         // symmetry under multiplication by -1.
         let old_half_order = table.len();
-        let new_half_order = *order / 2;
+        let new_half_order = order / 2;
 
         if new_half_order > old_half_order {
             let col_len = new_half_order / old_half_order;
-            let unity = Fr::get_root_of_unity(*order as u64).unwrap();
+            let unity = Fr::get_root_of_unity(order as u64).unwrap();
             table.reserve_exact(new_half_order - old_half_order);
             let (init, uninit) = table.split_at_spare_mut();
 
@@ -93,9 +89,14 @@ impl NTTEngine {
         }
     }
 
-    // Returns the maximum order that it supports without extention
-    fn order(&self) -> Pow2<usize> {
-        Pow2(self.0.len() * 2)
+    // Returns the maximum order that it supports without extension
+    fn order(&self) -> usize {
+        self.0.len() * 2
+    }
+
+    /// Returns the precomputed roots of unity as a slice.
+    pub fn roots(&self) -> &[Fr] {
+        &self.0
     }
 }
 
@@ -107,144 +108,30 @@ static ENGINE: LazyLock<RwLock<NTTEngine>> = LazyLock::new(|| RwLock::new(NTTEng
 /// # Arguments
 /// * `values` - A mutable reference to an NTT container holding the
 ///   coefficients to be transformed.
-pub fn ntt_nr<C: NTTContainer<Fr>>(values: &mut NTT<Fr, C>) {
+pub fn ntt_nr(values: &mut [Fr], codeword_size: usize, num_groups: usize) {
+    ntt_nr_ark(values, codeword_size, num_groups);
+}
+
+pub fn extend_roots_table<'a>(codeword_size: usize) -> RwLockReadGuard<'a, NTTEngine> {
     let roots = ENGINE.read().unwrap();
-    let new_root = if roots.order() >= values.order() {
+    let new_root = if roots.order() >= codeword_size {
         roots
     } else {
         // Drop read lock
         drop(roots);
         let mut roots = ENGINE.write().unwrap();
-        roots.extend_roots_table(values.order());
+        roots.extend_roots_table(codeword_size);
         // Drop write lock
         drop(roots);
         ENGINE.read().unwrap()
     };
 
-    interleaved_ntt_nr(&new_root.0, values)
+    new_root
 }
 
 impl Default for NTTEngine {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// In-place Number Theoretic Transform (NTT) from normal order to reverse bit
-/// order.
-///
-/// # Use Case
-///
-/// Use this function when you have multiple polynomials
-/// stored in an interleaved fashion within a single vector, such as
-/// `[a0, b0, c0, d0, a1, b1, c1, d1, ...]` for four polynomials `a`, `b`,
-/// `c`, and `d`. By operating on interleaved data, you can perform the
-/// NTT on all polynomials in-place without needing to first transpose
-/// the data
-///
-/// # Arguments
-/// * `reversed_ordered_roots` - Precomputed roots of unity in reverse bit
-///   order.
-/// * `values` - coefficients to be transformed in place with evaluation or vice
-///   versa.
-fn interleaved_ntt_nr<C: NTTContainer<Fr>>(reversed_ordered_roots: &[Fr], values: &mut NTT<Fr, C>) {
-    // Reversed ordered roots idea from "Inside the FFT blackbox"
-    // Implementation is a DIT NR algorithm
-
-    let n = values.len();
-
-    // The order of the interleaved NTTs themselves
-    let order = values.order().0;
-
-    // This conditional is here because chunk_size for *chunk_exact_mut can't be 0
-    if order <= 1 {
-        return;
-    }
-
-    let number_of_polynomials = n / order;
-
-    // Each unique twiddle factor within a stage is a group.
-    let mut pairs_in_group = n / 2;
-    let mut num_of_groups = 1;
-
-    // For large NTTs we start with linear scans through memory and once all the
-    // elements of the sub NTTs reach the size of workload_size we know that they
-    // are contiguous in cache memory and we switch over to a different strategy.
-    // If at the start the NTT already fits in cache memory we go directly to the
-    // cache strategy strategy.
-
-    // These following two loops could be merged together, but in microbenchmarks
-    // this split performs 5% better than nesting par_iter_mut inside
-    // par_chunks_exact over the ranges 2ˆ20 to 2ˆ24.
-
-    // Parallelizing over the groups is most effective but in the beginning there
-    // aren't enough groups to occupy all threads.
-    while num_of_groups < 32.min(order) && 2 * pairs_in_group > workload_size::<Fr>() {
-        values
-            .chunks_exact_mut(2 * pairs_in_group)
-            .enumerate()
-            .for_each(|(k, group)| {
-                let omega = reversed_ordered_roots[k];
-                let (evens, odds) = group.split_at_mut(pairs_in_group);
-
-                evens.par_iter_mut().zip(odds).for_each(|(even, odd)| {
-                    (*even, *odd) = (*even + omega * *odd, *even - omega * *odd)
-                });
-            });
-        pairs_in_group /= 2;
-        num_of_groups *= 2;
-    }
-
-    while num_of_groups < order && 2 * pairs_in_group > workload_size::<Fr>() {
-        values
-            .par_chunks_exact_mut(2 * pairs_in_group)
-            .enumerate()
-            .for_each(|(k, group)| {
-                let omega = reversed_ordered_roots[k];
-                let (evens, odds) = group.split_at_mut(pairs_in_group);
-
-                evens.iter_mut().zip(odds).for_each(|(even, odd)| {
-                    (*even, *odd) = (*even + omega * *odd, *even - omega * *odd)
-                });
-            });
-        pairs_in_group /= 2;
-        num_of_groups *= 2;
-    }
-
-    values
-        .par_chunks_exact_mut(2 * pairs_in_group)
-        .enumerate()
-        .for_each(|(k, group)| {
-            dit_nr_cache(reversed_ordered_roots, k, group, number_of_polynomials);
-        });
-}
-
-fn dit_nr_cache(
-    reverse_ordered_roots: &[Fr],
-    segment: usize,
-    input: &mut [Fr],
-    num_of_polys: usize,
-) {
-    let n = input.len();
-    debug_assert!(n.is_power_of_two());
-
-    let mut pairs_in_group = n / 2;
-    let mut num_of_groups = 1;
-
-    let single_n = n / num_of_polys;
-
-    while num_of_groups < single_n {
-        let twiddle_base = segment * num_of_groups;
-        for (k, group) in input.chunks_exact_mut(2 * pairs_in_group).enumerate() {
-            let twiddle = twiddle_base + k;
-            let omega = reverse_ordered_roots[twiddle];
-            let (evens, odds) = group.split_at_mut(pairs_in_group);
-            evens.iter_mut().zip(odds).for_each(|(even, odd)| {
-                (*even, *odd) = (*even + omega * *odd, *even - omega * *odd)
-            });
-        }
-        pairs_in_group /= 2;
-        num_of_groups *= 2;
     }
 }
 
@@ -273,8 +160,10 @@ fn reverse_bits(val: usize, bits: u32) -> usize {
 /// * `order` - The order of the NTT (must be a power of 2 or zero)
 /// * `capacity` - Optional capacity hint for the vector. If `None`, defaults to
 ///   `n`. If provided, will use `max(capacity, n)` to ensure sufficient space.
-fn init_roots_reverse_ordered(order: Pow2<usize>, capacity: Option<usize>) -> Vec<Fr> {
-    match *order / 2 {
+fn init_roots_reverse_ordered(order: usize, capacity: Option<usize>) -> Vec<Fr> {
+    assert!(order.is_power_of_two());
+
+    match order / 2 {
         0 => vec![],
         // 1 is a separate case due to `1.trailing_zeros = 0` which reverse_bit requires >0
         1 => vec![Fr::ONE],
@@ -282,7 +171,7 @@ fn init_roots_reverse_ordered(order: Pow2<usize>, capacity: Option<usize>) -> Ve
             // Use provided capacity or default to n, ensuring it's at least n
             let actual_capacity = capacity.map_or(n, |cap| cap.max(n));
 
-            let root = Fr::get_root_of_unity(*order as u64).unwrap();
+            let root = Fr::get_root_of_unity(order as u64).unwrap();
 
             let mut roots = Vec::with_capacity(actual_capacity);
             let uninit = roots.spare_capacity_mut();
@@ -306,8 +195,9 @@ fn init_roots_reverse_ordered(order: Pow2<usize>, capacity: Option<usize>) -> Ve
 
 // Reorder the input in reverse bit order, allows to convert from normal order
 // to reverse order or vice versa
-fn reverse_order<T, C: NTTContainer<T>>(values: &mut NTT<T, C>) {
-    match *values.order() {
+fn reverse_order<T>(values: &mut [T], codeword_size: usize) {
+    assert!(codeword_size.is_power_of_two());
+    match codeword_size {
         0 | 1 => (),
         n => {
             for index in 0..n {
@@ -321,20 +211,20 @@ fn reverse_order<T, C: NTTContainer<T>>(values: &mut NTT<T, C>) {
 }
 
 /// Note: not specifically optimized
-pub fn intt_rn<C: NTTContainer<Fr>>(input: &mut NTT<Fr, C>) {
-    reverse_order(input);
+pub fn intt_rn(input: &mut [Fr]) {
+    reverse_order(input, input.len());
     intt_nr(input);
-    reverse_order(input);
+    reverse_order(input, input.len());
 }
 
 // Inverse NTT
-fn intt_nr<C: NTTContainer<Fr>>(values: &mut NTT<Fr, C>) {
-    match *values.order() {
+fn intt_nr(values: &mut [Fr]) {
+    match values.len() {
         0 => (),
         n => {
             // Reverse the input such that the roots act as inverse roots
             values[1..].reverse();
-            ntt_nr(values);
+            ntt_nr(values, n, 1);
 
             let factor = Fr::ONE / Fr::from(n as u64);
 
@@ -345,19 +235,17 @@ fn intt_nr<C: NTTContainer<Fr>>(values: &mut NTT<Fr, C>) {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    #[cfg(test)]
-    use proptest::prelude::*;
     use {
         super::{init_roots_reverse_ordered, reverse_order},
         crate::{
             ntt::{intt_rn, NTTEngine},
-            ntt_nr, Pow2, NTT,
+            ntt_nr,
         },
         ark_bn254::Fr,
         ark_ff::BigInt,
-        proptest::collection,
+        proptest::{collection, prelude::*},
         std::{
             fmt,
             num::{NonZero, NonZeroUsize},
@@ -382,13 +270,11 @@ mod tests {
     /// length.
     fn ntt<T: fmt::Debug>(
         sizes: impl Strategy<Value = usize>,
-        number_of_polynomials: usize,
         elem: impl Strategy<Value = T> + Clone,
-    ) -> impl Strategy<Value = NTT<T, Vec<T>>> {
+    ) -> impl Strategy<Value = Vec<T>> {
         sizes
             .prop_map(|k| 1 << k)
             .prop_flat_map(move |len| collection::vec(elem.clone(), len..=len))
-            .prop_map(move |v| NTT::new(v, number_of_polynomials).unwrap())
     }
 
     /// Newtype wrapper to prevent proptest from writing the contents of an NTT
@@ -397,30 +283,30 @@ mod tests {
     /// If the contents does have to be viewed replace [`hidden_ntt`] with
     /// [`ntt`] as the test strategy
     #[derive(Clone, PartialEq)]
-    struct HiddenNTT<T>(NTT<T, Vec<T>>);
+    struct HiddenNTT<T>(Vec<T>);
 
     impl<T> fmt::Debug for HiddenNTT<T> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "HiddenNTT(len={})", self.0.order().0)
+            write!(f, "HiddenNTT(len={})", self.0.len())
         }
     }
 
     fn hidden_ntt<T: fmt::Debug>(
         sizes: impl Strategy<Value = usize>,
-        number_of_polynomials: usize,
         elem: impl Strategy<Value = T> + Clone,
     ) -> impl Strategy<Value = HiddenNTT<T>> {
-        ntt(sizes, number_of_polynomials, elem).prop_map(HiddenNTT)
+        ntt(sizes, elem).prop_map(HiddenNTT)
     }
 
     proptest! {
         #[test]
-        fn round_trip_ntt(original in hidden_ntt(0_usize..15, 1, fr()))
+        fn round_trip_ntt(original in hidden_ntt(0_usize..15, fr()))
         {
             let mut s = original.clone();
 
             // Forward NTT
-            ntt_nr(&mut s.0);
+            let codeword_size = s.0.len();
+            ntt_nr(&mut s.0, codeword_size,1);
 
             // Inverse NTT
             intt_rn(&mut s.0);
@@ -464,16 +350,14 @@ mod tests {
     ) -> impl Strategy<
         Value = (
             // rows
-            Pow2<NonZero<usize>>,
+            NonZero<usize>,
             // columns
-            Pow2<NonZero<usize>>,
+            NonZero<usize>,
             HiddenNTT<Fr>,
         ),
     > {
-        fn constr(exp: usize) -> Pow2<NonZero<usize>> {
-            NonZeroUsize::new(2_usize.pow(exp as u32))
-                .and_then(Pow2::new)
-                .unwrap()
+        fn constr(exp: usize) -> NonZero<usize> {
+            NonZeroUsize::new(2_usize.pow(exp as u32)).unwrap()
         }
 
         k.prop_flat_map(|len| {
@@ -481,7 +365,7 @@ mod tests {
                 (
                     Just(constr(len - column)),
                     Just(constr(column)),
-                    hidden_ntt(len..=len, constr(column).get(), fr()),
+                    hidden_ntt(len..=len, fr()),
                 )
             })
         })
@@ -494,14 +378,14 @@ mod tests {
             let mut transposed = transpose(&ntt, rows.get(), columns.get());
 
             for chunk in transposed.chunks_exact_mut(rows.get()){
-                let mut fold = NTT::new(chunk,1).unwrap();
-                ntt_nr(&mut fold);
+                let codeword_size = chunk.len();
+                ntt_nr(chunk, codeword_size,1);
             }
 
-        let double_transposed = transpose(&transposed, columns.get(), rows.get());
+            let double_transposed = transpose(&transposed, columns.get(), rows.get());
 
-        ntt_nr(&mut ntt);
-        prop_assert!(double_transposed == ntt.into_inner());
+            ntt_nr(&mut ntt, rows.get(),1);
+            prop_assert!(double_transposed == ntt);
 
         }
     }
@@ -509,14 +393,14 @@ mod tests {
     #[test]
     // The roundtrip test doesn't test size 0.
     fn ntt_empty() {
-        let mut v = NTT::new(vec![], 1).unwrap();
-        ntt_nr(&mut v);
+        let mut v = vec![];
+        ntt_nr(&mut v, 0, 1);
     }
 
     // Compare direct generation of the roots vs. extending from a base set of roots
     #[test]
     fn roots_direct_vs_extended() {
-        let order = Pow2::new(2_usize.pow(20)).unwrap();
+        let order = 2_usize.pow(20);
         let roots = init_roots_reverse_ordered(order, None);
         let engine = NTTEngine::with_order(order);
         assert_eq!(engine.0.len(), roots.len());
@@ -525,19 +409,21 @@ mod tests {
 
     proptest! {
         #[test]
-        fn round_trip_reverse_order(original in ntt(0_usize..10, 1, any::<u32>())){
+        fn round_trip_reverse_order(original in ntt(0_usize..10, any::<u32>())){
             let mut v = original.clone();
-            reverse_order(&mut v);
-            reverse_order(&mut v);
+            let codeword_size = v.len();
+            reverse_order(&mut v,codeword_size);
+            reverse_order(&mut v,codeword_size);
             prop_assert_eq!(original, v)
         }
     }
 
     proptest! {
         #[test]
-        fn reverse_order_noop(original in ntt(0_usize..=1, 1, any::<u32>())) {
+        fn reverse_order_noop(original in ntt(0_usize..=1, any::<u32>())) {
             let mut v = original.clone();
-            reverse_order(&mut v);
+            let codeword_size = v.len();
+            reverse_order(&mut v, codeword_size);
             assert_eq!(original, v)
         }
 

--- a/provekit/common/Cargo.toml
+++ b/provekit/common/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 
 [dependencies]
 # Workspace crates
+provekit-ntt.workspace = true
 # skyscraper.workspace = true
 
 # Noir language

--- a/provekit/common/src/lib.rs
+++ b/provekit/common/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod file;
 mod interner;
 mod noir_proof_scheme;
+pub mod ntt;
 pub mod prefix_covector;
 mod prover;
 mod r1cs;
@@ -47,7 +48,7 @@ pub fn register_ntt() {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         let ntt: Arc<dyn whir::algebra::ntt::ReedSolomon<FieldElement>> =
-            Arc::new(whir::algebra::ntt::ArkNtt::<FieldElement>::default());
+            Arc::new(crate::ntt::RSFr);
         whir::algebra::ntt::NTT.insert(ntt);
 
         // let skyscraper: Arc<dyn whir::hash::HashEngine> =

--- a/provekit/common/src/ntt.rs
+++ b/provekit/common/src/ntt.rs
@@ -1,0 +1,98 @@
+use {
+    crate::FieldElement, ark_ff::AdditiveGroup, provekit_ntt::ntt_nr, rayon::prelude::*,
+    whir::algebra::ntt::ReedSolomon,
+};
+
+#[derive(Debug)]
+pub struct RSFr;
+
+impl ReedSolomon<FieldElement> for RSFr {
+    fn interleaved_encode(
+        &self,
+        coeffs: &[&[FieldElement]],
+        codeword_length: usize,
+        interleaving_depth: usize,
+    ) -> Vec<FieldElement> {
+        if coeffs.is_empty() {
+            return Vec::new();
+        }
+
+        let poly_size = coeffs[0].len();
+        for poly in coeffs {
+            assert_eq!(poly_size, poly.len());
+        }
+        assert!(poly_size.is_multiple_of(interleaving_depth));
+        assert!(codeword_length.is_power_of_two());
+
+        let message_length = poly_size / interleaving_depth;
+        assert!(codeword_length.is_multiple_of(message_length));
+
+        let num_interleaved_polys = coeffs.len() * interleaving_depth;
+        let mut result = vec![FieldElement::ZERO; codeword_length * num_interleaved_polys];
+
+        for (poly_index, poly) in coeffs.iter().enumerate() {
+            for (block_index, block) in poly.chunks_exact(message_length).enumerate() {
+                let column = poly_index * interleaving_depth + block_index;
+                for (coeff_index, &coeff) in block.iter().enumerate() {
+                    result[coeff_index * num_interleaved_polys + column] = coeff;
+                }
+            }
+        }
+
+        ntt_nr(&mut result, codeword_length, 1);
+        bit_reverse_rows(&mut result, codeword_length, num_interleaved_polys);
+        result
+    }
+}
+
+fn bit_reverse_rows(matrix: &mut [FieldElement], rows: usize, cols: usize) {
+    debug_assert_eq!(matrix.len(), rows * cols);
+    let bits = rows.trailing_zeros();
+    if rows >= 1 << 14 {
+        let ptr = matrix.as_mut_ptr() as usize;
+        (0..rows).into_par_iter().for_each(|row| {
+            let rev = row.reverse_bits() >> (usize::BITS - bits);
+            if row < rev {
+                let row_start = row * cols;
+                let rev_start = rev * cols;
+                // Bit reversal is an involution and this branch only runs for
+                // row < rev, so each parallel swap touches disjoint rows.
+                unsafe {
+                    std::ptr::swap_nonoverlapping(
+                        (ptr as *mut FieldElement).add(row_start),
+                        (ptr as *mut FieldElement).add(rev_start),
+                        cols,
+                    );
+                }
+            }
+        });
+        return;
+    }
+
+    for row in 0..rows {
+        let rev = row.reverse_bits() >> (usize::BITS - bits);
+        if row < rev {
+            let row_start = row * cols;
+            let rev_start = rev * cols;
+            let (left, right) = matrix.split_at_mut(rev_start);
+            left[row_start..row_start + cols].swap_with_slice(&mut right[..cols]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, whir::algebra::ntt::ArkNtt};
+
+    #[test]
+    fn matches_ark_ntt_for_interleaved_encode() {
+        let poly_a: Vec<_> = (0..16).map(FieldElement::from).collect();
+        let poly_b: Vec<_> = (20..36).map(FieldElement::from).collect();
+        let coeffs = vec![poly_a.as_slice(), poly_b.as_slice()];
+
+        let fast = RSFr.interleaved_encode(&coeffs, 32, 4);
+        let reference = ArkNtt::<FieldElement>::default().interleaved_encode(&coeffs, 32, 4);
+
+        assert_eq!(fast, reference);
+    }
+}

--- a/provekit/common/src/ntt.rs
+++ b/provekit/common/src/ntt.rs
@@ -39,15 +39,17 @@ fn interleaved_rs_encode(
 ) -> Vec<FieldElement> {
     let column_count = coeffs.len() * interleaving_depth;
     let mut result = vec![FieldElement::ZERO; codeword_length * column_count];
+    let coset_size = message_length;
+    let num_cosets = codeword_length / coset_size;
+    let chunk_size = coset_size * column_count;
 
-    write_interleaved_coefficients(
-        &mut result[..message_length * column_count],
-        coeffs,
-        message_length,
-        interleaving_depth,
-    );
+    write_interleaved_coefficients(&mut result[..chunk_size], coeffs, message_length);
 
-    ntt_nr(&mut result, codeword_length, 1);
+    for k in 1..num_cosets {
+        result.copy_within(0..chunk_size, k * chunk_size);
+    }
+
+    ntt_nr(&mut result, codeword_length, num_cosets);
     bit_reverse_rows(&mut result, codeword_length, column_count);
     result
 }
@@ -56,21 +58,18 @@ fn write_interleaved_coefficients(
     interleaved_coeffs: &mut [FieldElement],
     coeffs: &[&[FieldElement]],
     message_length: usize,
-    interleaving_depth: usize,
 ) {
-    let column_count = coeffs.len() * interleaving_depth;
+    let column_count = interleaved_coeffs.len() / message_length;
     debug_assert_eq!(interleaved_coeffs.len(), message_length * column_count);
+    let blocks_per_poly = column_count / coeffs.len();
 
-    for (column_index, column_coeffs) in coeffs
-        .iter()
-        .flat_map(|poly| poly.chunks_exact(message_length))
-        .enumerate()
-    {
-        for (row, &coeff) in interleaved_coeffs
-            .chunks_exact_mut(column_count)
-            .zip(column_coeffs)
-        {
-            row[column_index] = coeff;
+    for column in 0..message_length {
+        let base = column * column_count;
+        for (poly_index, poly) in coeffs.iter().enumerate() {
+            for (block_index, block) in poly.chunks_exact(message_length).enumerate() {
+                interleaved_coeffs[base + poly_index * blocks_per_poly + block_index] =
+                    block[column];
+            }
         }
     }
 }

--- a/provekit/common/src/ntt.rs
+++ b/provekit/common/src/ntt.rs
@@ -74,34 +74,29 @@ fn write_interleaved_coefficients(
 fn bit_reverse_rows(matrix: &mut [FieldElement], rows: usize, cols: usize) {
     debug_assert_eq!(matrix.len(), rows * cols);
     let bits = rows.trailing_zeros();
+
+    let swap = |ptr: *mut FieldElement, row: usize, rev: usize| unsafe {
+        std::ptr::swap_nonoverlapping(ptr.add(row * cols), ptr.add(rev * cols), cols);
+    };
+
     if rows >= 1 << 14 {
         let ptr = matrix.as_mut_ptr() as usize;
         (0..rows).into_par_iter().for_each(|row| {
             let rev = row.reverse_bits() >> (usize::BITS - bits);
             if row < rev {
-                let row_start = row * cols;
-                let rev_start = rev * cols;
                 // Bit reversal is an involution and this branch only runs for
                 // row < rev, so each parallel swap touches disjoint rows.
-                unsafe {
-                    std::ptr::swap_nonoverlapping(
-                        (ptr as *mut FieldElement).add(row_start),
-                        (ptr as *mut FieldElement).add(rev_start),
-                        cols,
-                    );
-                }
+                swap(ptr as *mut FieldElement, row, rev);
             }
         });
         return;
     }
 
+    let ptr = matrix.as_mut_ptr();
     for row in 0..rows {
         let rev = row.reverse_bits() >> (usize::BITS - bits);
         if row < rev {
-            let row_start = row * cols;
-            let rev_start = rev * cols;
-            let (left, right) = matrix.split_at_mut(rev_start);
-            left[row_start..row_start + cols].swap_with_slice(&mut right[..cols]);
+            swap(ptr, row, rev);
         }
     }
 }

--- a/provekit/common/src/ntt.rs
+++ b/provekit/common/src/ntt.rs
@@ -27,21 +27,47 @@ impl ReedSolomon<FieldElement> for RSFr {
         let message_length = poly_size / interleaving_depth;
         assert!(codeword_length.is_multiple_of(message_length));
 
-        let num_interleaved_polys = coeffs.len() * interleaving_depth;
-        let mut result = vec![FieldElement::ZERO; codeword_length * num_interleaved_polys];
+        interleaved_rs_encode(coeffs, codeword_length, message_length, interleaving_depth)
+    }
+}
 
-        for (poly_index, poly) in coeffs.iter().enumerate() {
-            for (block_index, block) in poly.chunks_exact(message_length).enumerate() {
-                let column = poly_index * interleaving_depth + block_index;
-                for (coeff_index, &coeff) in block.iter().enumerate() {
-                    result[coeff_index * num_interleaved_polys + column] = coeff;
-                }
+fn interleaved_rs_encode(
+    coeffs: &[&[FieldElement]],
+    codeword_length: usize,
+    message_length: usize,
+    interleaving_depth: usize,
+) -> Vec<FieldElement> {
+    let column_count = coeffs.len() * interleaving_depth;
+    let mut result = vec![FieldElement::ZERO; codeword_length * column_count];
+
+    write_interleaved_coefficients(
+        &mut result[..message_length * column_count],
+        coeffs,
+        message_length,
+        interleaving_depth,
+    );
+
+    ntt_nr(&mut result, codeword_length, 1);
+    bit_reverse_rows(&mut result, codeword_length, column_count);
+    result
+}
+
+fn write_interleaved_coefficients(
+    interleaved_coeffs: &mut [FieldElement],
+    coeffs: &[&[FieldElement]],
+    message_length: usize,
+    interleaving_depth: usize,
+) {
+    let column_count = coeffs.len() * interleaving_depth;
+    debug_assert_eq!(interleaved_coeffs.len(), message_length * column_count);
+
+    for (poly_index, poly) in coeffs.iter().enumerate() {
+        for (block_index, block) in poly.chunks_exact(message_length).enumerate() {
+            let column = poly_index * interleaving_depth + block_index;
+            for (coeff_index, &coeff) in block.iter().enumerate() {
+                interleaved_coeffs[coeff_index * column_count + column] = coeff;
             }
         }
-
-        ntt_nr(&mut result, codeword_length, 1);
-        bit_reverse_rows(&mut result, codeword_length, num_interleaved_polys);
-        result
     }
 }
 

--- a/provekit/common/src/ntt.rs
+++ b/provekit/common/src/ntt.rs
@@ -61,43 +61,46 @@ fn write_interleaved_coefficients(
     let column_count = coeffs.len() * interleaving_depth;
     debug_assert_eq!(interleaved_coeffs.len(), message_length * column_count);
 
-    for (poly_index, poly) in coeffs.iter().enumerate() {
-        for (block_index, block) in poly.chunks_exact(message_length).enumerate() {
-            let column = poly_index * interleaving_depth + block_index;
-            for (coeff_index, &coeff) in block.iter().enumerate() {
-                interleaved_coeffs[coeff_index * column_count + column] = coeff;
-            }
+    for (column_index, column_coeffs) in coeffs
+        .iter()
+        .flat_map(|poly| poly.chunks_exact(message_length))
+        .enumerate()
+    {
+        for (row, &coeff) in interleaved_coeffs
+            .chunks_exact_mut(column_count)
+            .zip(column_coeffs)
+        {
+            row[column_index] = coeff;
         }
     }
 }
 
 fn bit_reverse_rows(matrix: &mut [FieldElement], rows: usize, cols: usize) {
     debug_assert_eq!(matrix.len(), rows * cols);
-    let bits = rows.trailing_zeros();
+    debug_assert!(rows.is_power_of_two());
 
-    let swap = |ptr: *mut FieldElement, row: usize, rev: usize| unsafe {
-        std::ptr::swap_nonoverlapping(ptr.add(row * cols), ptr.add(rev * cols), cols);
+    let bits = rows.trailing_zeros();
+    let ptr = matrix.as_mut_ptr() as usize;
+
+    let swap_bit_reversed_pair = |row: usize| {
+        let rev = row.reverse_bits() >> (usize::BITS - bits);
+        if row < rev {
+            // Bit reversal is an involution; keeping only row < rev gives each
+            // worker a disjoint row pair.
+            unsafe {
+                std::ptr::swap_nonoverlapping(
+                    (ptr as *mut FieldElement).add(row * cols),
+                    (ptr as *mut FieldElement).add(rev * cols),
+                    cols,
+                );
+            }
+        }
     };
 
     if rows >= 1 << 14 {
-        let ptr = matrix.as_mut_ptr() as usize;
-        (0..rows).into_par_iter().for_each(|row| {
-            let rev = row.reverse_bits() >> (usize::BITS - bits);
-            if row < rev {
-                // Bit reversal is an involution and this branch only runs for
-                // row < rev, so each parallel swap touches disjoint rows.
-                swap(ptr as *mut FieldElement, row, rev);
-            }
-        });
-        return;
-    }
-
-    let ptr = matrix.as_mut_ptr();
-    for row in 0..rows {
-        let rev = row.reverse_bits() >> (usize::BITS - bits);
-        if row < rev {
-            swap(ptr, row, rev);
-        }
+        (0..rows).into_par_iter().for_each(swap_bit_reversed_pair);
+    } else {
+        (0..rows).for_each(swap_bit_reversed_pair);
     }
 }
 

--- a/provekit/common/src/prefix_covector.rs
+++ b/provekit/common/src/prefix_covector.rs
@@ -1,6 +1,7 @@
 use {
     crate::FieldElement,
     ark_std::{One, Zero},
+    rayon::prelude::*,
     whir::algebra::{dot, linear_form::LinearForm, multilinear_extend},
 };
 
@@ -76,11 +77,18 @@ impl LinearForm<FieldElement> for PrefixCovector {
     }
 
     fn accumulate(&self, accumulator: &mut [FieldElement], scalar: FieldElement) {
-        for (acc, val) in accumulator[..self.vector.len()]
-            .iter_mut()
-            .zip(&self.vector)
-        {
-            *acc += scalar * *val;
+        let accumulator = &mut accumulator[..self.vector.len()];
+        if self.vector.len() > whir::utils::workload_size::<FieldElement>() {
+            accumulator
+                .par_iter_mut()
+                .zip(self.vector.par_iter())
+                .for_each(|(acc, val)| {
+                    *acc += scalar * *val;
+                });
+        } else {
+            for (acc, val) in accumulator.iter_mut().zip(&self.vector) {
+                *acc += scalar * *val;
+            }
         }
     }
 }

--- a/provekit/common/src/utils/sumcheck.rs
+++ b/provekit/common/src/utils/sumcheck.rs
@@ -208,9 +208,9 @@ pub fn transpose_r1cs_matrices(r1cs: &R1CS) -> (SparseMatrix, SparseMatrix, Spar
 /// external row.
 #[instrument(skip_all)]
 pub fn multiply_transposed_by_eq_alpha(
-    at: &SparseMatrix,
-    bt: &SparseMatrix,
-    ct: &SparseMatrix,
+    at: SparseMatrix,
+    bt: SparseMatrix,
+    ct: SparseMatrix,
     alpha: &[FieldElement],
     r1cs: &R1CS,
 ) -> [Vec<FieldElement>; 3] {
@@ -237,8 +237,8 @@ pub fn multiply_transposed_by_eq_alpha(
 #[instrument(skip_all)]
 pub fn calculate_external_row_of_r1cs_matrices(
     alpha: &[FieldElement],
-    r1cs: &R1CS,
+    r1cs: R1CS,
 ) -> [Vec<FieldElement>; 3] {
-    let (at, bt, ct) = transpose_r1cs_matrices(r1cs);
-    multiply_transposed_by_eq_alpha(&at, &bt, &ct, alpha, r1cs)
+    let (at, bt, ct) = transpose_r1cs_matrices(&r1cs);
+    multiply_transposed_by_eq_alpha(at, bt, ct, alpha, &r1cs)
 }

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -152,6 +152,7 @@ impl WhirR1CSProver for WhirR1CSScheme {
         drop(full_witness);
 
         let alphas = calculate_external_row_of_r1cs_matrices(&alpha, &r1cs);
+        drop(r1cs);
         let (x, public_weight) = get_public_weights(public_inputs, &mut merlin, self.m);
 
         let blinding_offset = blinding.offset;

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -151,8 +151,7 @@ impl WhirR1CSProver for WhirR1CSScheme {
         );
         drop(full_witness);
 
-        let alphas = calculate_external_row_of_r1cs_matrices(&alpha, &r1cs);
-        drop(r1cs);
+        let alphas = calculate_external_row_of_r1cs_matrices(&alpha, r1cs);
         let (x, public_weight) = get_public_weights(public_inputs, &mut merlin, self.m);
 
         let blinding_offset = blinding.offset;

--- a/provekit/r1cs-compiler/Cargo.toml
+++ b/provekit/r1cs-compiler/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 [dependencies]
 # Workspace crates
 provekit-common.workspace = true
+provekit-ntt.workspace = true
 ark-bn254.workspace = true
-# ntt.workspace = true
 
 # Noir language
 acir.workspace = true

--- a/provekit/r1cs-compiler/src/ntt.rs
+++ b/provekit/r1cs-compiler/src/ntt.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)] // Remove once RSFr is used for WHIR
-use {ark_bn254::Fr, ark_ff::AdditiveGroup, ntt::ntt_nr, whir::algebra::ntt::ReedSolomon};
+use {
+    ark_bn254::Fr, ark_ff::AdditiveGroup, provekit_ntt::ntt_nr, whir::algebra::ntt::ReedSolomon,
+};
 
 pub struct RSFr;
 impl ReedSolomon<Fr> for RSFr {
@@ -26,7 +28,7 @@ fn interleaved_rs_encode(
     let mut result = vec![Fr::ZERO; expanded_size];
     result[..interleaved_coeffs.len()].copy_from_slice(interleaved_coeffs);
 
-    let mut ntt = ntt::NTT::new(result, interleaving_depth).expect(
+    let mut ntt = provekit_ntt::NTT::new(result, interleaving_depth).expect(
         "interleaved_coeffs.len() * expansion / interleaving_depth needs to be a power of two.",
     );
 

--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -91,14 +91,8 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
         );
         let x: FieldElement = arthur.verifier_message();
 
-        let alphas = multiply_transposed_by_eq_alpha(
-            &at,
-            &bt,
-            &ct,
-            &data_from_sumcheck_verifier.alpha,
-            r1cs,
-        );
-        drop((at, bt, ct));
+        let alphas =
+            multiply_transposed_by_eq_alpha(at, bt, ct, &data_from_sumcheck_verifier.alpha, r1cs);
 
         let blinding_eval = data_from_sumcheck_verifier.blinding_eval;
         let blinding_weights = expand_powers::<4>(&data_from_sumcheck_verifier.alpha);

--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -98,6 +98,7 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
             &data_from_sumcheck_verifier.alpha,
             r1cs,
         );
+        drop((at, bt, ct));
 
         let blinding_eval = data_from_sumcheck_verifier.blinding_eval;
         let blinding_weights = expand_powers::<4>(&data_from_sumcheck_verifier.alpha);


### PR DESCRIPTION
## Summary

Ports the ProveKit NTT path from main:
- [main RS integration](https://github.com/worldfnd/provekit/blob/cc391c8cc72766cc47f8243402e7f51e16c6d7cd/provekit/common/src/ntt.rs)
- [main NTT crate](https://github.com/worldfnd/provekit/tree/cc391c8cc72766cc47f8243402e7f51e16c6d7cd/ntt)

The RS interface on this branch is slightly different from main WHIR, so this PR keeps the port minimal and adapts the interleaved encoding layout locally to match the older interface.

## Notes

Main also has a [B51 backend for wasm](https://github.com/worldfnd/provekit/blob/cc391c8cc72766cc47f8243402e7f51e16c6d7cd/ntt/src/b51_interleaved.rs).

That backend is not ported here because it depends on the `bn254` implementation from Skyscraper, which is also behind main on this branch. Pulling it in looks like a larger sync/refactor. Should we do that as part of this PR, or leave it for a follow-up?

## Results

On `complete_age_check`, 10 runs each (`~/before` vs `~/after`):

| metric | before | after|
| --- | ---: | ---: |
| allocator peak | `816 MB` | `774 MB` |
| max RSS avg | `1358.1 MiB` | `1025.2 MiB` |
| macOS peak footprint avg | `1328.1 MiB` | `994.9 MiB` |
| `prove_with_witness` avg | `1.100 s` | `0.993 s` |
| full `run` avg | `1.831 s` | `1.743 s` |
| wall-clock `real` avg | `1.838 s` | `1.752 s` |

The current `after` build keeps the memory win (`42 MB` allocator peak, about `333 MiB`
RSS/footprint) and is also faster in this run: about `9.7%` faster in
`prove_with_witness` and about `4.8%` faster for the full `prove` command.
