### PR TITLE
perf(prover): collapse R1CS row-covectors into one before WHIR

### DIFF
--- a/provekit/common/src/prefix_covector.rs
+++ b/provekit/common/src/prefix_covector.rs
@@ -249,15 +249,15 @@ pub fn build_combined_prefix_covector<const N: usize>(
     combined.resize(base_len, FieldElement::zero());
 
     // Scale the first vector by coeffs[0]. For geometric-RLC weights this is
-    // `one()` and the loop is skipped, but we support general coefficients.
+    // one() and the multiply is a no-op, but the cost is negligible vs. the
+    // accumulation that follows and a branchless path keeps the helper
+    // general for non-geometric callers.
     let c0 = coeffs[0];
-    if !c0.is_one() {
-        if raw_len > whir::utils::workload_size::<FieldElement>() {
-            combined[..raw_len].par_iter_mut().for_each(|v| *v *= c0);
-        } else {
-            for v in &mut combined[..raw_len] {
-                *v *= c0;
-            }
+    if raw_len > whir::utils::workload_size::<FieldElement>() {
+        combined[..raw_len].par_iter_mut().for_each(|v| *v *= c0);
+    } else {
+        for v in &mut combined[..raw_len] {
+            *v *= c0;
         }
     }
 
@@ -265,9 +265,6 @@ pub fn build_combined_prefix_covector<const N: usize>(
     // zero throughout, so we only walk `raw_len` positions per source.
     for (i, src) in iter.enumerate() {
         let c = coeffs[i + 1];
-        if c.is_zero() {
-            continue;
-        }
         let dst = &mut combined[..raw_len];
         if raw_len > whir::utils::workload_size::<FieldElement>() {
             dst.par_iter_mut().zip(src.par_iter()).for_each(|(d, &s)| {
@@ -290,8 +287,11 @@ pub fn build_combined_prefix_covector<const N: usize>(
 pub fn compute_alpha_evals<const N: usize>(
     polynomial: &[FieldElement],
     alphas: &[Vec<FieldElement>; N],
-) -> [FieldElement; N] {
-    std::array::from_fn(|i| dot(&alphas[i], &polynomial[..alphas[i].len()]))
+) -> Vec<FieldElement> {
+    alphas
+        .iter()
+        .map(|w| dot(w, &polynomial[..w.len()]))
+        .collect()
 }
 
 /// Compute the public weight evaluation `⟨[1, x, x², …, x^N], poly[0..=N]⟩`

--- a/provekit/common/src/prefix_covector.rs
+++ b/provekit/common/src/prefix_covector.rs
@@ -199,34 +199,13 @@ pub fn make_public_weight(x: FieldElement, num_public_inputs: usize, m: usize) -
     PrefixCovector::new(public_weights, domain_size)
 }
 
-/// Build [`PrefixCovector`] weights from alpha vectors, consuming the alphas.
-///
-/// Each alpha vector is padded to a power-of-two length (min 2) and wrapped
-/// in a `PrefixCovector` with the given domain size `2^m`.
-#[must_use]
-pub fn build_prefix_covectors<const N: usize>(
-    m: usize,
-    alphas: [Vec<FieldElement>; N],
-) -> Vec<PrefixCovector> {
-    let domain_size = 1usize << m;
-    alphas
-        .into_iter()
-        .map(|mut w| {
-            let base_len = w.len().next_power_of_two().max(2);
-            w.resize(base_len, FieldElement::zero());
-            PrefixCovector::new(w, domain_size)
-        })
-        .collect()
-}
-
 /// Build a single [`PrefixCovector`] equal to `Σᵢ coeffs[i] · alphas[i]`,
 /// consuming the inputs.
 ///
-/// Behaves like [`build_prefix_covectors`] followed by a coefficient-weighted
-/// sum across the resulting covectors, but allocates only the combined vector
-/// instead of `N` independent ones — saving `(N − 1) × base_len` field
-/// elements at peak for callers that would otherwise materialise all of them
-/// simultaneously (e.g. the three R1CS matrix covectors A, B, C).
+/// Allocates one combined vector instead of `N` independent
+/// [`PrefixCovector`]s — saving `(N − 1) × base_len` field elements at peak
+/// for callers that would otherwise materialise all of them simultaneously
+/// (e.g. the three R1CS matrix covectors A, B, C).
 ///
 /// All input vectors must share the same length; the result is padded to
 /// the next power of two (min 2) to match [`PrefixCovector`]'s convention.

--- a/provekit/common/src/prefix_covector.rs
+++ b/provekit/common/src/prefix_covector.rs
@@ -1,6 +1,7 @@
 use {
     crate::FieldElement,
     ark_std::{One, Zero},
+    rayon::prelude::*,
     whir::algebra::{dot, linear_form::LinearForm, multilinear_extend},
 };
 
@@ -165,6 +166,19 @@ pub fn expand_powers<const D: usize>(values: &[FieldElement]) -> Vec<FieldElemen
     result
 }
 
+/// Geometric series `[1, x, x², …, x^{N-1}]` as a fixed-size array.
+///
+/// Used to expand a single Fiat-Shamir RLC challenge into the coefficient
+/// vector that collapses `N` parallel claims into one.
+#[must_use]
+pub fn rlc_powers<const N: usize>(x: FieldElement) -> [FieldElement; N] {
+    let mut out = [FieldElement::one(); N];
+    for i in 1..N {
+        out[i] = out[i - 1] * x;
+    }
+    out
+}
+
 /// Create a public weight [`PrefixCovector`] from Fiat-Shamir randomness `x`.
 ///
 /// Builds the vector `[1, x, x², …, x^{n-1}]` where `n = num_public_inputs +
@@ -205,6 +219,70 @@ pub fn build_prefix_covectors<const N: usize>(
         .collect()
 }
 
+/// Build a single [`PrefixCovector`] equal to `Σᵢ coeffs[i] · alphas[i]`,
+/// consuming the inputs.
+///
+/// Behaves like [`build_prefix_covectors`] followed by a coefficient-weighted
+/// sum across the resulting covectors, but allocates only the combined vector
+/// instead of `N` independent ones — saving `(N − 1) × base_len` field
+/// elements at peak for callers that would otherwise materialise all of them
+/// simultaneously (e.g. the three R1CS matrix covectors A, B, C).
+///
+/// All input vectors must share the same length; the result is padded to
+/// the next power of two (min 2) to match [`PrefixCovector`]'s convention.
+#[must_use]
+pub fn build_combined_prefix_covector<const N: usize>(
+    alphas: [Vec<FieldElement>; N],
+    coeffs: &[FieldElement; N],
+    domain_size: usize,
+) -> PrefixCovector {
+    const { assert!(N > 0, "need at least one input vector") };
+    let raw_len = alphas[0].len();
+    debug_assert!(
+        alphas.iter().all(|v| v.len() == raw_len),
+        "all input vectors must share the same length"
+    );
+    let base_len = raw_len.next_power_of_two().max(2);
+
+    let mut iter = alphas.into_iter();
+    let mut combined = iter.next().expect("N > 0 enforced at compile time");
+    combined.resize(base_len, FieldElement::zero());
+
+    // Scale the first vector by coeffs[0]. For geometric-RLC weights this is
+    // `one()` and the loop is skipped, but we support general coefficients.
+    let c0 = coeffs[0];
+    if !c0.is_one() {
+        if raw_len > whir::utils::workload_size::<FieldElement>() {
+            combined[..raw_len].par_iter_mut().for_each(|v| *v *= c0);
+        } else {
+            for v in &mut combined[..raw_len] {
+                *v *= c0;
+            }
+        }
+    }
+
+    // Accumulate the remaining vectors. The padded tail of `combined` stays
+    // zero throughout, so we only walk `raw_len` positions per source.
+    for (i, src) in iter.enumerate() {
+        let c = coeffs[i + 1];
+        if c.is_zero() {
+            continue;
+        }
+        let dst = &mut combined[..raw_len];
+        if raw_len > whir::utils::workload_size::<FieldElement>() {
+            dst.par_iter_mut().zip(src.par_iter()).for_each(|(d, &s)| {
+                *d += c * s;
+            });
+        } else {
+            for (d, &s) in dst.iter_mut().zip(src.iter()) {
+                *d += c * s;
+            }
+        }
+    }
+
+    PrefixCovector::new(combined, domain_size)
+}
+
 /// Compute dot products of alpha vectors against a polynomial without
 /// allocating [`PrefixCovector`] weights. Used to write transcript hints
 /// before deferring weight construction (saves memory in dual-commit).
@@ -212,11 +290,8 @@ pub fn build_prefix_covectors<const N: usize>(
 pub fn compute_alpha_evals<const N: usize>(
     polynomial: &[FieldElement],
     alphas: &[Vec<FieldElement>; N],
-) -> Vec<FieldElement> {
-    alphas
-        .iter()
-        .map(|w| dot(w, &polynomial[..w.len()]))
-        .collect()
+) -> [FieldElement; N] {
+    std::array::from_fn(|i| dot(&alphas[i], &polynomial[..alphas[i].len()]))
 }
 
 /// Compute the public weight evaluation `⟨[1, x, x², …, x^N], poly[0..=N]⟩`

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -158,6 +158,7 @@ impl WhirR1CSProver for WhirR1CSScheme {
         let domain_size = 1usize << self.m;
 
         if is_single {
+            // Single commitment path
             let commitment = commitments.into_iter().next().unwrap();
 
             let evals = compute_alpha_evals(&commitment.polynomial, &alphas);
@@ -173,10 +174,11 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 None
             };
 
-            // `inner_rlc` is sampled only after every alpha eval (and the
-            // optional public eval) is absorbed: standard Schwartz-Zippel on
-            // the (A, B, C) -> A + r·B + r²·C collapse then gives soundness
-            // ≤ 2/|F| per commitment.
+            // Sample `inner_rlc` only after every alpha eval (and the optional
+            // public eval) is absorbed into the transcript. By Schwartz-Zippel
+            // on the degree-2 polynomial `A + r·B + r²·C`, a false (A, B, C)
+            // claim collapses to a true combined claim with probability at
+            // most 2/|F|.
             let powers = rlc_powers::<3>(merlin.verifier_message());
             let combined_eval = dot(&powers, &evals);
             let combined_lf = build_combined_prefix_covector(alphas, &powers, domain_size);
@@ -202,6 +204,7 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 Cow::Borrowed(&evaluations),
             );
         } else {
+            // Dual commitment path
             let mut commitments = commitments.into_iter();
             let c1 = commitments.next().unwrap();
             let c2 = commitments.next().unwrap();
@@ -234,6 +237,10 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 None
             };
 
+            // Challenge binding: compute eval of challenge positions in w2 and
+            // send as transcript-bound message so the verifier can check that
+            // the committed w2 polynomial contains the correct Fiat-Shamir
+            // challenges.
             let challenge_eval = if !self.challenge_offsets.is_empty() {
                 let ce = compute_challenge_eval(x, &self.challenge_offsets, &c2.polynomial);
                 merlin.prover_message(&ce);
@@ -242,9 +249,13 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 None
             };
 
-            // One FS challenge is reused for both commitments — it is sampled
-            // after every prover message above is bound, so c1 and c2 cannot
-            // be adversarially aligned against each other.
+            // One `inner_rlc` is reused across c1 and c2: it is sampled only
+            // after every alpha eval (plus optional public/challenge evals)
+            // for both halves is absorbed, so the prover cannot adversarially
+            // align one half against the other. Sharing the challenge does
+            // not degrade soundness: by Schwartz-Zippel on the degree-2
+            // collapse, each individual false claim still folds to a true
+            // combined claim with probability at most 2/|F|.
             let powers = rlc_powers::<3>(merlin.verifier_message());
             let combined_eval_1 = dot(&powers, &evals_1);
             let combined_eval_2 = dot(&powers, &evals_2);

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -4,9 +4,9 @@ use {
     ark_std::{One, Zero},
     provekit_common::{
         prefix_covector::{
-            build_prefix_covectors, compute_alpha_evals, compute_challenge_eval,
+            build_combined_prefix_covector, compute_alpha_evals, compute_challenge_eval,
             compute_public_eval, expand_powers, make_challenge_weight, make_public_weight,
-            OffsetCovector,
+            rlc_powers, OffsetCovector,
         },
         utils::{
             pad_to_power_of_two,
@@ -17,8 +17,7 @@ use {
             },
             HALF,
         },
-        FieldElement, PrefixCovector, PublicInputs, TranscriptSponge, WhirR1CSProof,
-        WhirR1CSScheme, R1CS,
+        FieldElement, PublicInputs, TranscriptSponge, WhirR1CSProof, WhirR1CSScheme, R1CS,
     },
     std::borrow::Cow,
     tracing::instrument,
@@ -152,42 +151,48 @@ impl WhirR1CSProver for WhirR1CSScheme {
         drop(full_witness);
 
         let alphas = calculate_external_row_of_r1cs_matrices(&alpha, &r1cs);
-        let (x, public_weight) = get_public_weights(public_inputs, &mut merlin, self.m);
+        let x = read_public_inputs_challenge(public_inputs, &mut merlin);
 
         let blinding_offset = blinding.offset;
         let blinding_weights = expand_powers::<4>(&alpha);
         let domain_size = 1usize << self.m;
 
         if is_single {
-            // Single commitment path
             let commitment = commitments.into_iter().next().unwrap();
-            let (mut weights, evals) =
-                create_weights_and_evaluations::<3>(self.m, &commitment.polynomial, alphas);
 
+            let evals = compute_alpha_evals(&commitment.polynomial, &alphas);
             for eval in &evals {
                 merlin.prover_message(eval);
             }
 
-            if !public_inputs.is_empty() {
-                let public_eval = compute_public_weight_evaluation(
-                    &mut weights,
-                    &commitment.polynomial,
-                    public_weight,
-                );
-                merlin.prover_message(&public_eval);
-            }
+            let public_eval = if !public_inputs.is_empty() {
+                let pe = compute_public_eval(x, public_inputs.len(), &commitment.polynomial);
+                merlin.prover_message(&pe);
+                Some(pe)
+            } else {
+                None
+            };
 
-            let mut evaluations = compute_evaluations(&weights, &commitment.polynomial);
-            evaluations.push(blinding_eval);
+            // `inner_rlc` is sampled only after every alpha eval (and the
+            // optional public eval) is absorbed: standard Schwartz-Zippel on
+            // the (A, B, C) -> A + r·B + r²·C collapse then gives soundness
+            // ≤ 2/|F| per commitment.
+            let powers = rlc_powers::<3>(merlin.verifier_message());
+            let combined_eval = dot(&powers, &evals);
+            let combined_lf = build_combined_prefix_covector(alphas, &powers, domain_size);
 
             let blinding_covector =
                 OffsetCovector::new(blinding_weights, blinding_offset, domain_size);
-
-            let mut boxed_weights: Vec<Box<dyn LinearForm<FieldElement>>> = weights
-                .into_iter()
-                .map(|w| Box::new(w) as Box<dyn LinearForm<FieldElement>>)
-                .collect();
+            let mut boxed_weights: Vec<Box<dyn LinearForm<FieldElement>>> = Vec::new();
+            let mut evaluations: Vec<FieldElement> = Vec::new();
+            if let Some(pe) = public_eval {
+                boxed_weights.push(Box::new(make_public_weight(x, public_inputs.len(), self.m)));
+                evaluations.push(pe);
+            }
+            boxed_weights.push(Box::new(combined_lf));
+            evaluations.push(combined_eval);
             boxed_weights.push(Box::new(blinding_covector));
+            evaluations.push(blinding_eval);
 
             let _ = self.whir_witness.prove(
                 &mut merlin,
@@ -197,7 +202,6 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 Cow::Borrowed(&evaluations),
             );
         } else {
-            // Dual commitment path
             let mut commitments = commitments.into_iter();
             let c1 = commitments.next().unwrap();
             let c2 = commitments.next().unwrap();
@@ -230,10 +234,6 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 None
             };
 
-            // Challenge binding: compute eval of challenge positions in w2 and
-            // send as transcript-bound message so the verifier can check that
-            // the committed w2 polynomial contains the correct Fiat-Shamir
-            // challenges.
             let challenge_eval = if !self.challenge_offsets.is_empty() {
                 let ce = compute_challenge_eval(x, &self.challenge_offsets, &c2.polynomial);
                 merlin.prover_message(&ce);
@@ -242,29 +242,35 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 None
             };
 
+            // One FS challenge is reused for both commitments — it is sampled
+            // after every prover message above is bound, so c1 and c2 cannot
+            // be adversarially aligned against each other.
+            let powers = rlc_powers::<3>(merlin.verifier_message());
+            let combined_eval_1 = dot(&powers, &evals_1);
+            let combined_eval_2 = dot(&powers, &evals_2);
+            let combined_lf_1 = build_combined_prefix_covector(alphas_1, &powers, domain_size);
+            let combined_lf_2 = build_combined_prefix_covector(alphas_2, &powers, domain_size);
+
             let WhirR1CSCommitment {
                 witness: w1,
                 polynomial: p1,
                 ..
             } = c1;
             {
-                let mut weights = build_prefix_covectors(self.m, alphas_1);
+                let mut boxed_weights: Vec<Box<dyn LinearForm<FieldElement>>> = Vec::new();
                 let mut evaluations: Vec<FieldElement> = Vec::new();
                 if let Some(pe) = public_1 {
-                    weights.insert(0, make_public_weight(x, public_inputs.len(), self.m));
+                    boxed_weights
+                        .push(Box::new(make_public_weight(x, public_inputs.len(), self.m)));
                     evaluations.push(pe);
                 }
-                evaluations.extend_from_slice(&evals_1);
-                evaluations.push(blinding_eval);
+                boxed_weights.push(Box::new(combined_lf_1));
+                evaluations.push(combined_eval_1);
 
                 let blinding_covector =
                     OffsetCovector::new(blinding_weights, blinding_offset, domain_size);
-
-                let mut boxed_weights: Vec<Box<dyn LinearForm<FieldElement>>> = weights
-                    .into_iter()
-                    .map(|w| Box::new(w) as Box<dyn LinearForm<FieldElement>>)
-                    .collect();
                 boxed_weights.push(Box::new(blinding_covector));
+                evaluations.push(blinding_eval);
 
                 let _ = self.whir_witness.prove(
                     &mut merlin,
@@ -282,13 +288,9 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 ..
             } = c2;
             {
-                let weights = build_prefix_covectors(self.m, alphas_2);
-                let mut evaluations: Vec<FieldElement> = evals_2;
-
-                let mut boxed_weights: Vec<Box<dyn LinearForm<FieldElement>>> = weights
-                    .into_iter()
-                    .map(|w| Box::new(w) as Box<dyn LinearForm<FieldElement>>)
-                    .collect();
+                let mut boxed_weights: Vec<Box<dyn LinearForm<FieldElement>>> =
+                    vec![Box::new(combined_lf_2)];
+                let mut evaluations: Vec<FieldElement> = vec![combined_eval_2];
 
                 if let Some(ce) = challenge_eval {
                     let challenge_weight =
@@ -515,57 +517,12 @@ pub fn run_zk_sumcheck_prover(
     (alpha, blinding_eval)
 }
 
-fn create_weights_and_evaluations<const N: usize>(
-    m: usize,
-    polynomial: &[FieldElement],
-    alphas: [Vec<FieldElement>; N],
-) -> (Vec<PrefixCovector>, Vec<FieldElement>) {
-    let domain_size = 1usize << m;
-
-    let mut weights = Vec::with_capacity(N);
-    let mut evals = Vec::with_capacity(N);
-
-    for mut w in alphas {
-        let base_len = w.len().next_power_of_two().max(2);
-        w.resize(base_len, FieldElement::zero());
-
-        evals.push(dot(&w, &polynomial[..base_len]));
-        weights.push(PrefixCovector::new(w, domain_size));
-    }
-
-    (weights, evals)
-}
-
-fn compute_evaluations(
-    weights: &[PrefixCovector],
-    polynomial: &[FieldElement],
-) -> Vec<FieldElement> {
-    weights
-        .iter()
-        .map(|w| dot(w.vector(), &polynomial[..w.vector().len()]))
-        .collect()
-}
-
-fn compute_public_weight_evaluation(
-    weights: &mut Vec<PrefixCovector>,
-    polynomial: &[FieldElement],
-    public_weights: PrefixCovector,
-) -> FieldElement {
-    let n = public_weights.vector().len();
-    let eval = dot(public_weights.vector(), &polynomial[..n]);
-    weights.insert(0, public_weights);
-    eval
-}
-
-fn get_public_weights(
+/// Bind the public-inputs hash to the transcript and sample the FS challenge
+/// `x` used by both the public-input weight and the challenge-binding weight.
+fn read_public_inputs_challenge(
     public_inputs: &PublicInputs,
     merlin: &mut ProverState<TranscriptSponge>,
-    m: usize,
-) -> (FieldElement, PrefixCovector) {
-    let public_inputs_hash = public_inputs.hash();
-    merlin.prover_message(&public_inputs_hash);
-
-    let x: FieldElement = merlin.verifier_message();
-
-    (x, make_public_weight(x, public_inputs.len(), m))
+) -> FieldElement {
+    merlin.prover_message(&public_inputs.hash());
+    merlin.verifier_message()
 }

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -271,8 +271,11 @@ impl WhirR1CSProver for WhirR1CSScheme {
                 let mut boxed_weights: Vec<Box<dyn LinearForm<FieldElement>>> = Vec::new();
                 let mut evaluations: Vec<FieldElement> = Vec::new();
                 if let Some(pe) = public_1 {
-                    boxed_weights
-                        .push(Box::new(make_public_weight(x, public_inputs.len(), self.m)));
+                    boxed_weights.push(Box::new(make_public_weight(
+                        x,
+                        public_inputs.len(),
+                        self.m,
+                    )));
                     evaluations.push(pe);
                 }
                 boxed_weights.push(Box::new(combined_lf_1));

--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -3,8 +3,8 @@ use {
     ark_std::{One, Zero},
     provekit_common::{
         prefix_covector::{
-            build_prefix_covectors, expand_powers, make_challenge_weight, make_public_weight,
-            OffsetCovector,
+            build_combined_prefix_covector, expand_powers, make_challenge_weight,
+            make_public_weight, rlc_powers, OffsetCovector,
         },
         utils::sumcheck::{
             calculate_eq, eval_cubic_poly, multiply_transposed_by_eq_alpha, transpose_r1cs_matrices,
@@ -13,7 +13,7 @@ use {
     },
     tracing::instrument,
     whir::{
-        algebra::linear_form::LinearForm,
+        algebra::{dot, linear_form::LinearForm},
         transcript::{Proof, VerifierMessage, VerifierState},
     },
 };
@@ -142,52 +142,65 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
                     .map_err(|_| anyhow::anyhow!("Failed to read evals_2[2]"))?,
             ];
 
-            let mut weights_1 = build_prefix_covectors(self.m, alphas_1);
-            let weights_2 = build_prefix_covectors(self.m, alphas_2);
-
-            let mut evaluations_1 = if !public_inputs.is_empty() {
+            // Mirror prover: read optional public/challenge evals first so the
+            // FS state matches at the inner_rlc sample below.
+            let public_1_eval = if !public_inputs.is_empty() {
                 let public_1: FieldElement = arthur
                     .prover_message()
                     .map_err(|_| anyhow::anyhow!("Failed to read public_1"))?;
                 verify_public_input_binding(public_1, x, public_inputs)?;
-                weights_1.insert(0, make_public_weight(x, public_inputs.len(), self.m));
-                vec![public_1, evals_1[0], evals_1[1], evals_1[2]]
-            } else {
-                evals_1.to_vec()
-            };
-            evaluations_1.push(blinding_eval);
-            let mut evaluations_2 = evals_2.to_vec();
-
-            // Challenge binding: read the prover's claimed evaluation and verify
-            // that it matches the expected inner product of challenges with the
-            // committed w2 polynomial.
-            let challenge_weight = if !self.challenge_offsets.is_empty() {
-                let challenge_eval: FieldElement = arthur
-                    .prover_message()
-                    .map_err(|_| anyhow::anyhow!("Failed to read challenge eval"))?;
-                verify_challenge_binding(challenge_eval, x, &logup_challenges)?;
-                evaluations_2.push(challenge_eval);
-                Some(make_challenge_weight(x, &self.challenge_offsets, self.m))
+                Some(public_1)
             } else {
                 None
             };
 
-            let mut weight_refs_1: Vec<&dyn LinearForm<FieldElement>> = weights_1
-                .iter()
-                .map(|w| w as &dyn LinearForm<FieldElement>)
-                .collect();
+            // Challenge binding: read the prover's claimed evaluation and verify
+            // that it matches the expected inner product of challenges with the
+            // committed w2 polynomial.
+            let challenge_binding = if !self.challenge_offsets.is_empty() {
+                let challenge_eval: FieldElement = arthur
+                    .prover_message()
+                    .map_err(|_| anyhow::anyhow!("Failed to read challenge eval"))?;
+                verify_challenge_binding(challenge_eval, x, &logup_challenges)?;
+                Some(challenge_eval)
+            } else {
+                None
+            };
+
+            // Mirror prover's direct-RLC sample. One challenge collapses each
+            // commitment's (A, B, C) triple into a single linear form.
+            let powers = rlc_powers::<3>(arthur.verifier_message());
+            let combined_eval_1 = dot(&powers, &evals_1);
+            let combined_eval_2 = dot(&powers, &evals_2);
+            let combined_lf_1 = build_combined_prefix_covector(alphas_1, &powers, domain_size);
+            let combined_lf_2 = build_combined_prefix_covector(alphas_2, &powers, domain_size);
+
+            let public_weight_1 = public_1_eval
+                .map(|_| make_public_weight(x, public_inputs.len(), self.m));
+            let challenge_weight = challenge_binding
+                .map(|_| make_challenge_weight(x, &self.challenge_offsets, self.m));
+
+            let mut weight_refs_1: Vec<&dyn LinearForm<FieldElement>> = Vec::new();
+            let mut evaluations_1: Vec<FieldElement> = Vec::new();
+            if let (Some(ref pw), Some(pe)) = (&public_weight_1, public_1_eval) {
+                weight_refs_1.push(pw as &dyn LinearForm<FieldElement>);
+                evaluations_1.push(pe);
+            }
+            weight_refs_1.push(&combined_lf_1 as &dyn LinearForm<FieldElement>);
+            evaluations_1.push(combined_eval_1);
             weight_refs_1.push(&blinding_covector as &dyn LinearForm<FieldElement>);
+            evaluations_1.push(blinding_eval);
 
             self.whir_witness
                 .verify(&mut arthur, &weight_refs_1, &evaluations_1, &commitment_1)
                 .map_err(|_| anyhow::anyhow!("WHIR verification failed for c1"))?;
 
-            let mut weight_refs_2: Vec<&dyn LinearForm<FieldElement>> = weights_2
-                .iter()
-                .map(|w| w as &dyn LinearForm<FieldElement>)
-                .collect();
-            if let Some(ref cw) = challenge_weight {
+            let mut weight_refs_2: Vec<&dyn LinearForm<FieldElement>> =
+                vec![&combined_lf_2 as &dyn LinearForm<FieldElement>];
+            let mut evaluations_2: Vec<FieldElement> = vec![combined_eval_2];
+            if let (Some(ref cw), Some(ce)) = (&challenge_weight, challenge_binding) {
                 weight_refs_2.push(cw as &dyn LinearForm<FieldElement>);
+                evaluations_2.push(ce);
             }
             self.whir_witness
                 .verify(&mut arthur, &weight_refs_2, &evaluations_2, &commitment_2)
@@ -211,25 +224,34 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
                     .map_err(|_| anyhow::anyhow!("Failed to read evals[2]"))?,
             ];
 
-            let mut weights = build_prefix_covectors(self.m, alphas);
-
-            let mut evaluations = if !public_inputs.is_empty() {
-                let public_eval: FieldElement = arthur
+            // Mirror prover: read public eval (if any), then sample inner_rlc
+            // and collapse the three R1CS row-covectors into one.
+            let public_eval = if !public_inputs.is_empty() {
+                let pe: FieldElement = arthur
                     .prover_message()
                     .map_err(|_| anyhow::anyhow!("Failed to read public eval"))?;
-                verify_public_input_binding(public_eval, x, public_inputs)?;
-                weights.insert(0, make_public_weight(x, public_inputs.len(), self.m));
-                vec![public_eval, evals[0], evals[1], evals[2]]
+                verify_public_input_binding(pe, x, public_inputs)?;
+                Some(pe)
             } else {
-                evals.to_vec()
+                None
             };
-            evaluations.push(blinding_eval);
 
-            let mut weight_refs: Vec<&dyn LinearForm<FieldElement>> = weights
-                .iter()
-                .map(|w| w as &dyn LinearForm<FieldElement>)
-                .collect();
+            let powers = rlc_powers::<3>(arthur.verifier_message());
+            let combined_eval = dot(&powers, &evals);
+            let combined_lf = build_combined_prefix_covector(alphas, &powers, domain_size);
+            let public_weight =
+                public_eval.map(|_| make_public_weight(x, public_inputs.len(), self.m));
+
+            let mut weight_refs: Vec<&dyn LinearForm<FieldElement>> = Vec::new();
+            let mut evaluations: Vec<FieldElement> = Vec::new();
+            if let (Some(ref pw), Some(pe)) = (&public_weight, public_eval) {
+                weight_refs.push(pw as &dyn LinearForm<FieldElement>);
+                evaluations.push(pe);
+            }
+            weight_refs.push(&combined_lf as &dyn LinearForm<FieldElement>);
+            evaluations.push(combined_eval);
             weight_refs.push(&blinding_covector as &dyn LinearForm<FieldElement>);
+            evaluations.push(blinding_eval);
 
             self.whir_witness
                 .verify(&mut arthur, &weight_refs, &evaluations, &commitment_1)

--- a/provekit/verifier/src/whir_r1cs.rs
+++ b/provekit/verifier/src/whir_r1cs.rs
@@ -175,14 +175,14 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
             let combined_lf_1 = build_combined_prefix_covector(alphas_1, &powers, domain_size);
             let combined_lf_2 = build_combined_prefix_covector(alphas_2, &powers, domain_size);
 
-            let public_weight_1 = public_1_eval
-                .map(|_| make_public_weight(x, public_inputs.len(), self.m));
-            let challenge_weight = challenge_binding
-                .map(|_| make_challenge_weight(x, &self.challenge_offsets, self.m));
+            let public_weight_1 = (!public_inputs.is_empty())
+                .then(|| make_public_weight(x, public_inputs.len(), self.m));
+            let challenge_weight = (!self.challenge_offsets.is_empty())
+                .then(|| make_challenge_weight(x, &self.challenge_offsets, self.m));
 
             let mut weight_refs_1: Vec<&dyn LinearForm<FieldElement>> = Vec::new();
             let mut evaluations_1: Vec<FieldElement> = Vec::new();
-            if let (Some(ref pw), Some(pe)) = (&public_weight_1, public_1_eval) {
+            if let (Some(pw), Some(pe)) = (public_weight_1.as_ref(), public_1_eval) {
                 weight_refs_1.push(pw as &dyn LinearForm<FieldElement>);
                 evaluations_1.push(pe);
             }
@@ -198,7 +198,7 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
             let mut weight_refs_2: Vec<&dyn LinearForm<FieldElement>> =
                 vec![&combined_lf_2 as &dyn LinearForm<FieldElement>];
             let mut evaluations_2: Vec<FieldElement> = vec![combined_eval_2];
-            if let (Some(ref cw), Some(ce)) = (&challenge_weight, challenge_binding) {
+            if let (Some(cw), Some(ce)) = (challenge_weight.as_ref(), challenge_binding) {
                 weight_refs_2.push(cw as &dyn LinearForm<FieldElement>);
                 evaluations_2.push(ce);
             }
@@ -239,12 +239,12 @@ impl WhirR1CSVerifier for WhirR1CSScheme {
             let powers = rlc_powers::<3>(arthur.verifier_message());
             let combined_eval = dot(&powers, &evals);
             let combined_lf = build_combined_prefix_covector(alphas, &powers, domain_size);
-            let public_weight =
-                public_eval.map(|_| make_public_weight(x, public_inputs.len(), self.m));
+            let public_weight = (!public_inputs.is_empty())
+                .then(|| make_public_weight(x, public_inputs.len(), self.m));
 
             let mut weight_refs: Vec<&dyn LinearForm<FieldElement>> = Vec::new();
             let mut evaluations: Vec<FieldElement> = Vec::new();
-            if let (Some(ref pw), Some(pe)) = (&public_weight, public_eval) {
+            if let (Some(pw), Some(pe)) = (public_weight.as_ref(), public_eval) {
                 weight_refs.push(pw as &dyn LinearForm<FieldElement>);
                 evaluations.push(pe);
             }


### PR DESCRIPTION
## Summary

R1CS row-covectors a, b, c (~32 MB each at m=20) were each wrapped in their own `PrefixCovector` and passed to `whir.prove` as three separate linear forms. WHIR's `prepare_and_sumcheck` then sampled one FS challenge and folded them into a single covector internally. The three intermediate dense vectors stayed resident across the setup until WHIR consumed them, even though only the combined linear form had any
downstream use.

This PR moves the row-RLC into provekit: sample `inner_rlc` from the prover transcript right after the three matrix evaluations are sent, fold a, b, c into a single `PrefixCovector` via the new `build_combined_prefix_covector` helper, and pass one LF to `whir.prove` instead of three. Verifier mirrors at the same transcript position; soundness follows from `inner_rlc` being bound to all three evals before being drawn.

Same direct-RLC applies to the dual-commit path with one shared `inner_rlc` across both commitments.

WHIR itself is unchanged — the LF count it receives just shrinks from three to one. `geometric_challenge(1)` short-circuits to `[ONE]` with no extra FS sample, so the only transcript-level change is the new `inner_rlc` sample on the provekit side.

## Measured impact

Single run, `complete_age_check`. Baseline used was v1 + the `perf(prover): drop R1CS after sumcheck …` commit (raised separately). Numbers are for the eventual merged state of both PRs.

| Metric | baseline | this PR | Δ |
|---|---:|---:|---:|
| Run peak memory | 816 MB | 766 MB | **−50 MB / −6.1%** |
| `prove_with_toml` duration | 1.96 s | 1.93 s | within noise |
| Allocations | 3.56M | 3.56M | 0 |

Removes three now-dead helpers from `prover/src/whir_r1cs.rs` (`create_weights_and_evaluations`, `compute_evaluations`, `compute_public_weight_evaluation`), and refactors the public-inputs-hash absorption into `read_public_inputs_challenge` so the public-weight covector is built lazily only when needed.

## Test plan

- [x] `cargo test -p provekit-bench --test compiler --release` — 16 passed (incl. `complete_age_check`, `test_public_input_binding_exploit`)
- [x] `provekit-cli prove` → `provekit-cli verify` round-trip on complete_age_check
- [x] Dual-commit circuits (`small-sha`, `read_write_memory`, etc.) round-trip
- [ ] Bench additional circuits (`t_add_dsc_1850`, `t_add_id_data_1850`) to confirm percentage scales

## Rollback

Revert the single commit. The protocol modification is local: one
extra `verifier_message()` sample in provekit's prover/verifier, no
WHIR-side changes.