### PR TITLE
feat(groth16): on-chain Groth16+BSB22 verifier

### DIFF
--- a/provekit/groth16/contracts/ProvekitGroth16Verifier.sol
+++ b/provekit/groth16/contracts/ProvekitGroth16Verifier.sol
@@ -1,0 +1,652 @@
+// SPDX-License-Identifier: MIT
+//
+// Provekit Groth16 + BSB22 on-chain verifier.
+//
+// STATUS: FIRST CUT — NOT AUDITED. DO NOT DEPLOY TO MAINNET.
+//
+// Verifies proofs produced by `provekit/groth16/` (the Rust Groth16+BSB22
+// prover in this repository). The on-chain check mirrors
+// `provekit_groth16::verifier::verify` — which is the authoritative spec.
+//
+// Four protocol-specific choices worth flagging up front:
+//
+//   1. BSB22 challenge hash. Challenges are derived with Keccak-256 to
+//      match the EVM-native `KECCAK256` opcode (gas-cheap). Two shapes:
+//        * single-challenge:  challenge = keccak256(dst || msg) mod R
+//        * multi-challenge:   root      = keccak256(dst || msg)
+//                             out[i]    = keccak256(root || I2OSP(i, 1)) mod R
+//      See `_hashToFr` / `_hashToFrMulti`. The Rust counterparts
+//      (`hash_to_fr`, `hash_to_fr_multi`) produce identical bytes.
+//
+//   2. Hash-input byte order. The Rust prover serialises G1 coordinates
+//      and Fr values with arkworks `serialize_uncompressed` /
+//      `serialize_compressed`, which is little-endian. EVM-native encoding
+//      is big-endian, so the contract byte-reverses each 32-byte word
+//      before feeding it into the challenge hash. See `_reverseBytes32`.
+//
+//   3. Proof byte layout uses EIP-197 ordering for G2 (X.c1, X.c0, Y.c1,
+//      Y.c0), big-endian. The off-chain marshaller `provekit-cli
+//      export-evm-proof` (see `tooling/cli/src/cmd/export_evm_proof.rs`)
+//      emits proofs in exactly that layout — re-serialise from arkworks
+//      before feeding the bytes into `verifyProof`.
+//
+//   4. RLC batching ("poor man's SNARKpack",
+//      https://xn--2-umb.com/23/groth16-batch/). The Groth16 pairing
+//      equation (4 pairings) and the Pedersen commitment equation (2
+//      pairings) are folded into ONE pairing precompile call of 6 pairs
+//      via a Fiat-Shamir scalar `r`:
+//        e(Ar, Bs)·e(Krs, -δ)·e(α, -β)·e(k_sum, -γ)
+//                 · e(r·C, -σG) · e(r·PoK, G)  ==  1
+//      Soundness: by bilinearity `e(P,Q)^r = e(r·P, Q)`, so the combined
+//      identity equals `P_groth16 · P_pedersen^r`; if either factor were
+//      ≠ 1, the product equals 1 for at most one `r ∈ F_R`. The prover
+//      cannot adaptively choose `r` because it is bound to all proof
+//      bytes and public inputs via keccak256 (see `_deriveRlcChallenge`).
+//      Saves one precompile invocation (≈45k gas of base cost) plus
+//      avoids re-pairing intermediate field elements.
+//
+// Template shape (v1):
+//   - exactly ONE Pedersen commitment over private wires
+//   - one or more derived challenges per commitment (N_CHALLENGE)
+//   - uncompressed proof points (no on-chain decompression)
+//
+// Multi-commitment and compressed-proof variants are out of scope here;
+// see the EXTENSIONS footer for the migration map.
+//
+// All `// CODEGEN:` markers are placeholders substituted by the codegen
+// tool `provekit-cli export-solidity` (see
+// `tooling/cli/src/cmd/export_solidity.rs`), which reads a `.pkv`,
+// precomputes the negated VK points (-β, -γ, -δ, -σ·G), and rewrites this
+// template into a circuit-specific contract.
+
+pragma solidity ^0.8.20;
+
+contract ProvekitGroth16Verifier {
+    // ------------------------------------------------------------------
+    // Field constants (BN254).
+    // ------------------------------------------------------------------
+
+    /// (P - 1) / 2 where P is the BN254 base field prime. Threshold for
+    /// arkworks' SWFlags::YIsNegative flag: y > P_HALF means the serialized
+    /// affine point gets 0x80 OR'd into the high byte of Y.
+    uint256 internal constant P_HALF =
+        0x183227397098d014dc2822db40c0ac2ecbc0b548b438e5469e10460b6c3e7ea3;
+
+    /// Scalar field prime R (BN254).
+    uint256 internal constant R =
+        0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+
+    // ------------------------------------------------------------------
+    // Precompile addresses.
+    // ------------------------------------------------------------------
+
+    uint256 internal constant PRECOMPILE_ECADD   = 0x06;
+    uint256 internal constant PRECOMPILE_ECMUL   = 0x07;
+    uint256 internal constant PRECOMPILE_PAIRING = 0x08;
+
+    // ------------------------------------------------------------------
+    // Circuit parameters.
+    // ------------------------------------------------------------------
+
+    /// Number of EXPLICIT public inputs the circuit takes (not counting
+    /// the ONE_WIRE or BSB22 derived challenges).
+    /// CODEGEN: substitute from VerifyingKey.
+    uint256 internal constant N_PUB = 1;
+
+    /// Number of BSB22 Pedersen commitments in the proof.
+    /// CODEGEN: substitute from VerifyingKey. v1 template assumes 1.
+    uint256 internal constant N_COMMIT = 1;
+
+    /// Number of derived challenges per commitment. v1 template assumes 1.
+    /// CODEGEN: substitute from `num_challenges_per_commitment[0]`.
+    uint256 internal constant N_CHALLENGE = 1;
+
+    /// Length of `extended_public` = N_PUB + N_COMMIT * N_CHALLENGE. Equal to
+    /// `vk.g1_k.len() - 1` (the `-1` strips the constant-1 ONE_WIRE entry).
+    /// Required by the codegen tool; not referenced from contract code.
+    /// CODEGEN: substitute from VerifyingKey.
+    uint256 internal constant N_PUB_EXTENDED = 2;
+
+    /// Number of `input[]` entries that are hashed into the BSB22 commitment
+    /// challenge. Matches `len(vk.public_and_commitment_committed[0])`.
+    ///
+    /// CODEGEN: substitute per circuit. The committed list is a subset of
+    /// `input[]`; the indices used live in `_deriveCommitmentChallenge` and
+    /// must be regenerated together with this constant.
+    /// Default template assumes ALL N_PUB inputs are committed.
+    uint256 internal constant N_COMMITTED = 1; // CODEGEN: must equal N_PUB if all inputs are committed
+
+    // ------------------------------------------------------------------
+    // BSB22 domain separation tags (from `provekit_groth16::lib.rs`).
+    // ------------------------------------------------------------------
+
+    /// DST for per-commitment BSB22 challenges. ASCII bytes "bsb22-commitment".
+    bytes internal constant DST_COMMITMENT = "bsb22-commitment";
+
+    /// DST for the RLC scalar that batches the Groth16 + Pedersen pairing
+    /// checks into a single precompile call. Must NOT collide with any
+    /// other Fiat-Shamir DST used in the prover/verifier (in particular
+    /// DST_COMMITMENT and the future "G16-BSB22" multi-commitment DST).
+    bytes internal constant DST_RLC = "groth16-pedersen-rlc";
+
+    // EXTEND: multi-commitment folding uses DST "G16-BSB22" — add when
+    // implementing the multi-commitment path.
+
+    // ------------------------------------------------------------------
+    // Verifying key constants. CODEGEN: substitute all of these per
+    // circuit. The values below are placeholders.
+    //
+    // β, γ, δ are stored pre-negated so the pairing equation can be written
+    // directly as e(α, -β) · e(k_sum, -γ) · e(Krs, -δ) · e(Ar, Bs) == 1.
+    // The Rust verifier does the same precomputation at deserialisation
+    // (see `VerifyingKey::precompute` in `provekit/groth16/src/types.rs`);
+    // the codegen tool runs it once and bakes the negated coordinates in.
+    // ------------------------------------------------------------------
+
+    // Groth16 alpha (G1, positive).
+    uint256 internal constant ALPHA_X = 0; // CODEGEN
+    uint256 internal constant ALPHA_Y = 0; // CODEGEN
+
+    // Groth16 beta (G2, NEGATED so we can write e(α, -β) directly).
+    uint256 internal constant BETA_NEG_X_0 = 0; // CODEGEN
+    uint256 internal constant BETA_NEG_X_1 = 0; // CODEGEN
+    uint256 internal constant BETA_NEG_Y_0 = 0; // CODEGEN
+    uint256 internal constant BETA_NEG_Y_1 = 0; // CODEGEN
+
+    // Groth16 gamma (G2, NEGATED).
+    uint256 internal constant GAMMA_NEG_X_0 = 0; // CODEGEN
+    uint256 internal constant GAMMA_NEG_X_1 = 0; // CODEGEN
+    uint256 internal constant GAMMA_NEG_Y_0 = 0; // CODEGEN
+    uint256 internal constant GAMMA_NEG_Y_1 = 0; // CODEGEN
+
+    // Groth16 delta (G2, NEGATED).
+    uint256 internal constant DELTA_NEG_X_0 = 0; // CODEGEN
+    uint256 internal constant DELTA_NEG_X_1 = 0; // CODEGEN
+    uint256 internal constant DELTA_NEG_Y_0 = 0; // CODEGEN
+    uint256 internal constant DELTA_NEG_Y_1 = 0; // CODEGEN
+
+    // K[0] (constant term of the public-input MSM).
+    uint256 internal constant K0_X = 0; // CODEGEN
+    uint256 internal constant K0_Y = 0; // CODEGEN
+
+    // K[1..1+N_PUB_EXTENDED] — one G1 point per extended public input.
+    // CODEGEN: emit N_PUB_EXTENDED entries (PUB_0_X, PUB_0_Y, ..., PUB_{N-1}_*).
+    //<BEGIN_CODEGEN:PUB_BASES>
+    uint256 internal constant PUB_0_X = 0; // CODEGEN: K[1]
+    uint256 internal constant PUB_0_Y = 0; // CODEGEN: K[1]
+    uint256 internal constant PUB_1_X = 0; // CODEGEN: K[2]
+    uint256 internal constant PUB_1_Y = 0; // CODEGEN: K[2]
+    //<END_CODEGEN:PUB_BASES>
+
+    // Pedersen verifying key (single-commitment template).
+    // G is in G2; GSigmaNeg = -σ·G also in G2.
+    uint256 internal constant PEDERSEN_G_X_0          = 0; // CODEGEN
+    uint256 internal constant PEDERSEN_G_X_1          = 0; // CODEGEN
+    uint256 internal constant PEDERSEN_G_Y_0          = 0; // CODEGEN
+    uint256 internal constant PEDERSEN_G_Y_1          = 0; // CODEGEN
+    uint256 internal constant PEDERSEN_GSIGMA_NEG_X_0 = 0; // CODEGEN
+    uint256 internal constant PEDERSEN_GSIGMA_NEG_X_1 = 0; // CODEGEN
+    uint256 internal constant PEDERSEN_GSIGMA_NEG_Y_0 = 0; // CODEGEN
+    uint256 internal constant PEDERSEN_GSIGMA_NEG_Y_1 = 0; // CODEGEN
+
+    // ------------------------------------------------------------------
+    // Errors.
+    // ------------------------------------------------------------------
+
+    error ProofInvalid();
+    error ProofLengthInvalid();
+    error PublicInputNotInField();
+    error ProofPointAtInfinity();
+
+    // ==================================================================
+    //                   Public entry point
+    // ==================================================================
+
+    /// Verify a Groth16+BSB22 proof.
+    ///
+    /// `proof` byte layout (all coordinates big-endian, all G2 components
+    /// in EIP-197 order — produced by `provekit-cli export-evm-proof`):
+    ///   bytes   0 ..  64 : Ar           (G1: X, Y)
+    ///   bytes  64 .. 192 : Bs           (G2: X.c1, X.c0, Y.c1, Y.c0)
+    ///   bytes 192 .. 256 : Krs          (G1: X, Y)
+    ///   bytes 256 .. 256 + 64·N_COMMIT       : Commitments (G1 each)
+    ///   bytes 256 + 64·N_COMMIT ..  +64      : CommitmentPok (G1)
+    /// Total length: 256 + 64·(N_COMMIT + 1).
+    ///
+    /// `input` carries only the EXPLICIT public inputs (N_PUB of them);
+    /// the BSB22 challenge wires are derived on chain in
+    /// `_deriveCommitmentChallenges`.
+    function verifyProof(
+        bytes calldata proof,
+        uint256[N_PUB] calldata input
+    ) external view {
+        // Expected length: 256 + 64·(N_COMMIT + 1).
+        if (proof.length != 256 + 64 * (N_COMMIT + 1)) revert ProofLengthInvalid();
+
+        // Field-range checks on input[] are folded into `_msmStep` (every
+        // public input flows through the MSM, where `s >= R` reverts with
+        // `PublicInputNotInField`). Derived challenges from `_hashToFr` /
+        // `_hashToFrMulti` are already reduced mod R by construction.
+
+        // Only materialise the coords used outside the final pairing call.
+        // Ar / Bs / Krs flow into the pairing buffer only, so we leave them
+        // in calldata and `calldatacopy` them straight into `pairings[0..8]`
+        // when the buffer is laid out below. Keeping them off the Solidity
+        // stack reduces simultaneous-locals pressure in this function from
+        // ~20 to ~12 — see the top-of-file note on stack budget.
+        uint256 cX;
+        uint256 cY;
+        uint256 pokX;
+        uint256 pokY;
+        assembly ("memory-safe") {
+            cX   := calldataload(add(proof.offset, 0x100))
+            cY   := calldataload(add(proof.offset, 0x120))
+            pokX := calldataload(add(proof.offset, 0x140))
+            pokY := calldataload(add(proof.offset, 0x160))
+        }
+
+        // Point-at-infinity rejection.
+        //
+        // EIP-196/197 precompiles accept (0,0) (resp. (0,0,0,0)) as the
+        // identity element. The Rust verifier (`Proof::is_valid` in
+        // `provekit/groth16/src/types.rs`) rejects zero proof points
+        // outright — accepting them widens the surface for malformed or
+        // malicious proofs (e.g. with Ar = ∞ the pairing equation collapses
+        // to one fewer factor). Mirror that here. Curve-membership of
+        // non-zero points is enforced by the ECMUL/ECADD/pairing
+        // precompiles downstream.
+        _rejectInfinityArBsKrs(proof);
+        if ((cX   | cY  ) == 0) revert ProofPointAtInfinity();
+        if ((pokX | pokY) == 0) revert ProofPointAtInfinity();
+
+        // RLC-batched pairing identity (see top-of-file note 4):
+        //   e(Ar, Bs) · e(Krs, -δ) · e(α, -β) · e(k_sum, -γ)
+        //            · e(r·C, -σG) · e(r·PoK, G) == 1
+        //
+        // `r` is derived AFTER all prover-controlled values have been
+        // observed (proof bytes + public inputs), so the prover cannot
+        // adaptively pick points that exploit the combination. Soundness:
+        // if either original check fails, the combined check passes for at
+        // most one `r ∈ F_R` (probability ≤ 1/R).
+        //
+        // The buffer is filled top-down (Ar/Bs/Krs from calldata, then VK
+        // constants, then k_sum, then the two RLC factors via ECMUL output
+        // written in-place — see the assembly block below). On failure of
+        // any sub-call, the AND-chained `success` collapses to 0 and we
+        // revert. After batching, the pairing precompile cannot distinguish
+        // which sub-check failed, so the collapsed error path is by design.
+        uint256[36] memory pairings;
+
+        // e(Ar, Bs) and Krs.G1: bytes 0..192 of `proof` already lay out
+        // exactly as the EIP-197 input expects (Ar.X, Ar.Y, Bs.X.c1,
+        // Bs.X.c0, Bs.Y.c1, Bs.Y.c0, Krs.X, Krs.Y — all big-endian) — so a
+        // single calldatacopy fills pairings[0..8] without naming any coord.
+        assembly ("memory-safe") {
+            calldatacopy(pairings,             proof.offset,             0xC0)
+            calldatacopy(add(pairings, 0xC0),  add(proof.offset, 0xC0),  0x40)
+        }
+
+        // e(Krs, -δ): G2 side from VK constants.
+        pairings[8]  = DELTA_NEG_X_1;
+        pairings[9]  = DELTA_NEG_X_0;
+        pairings[10] = DELTA_NEG_Y_1;
+        pairings[11] = DELTA_NEG_Y_0;
+
+        // e(α, -β)
+        pairings[12] = ALPHA_X;
+        pairings[13] = ALPHA_Y;
+        pairings[14] = BETA_NEG_X_1;
+        pairings[15] = BETA_NEG_X_0;
+        pairings[16] = BETA_NEG_Y_1;
+        pairings[17] = BETA_NEG_Y_0;
+
+        // e(kSum, -γ). BSB22 derivation + MSM live in their own scope so
+        // `challenges`, `kSumX`, `kSumY` drop off the stack before the RLC
+        // stage — frees slots for `r` and assembly temporaries.
+        //
+        // Which `input[]` entries feed `_deriveCommitmentChallenges` (and
+        // their order) is determined by
+        // `VerifyingKey.public_and_commitment_committed[0]`; see the
+        // CODEGEN block inside that helper. `_publicInputMSM` builds
+        // k_sum = K[0] + Σᵢ extended_public[i]·K[1+i] + Σⱼ commitments[j],
+        // mirroring `provekit_groth16::verifier::verify`.
+        {
+            uint256[N_CHALLENGE] memory challenges = _deriveCommitmentChallenges(cX, cY, input);
+            (uint256 kSumX, uint256 kSumY) = _publicInputMSM(input, challenges, cX, cY);
+            pairings[18] = kSumX;
+            pairings[19] = kSumY;
+        }
+        pairings[20] = GAMMA_NEG_X_1;
+        pairings[21] = GAMMA_NEG_X_0;
+        pairings[22] = GAMMA_NEG_Y_1;
+        pairings[23] = GAMMA_NEG_Y_0;
+
+        uint256 r = _deriveRlcChallenge(proof, input);
+        // Reject the degenerate r == 0 (would erase the Pedersen factor
+        // from the combined check). Probability of a hash output landing at
+        // 0 mod R is ~1/R and unreachable by a computationally bounded
+        // adversary; revert defensively rather than rebase.
+        if (r == 0) revert ProofInvalid();
+
+        // Fuse the two RLC ECMULs into the pairing buffer. For each factor
+        // we stage (px, py, r) in three consecutive slots, call ECMUL with
+        // output (0x40) overlapping the first two slots (px/py become rx/ry
+        // in place), then overwrite the trailing scalar slot plus the next
+        // three with the G2 coordinates. Avoids the per-ECMUL `uint256[3]`
+        // buffer and the rcX/rcY/rpokX/rpokY stack locals of the prior
+        // implementation.
+        bool success;
+        uint256 result;
+        assembly ("memory-safe") {
+            // e(r·C, -σG): pairings[24..30].
+            let p := add(pairings, 0x300)
+            mstore(p, cX)
+            mstore(add(p, 0x20), cY)
+            mstore(add(p, 0x40), r)
+            success := staticcall(gas(), PRECOMPILE_ECMUL, p, 0x60, p, 0x40)
+            mstore(add(p, 0x40), PEDERSEN_GSIGMA_NEG_X_1)
+            mstore(add(p, 0x60), PEDERSEN_GSIGMA_NEG_X_0)
+            mstore(add(p, 0x80), PEDERSEN_GSIGMA_NEG_Y_1)
+            mstore(add(p, 0xA0), PEDERSEN_GSIGMA_NEG_Y_0)
+
+            // e(r·PoK, G): pairings[30..36].
+            p := add(pairings, 0x3C0)
+            mstore(p, pokX)
+            mstore(add(p, 0x20), pokY)
+            mstore(add(p, 0x40), r)
+            success := and(success, staticcall(gas(), PRECOMPILE_ECMUL, p, 0x60, p, 0x40))
+            mstore(add(p, 0x40), PEDERSEN_G_X_1)
+            mstore(add(p, 0x60), PEDERSEN_G_X_0)
+            mstore(add(p, 0x80), PEDERSEN_G_Y_1)
+            mstore(add(p, 0xA0), PEDERSEN_G_Y_0)
+
+            // 36 words · 32 bytes = 0x480 input length, 32-byte bool output.
+            success := and(success, staticcall(gas(), PRECOMPILE_PAIRING, pairings, 0x480, pairings, 0x20))
+            result := mload(pairings)
+        }
+        if (!success || result != 1) revert ProofInvalid();
+    }
+
+    /// Reject (0,0) / (0,0,0,0) for Ar, Bs, Krs without lifting their
+    /// coordinates onto the Solidity stack. Each `or` collapses one point
+    /// to a single "is zero?" word; the three checks remain per-point (not
+    /// a single coarse OR across all 8 words) to preserve the original
+    /// semantics.
+    function _rejectInfinityArBsKrs(bytes calldata proof) internal pure {
+        uint256 arOr;
+        uint256 bsOr;
+        uint256 krsOr;
+        assembly ("memory-safe") {
+            arOr := or(
+                calldataload(proof.offset),
+                calldataload(add(proof.offset, 0x20))
+            )
+            bsOr := or(
+                or(
+                    calldataload(add(proof.offset, 0x40)),
+                    calldataload(add(proof.offset, 0x60))
+                ),
+                or(
+                    calldataload(add(proof.offset, 0x80)),
+                    calldataload(add(proof.offset, 0xA0))
+                )
+            )
+            krsOr := or(
+                calldataload(add(proof.offset, 0xC0)),
+                calldataload(add(proof.offset, 0xE0))
+            )
+        }
+        if (arOr == 0 || bsOr == 0 || krsOr == 0) revert ProofPointAtInfinity();
+    }
+
+    // ==================================================================
+    //               BSB22 challenge derivation
+    // ==================================================================
+
+    /// Compute the BSB22 challenge(s) for the single commitment.
+    ///
+    /// Hash input (arkworks little-endian throughout):
+    ///   serialize_g1(C) || serialize_fr(input[i0]) || ...
+    ///                  || serialize_fr(input[i_{N_COMMITTED-1}])
+    /// The indices (i0, i1, ...) come from
+    /// `vk.public_and_commitment_committed[0]` — a subset of `input[]`,
+    /// NOT necessarily the whole array — in the order recorded by the VK.
+    ///
+    /// Reduction:
+    ///   * N_CHALLENGE == 1:  challenge = keccak256("bsb22-commitment" || msg) mod R
+    ///                        (one round; matches Rust `hash_to_fr`)
+    ///   * N_CHALLENGE  > 1:  root      = keccak256("bsb22-commitment" || msg)
+    ///                        out[i]    = keccak256(root || I2OSP(i, 1)) mod R
+    ///                        (matches Rust `hash_to_fr_multi`)
+    ///
+    /// Authoritative spec: `derive_commitment_challenge`, `hash_to_fr`, and
+    /// `hash_to_fr_multi` in `provekit/groth16/src/prover.rs`, plus the
+    /// branch in `provekit::groth16::verifier::verify` that selects between
+    /// them based on `num_challenges_per_commitment[i]`.
+    function _deriveCommitmentChallenges(
+        uint256 cX,
+        uint256 cY,
+        uint256[N_PUB] calldata input
+    ) internal pure returns (uint256[N_CHALLENGE] memory) {
+        // Build the hash input in arkworks little-endian.
+        // Length: 64 (G1) + 32 · N_COMMITTED.
+        bytes memory msgBuf = new bytes(64 + 32 * N_COMMITTED);
+
+        // Commitment in arkworks LE.
+        //
+        // arkworks `serialize_uncompressed` for SW affine writes X with
+        // EmptyFlags and Y with SWFlags::from_y_sign(). For a valid
+        // (non-infinity) commitment that flag is YIsNegative (= 0x80) when
+        // y > (P-1)/2, OR'd into the highest byte of Y's little-endian
+        // encoding. Folding the flag into bit 255 of cY before the byte
+        // reverse places it exactly there (msgBuf[63]). Skipping this makes
+        // the on-chain hash diverge from the prover's hash whenever cY is
+        // in the upper half of the field — i.e. ~half of all valid proofs.
+        uint256 cYFlagged = cY > P_HALF ? cY | (uint256(1) << 255) : cY;
+        _writeReversedAt(msgBuf, 0,  cX);
+        _writeReversedAt(msgBuf, 32, cYFlagged);
+
+        // Public-committed inputs in arkworks LE.
+        //
+        // CODEGEN: emit exactly N_COMMITTED `_writeReversedAt` calls — one
+        // per entry of `vk.public_and_commitment_committed[0]`, in the
+        // order recorded in the VK. Index conversion: the VK stores
+        // 1-based absolute witness indices (`0 = ONE_WIRE`, `1 =
+        // public_witness[0]`, ...); the codegen tool subtracts 1 so each
+        // emitted call indexes `input[]` 0-based (see
+        // `tooling/cli/src/cmd/export_solidity.rs::CircuitParams`).
+        //
+        // The Rust verifier reads these same values via
+        // `extended_public[idx - 1]`; emitting the wrong subset — or the
+        // right subset in the wrong order — silently produces a different
+        // challenge and makes every valid proof fail.
+        //
+        // Default placeholder below assumes committed = [input[0]]; the
+        // codegen tool overwrites this block whole.
+        //<BEGIN_CODEGEN:COMMITTED_INDICES>
+        _writeReversedAt(msgBuf, 64 + 32 * 0, input[0]); // CODEGEN: committed[0] = input[0]
+        //<END_CODEGEN:COMMITTED_INDICES>
+
+        // Match the Rust verifier: when num_challenges <= 1, the prover and
+        // off-chain verifier use `derive_commitment_challenge` (a single
+        // keccak round via `hash_to_fr`); otherwise they use the counter
+        // chain `hash_to_fr_multi`. The on-chain split below mirrors that.
+        // N_CHALLENGE is a compile-time constant, so the dead branch is
+        // pruned.
+        uint256[N_CHALLENGE] memory out;
+        if (N_CHALLENGE == 1) {
+            out[0] = _hashToFr(msgBuf, DST_COMMITMENT);
+            return out;
+        }
+        return _hashToFrMulti(msgBuf, DST_COMMITMENT);
+    }
+
+    // ==================================================================
+    //               RLC scalar (Fiat-Shamir for pairing batching)
+    // ==================================================================
+
+    /// Derive the random-linear-combination scalar `r ∈ F_R` that folds
+    /// the Pedersen pairing factor into the Groth16 pairing equation.
+    ///
+    /// Hash domain:
+    ///     r = keccak256(DST_RLC || proof || input) mod R
+    ///
+    /// All prover-chosen values flow into the hash:
+    ///   * `proof` — Ar, Bs, Krs, C, PoK in their EVM big-endian layout
+    ///   * `input` — the EXPLICIT public inputs (the derived BSB22
+    ///     challenges and k_sum are deterministic functions of `proof`
+    ///     and `input`, so hashing them again would be redundant)
+    ///
+    /// This pins `r` to the prover's commitments before they are
+    /// "interpreted" through the pairing, eliminating adaptive attacks
+    /// (cf. Fiat-Shamir transform applied to the interactive batch-
+    /// verification protocol).
+    ///
+    /// Bias note: the same ~2^-126 statistical bias as elsewhere in this
+    /// contract (256-bit hash output reduced mod a 254-bit prime) — well
+    /// inside the soundness margin for a single Fiat-Shamir scalar.
+    function _deriveRlcChallenge(
+        bytes calldata proof,
+        uint256[N_PUB] calldata input
+    ) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(DST_RLC, proof, input))) % R;
+    }
+
+    // ==================================================================
+    //               Public-input MSM
+    // ==================================================================
+
+    /// k_sum = K[0] + Σᵢ extended_public[i] · K[1+i] + Σⱼ commitments[j]
+    ///
+    /// extended_public = [input[0], …, input[N_PUB-1],
+    ///                    challenges[0], …, challenges[N_CHALLENGE-1]].
+    /// Each commitment is added directly to the running sum after the MSM;
+    /// for the single-commitment template that's just one extra ECADD.
+    function _publicInputMSM(
+        uint256[N_PUB] calldata input,
+        uint256[N_CHALLENGE] memory challenges,
+        uint256 cX,
+        uint256 cY
+    ) internal view returns (uint256 x, uint256 y) {
+        // Working buffer holds the running sum.
+        uint256[4] memory buf;
+        buf[0] = K0_X;
+        buf[1] = K0_Y;
+
+        // ECMUL/ECADD for each entry of extended_public.
+        // We list the K-points inline (CODEGEN should unroll for arbitrary N).
+        //<BEGIN_CODEGEN:MSM_STEPS>
+        _msmStep(buf, PUB_0_X, PUB_0_Y, input[0]);
+        _msmStep(buf, PUB_1_X, PUB_1_Y, challenges[0]);
+        //<END_CODEGEN:MSM_STEPS>
+
+        // Add commitment(s) to k_sum.
+        _ecAddInto(buf, cX, cY);
+
+        x = buf[0];
+        y = buf[1];
+    }
+
+    /// buf[0..2] += K · s  (via ECMUL then ECADD).
+    function _msmStep(
+        uint256[4] memory buf,
+        uint256 kx,
+        uint256 ky,
+        uint256 s
+    ) internal view {
+        if (s >= R) revert PublicInputNotInField();
+
+        bool success;
+        assembly ("memory-safe") {
+            let p := add(buf, 0x40)
+            mstore(p, kx)
+            mstore(add(p, 0x20), ky)
+            mstore(add(p, 0x40), s)
+            // ECMUL: (kx, ky, s) -> (rx, ry)
+            success := staticcall(gas(), PRECOMPILE_ECMUL, p, 0x60, p, 0x40)
+            // ECADD: buf[0..2] += [p..p+64]
+            success := and(success, staticcall(gas(), PRECOMPILE_ECADD, buf, 0x80, buf, 0x40))
+        }
+        if (!success) revert ProofInvalid();
+    }
+
+    /// buf[0..2] += (px, py).
+    function _ecAddInto(
+        uint256[4] memory buf,
+        uint256 px,
+        uint256 py
+    ) internal view {
+        bool success;
+        assembly ("memory-safe") {
+            mstore(add(buf, 0x40), px)
+            mstore(add(buf, 0x60), py)
+            success := staticcall(gas(), PRECOMPILE_ECADD, buf, 0x80, buf, 0x40)
+        }
+        if (!success) revert ProofInvalid();
+    }
+
+    // ==================================================================
+    //               BSB22 hash-to-Fr primitives
+    // ==================================================================
+
+    /// Counter-chain hash to N_CHALLENGE field elements. Matches
+    /// `provekit_groth16::prover::hash_to_fr_multi`:
+    ///   root   = keccak256(dst || msg)
+    ///   out[i] = keccak256(root || I2OSP(i, 1)) mod R    for i = 0..N
+    ///
+    /// One outer hash over `msg` (which may be large), then N cheap
+    /// 33-byte hashes — total cost stays close to a single keccak even
+    /// for moderately large N.
+    ///
+    /// Bias: each `out[i]` is uniform over [0, 2^256) before reduction.
+    /// Reducing a 256-bit value mod R (254-bit) leaves ~2^-126
+    /// statistical bias — negligible for BSB22 challenge use.
+    function _hashToFrMulti(
+        bytes memory msgBuf,
+        bytes memory dst
+    ) internal pure returns (uint256[N_CHALLENGE] memory out) {
+        bytes32 root = keccak256(abi.encodePacked(dst, msgBuf));
+        for (uint256 i = 0; i < N_CHALLENGE; i++) {
+            out[i] = uint256(keccak256(abi.encodePacked(root, uint8(i)))) % R;
+        }
+    }
+
+    /// Single-round hash to one field element:
+    ///   keccak256(dst || msg) mod R
+    /// Matches `provekit_groth16::prover::hash_to_fr`. Used both for the
+    /// single-challenge commitment path (above) and — once implemented —
+    /// for the multi-commitment folding challenge with dst "G16-BSB22".
+    function _hashToFr(bytes memory msgBuf, bytes memory dst) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(dst, msgBuf))) % R;
+    }
+
+    // ==================================================================
+    //               Byte-reversal helpers
+    // ==================================================================
+
+    /// Write `value` (an EVM uint256, big-endian) into `buf[offset..offset+32]`
+    /// in REVERSED (little-endian) byte order. Used to convert EVM-side
+    /// G1 coordinates and Fr values to arkworks' on-the-wire layout before
+    /// hashing.
+    function _writeReversedAt(bytes memory buf, uint256 offset, uint256 value) internal pure {
+        uint256 rev = _reverseBytes32(value);
+        assembly ("memory-safe") {
+            mstore(add(add(buf, 0x20), offset), rev)
+        }
+    }
+
+    /// Reverse the byte order of a 32-byte word (BE ↔ LE).
+    /// Constant-time bitwise reversal in 12 ops.
+    function _reverseBytes32(uint256 x) internal pure returns (uint256 r) {
+        r = x;
+        r = ((r >> 8)  & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) |
+            ((r        & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+        r = ((r >> 16) & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) |
+            ((r        & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) << 16);
+        r = ((r >> 32) & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) |
+            ((r        & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) << 32);
+        r = ((r >> 64) & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) |
+            ((r        & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) << 64);
+        r = (r >> 128) | (r << 128);
+    }
+}

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -24,6 +24,8 @@ noirc_abi.workspace = true
 noirc_driver.workspace = true
 
 # Cryptography and proof systems
+ark-bn254.workspace = true
+ark-ec.workspace = true
 ark-ff.workspace = true
 ark-serialize.workspace = true
 

--- a/tooling/cli/src/cmd/export_evm_proof.rs
+++ b/tooling/cli/src/cmd/export_evm_proof.rs
@@ -9,10 +9,13 @@
 //!     N_PUB lines.
 //!
 //! Pair with:
-//!   cast call <verifier_addr> \
+//!
+//! ```text
+//! cast call <verifier_addr> \
 //!     "verifyProof(bytes,uint256[N])" \
 //!     $(cat proof.hex) \
 //!     "[$(paste -sd, inputs.txt)]"
+//! ```
 //!
 //! The prover stores the Groth16 proof in arkworks **compressed** form (the
 //! 192-byte representation in the postcard blob). On-chain we need

--- a/tooling/cli/src/cmd/export_evm_proof.rs
+++ b/tooling/cli/src/cmd/export_evm_proof.rs
@@ -1,0 +1,161 @@
+//! `export-evm-proof` — turn a `proof.np` (Groth16 variant) into the calldata
+//! the on-chain `ProvekitGroth16Verifier.verifyProof(bytes,uint256[N_PUB])`
+//! expects.
+//!
+//! Output:
+//!   * `<out_dir>/proof.hex`   — single line, `0x` + hex of the 384-byte EVM-BE
+//!     proof (Ar(64) || Bs(128) || Krs(64) || Commit(64) || PoK(64)).
+//!   * `<out_dir>/inputs.txt`  — one decimal field element per line, exactly
+//!     N_PUB lines.
+//!
+//! Pair with:
+//!   cast call <verifier_addr> \
+//!     "verifyProof(bytes,uint256[N])" \
+//!     $(cat proof.hex) \
+//!     "[$(paste -sd, inputs.txt)]"
+//!
+//! The prover stores the Groth16 proof in arkworks **compressed** form (the
+//! 192-byte representation in the postcard blob). On-chain we need
+//! **uncompressed** points in EVM big-endian — gnark's `MarshalSolidity`
+//! convention. This command performs that conversion.
+
+use {
+    super::Command,
+    anyhow::{bail, Context, Result},
+    argh::FromArgs,
+    ark_bn254::{Fq, Fr, G1Affine, G2Affine},
+    ark_ec::AffineRepr,
+    ark_ff::{BigInteger, PrimeField},
+    ark_serialize::CanonicalDeserialize,
+    provekit_common::{file::read, NoirProof},
+    provekit_groth16::Proof as Groth16Proof,
+    std::{fmt::Write as _, fs, path::PathBuf},
+    tracing::{info, instrument},
+};
+
+/// Re-emit a Groth16 NoirProof as EVM calldata for the on-chain verifier.
+#[derive(FromArgs, PartialEq, Eq, Debug)]
+#[argh(subcommand, name = "export-evm-proof")]
+pub struct Args {
+    /// path to the prover output (`proof.np`)
+    #[argh(option, long = "proof", short = 'p')]
+    proof_path: PathBuf,
+
+    /// directory for `proof.hex` + `inputs.txt` (created if missing)
+    #[argh(option, long = "out-dir", short = 'o')]
+    out_dir: PathBuf,
+}
+
+impl Command for Args {
+    #[instrument(skip_all)]
+    fn run(&self) -> Result<()> {
+        let proof: NoirProof = read(&self.proof_path)
+            .with_context(|| format!("reading {}", self.proof_path.display()))?;
+
+        let (public_inputs, proof_bytes) = match proof {
+            NoirProof::Groth16 {
+                public_inputs,
+                groth16_proof,
+            } => (public_inputs, groth16_proof),
+            NoirProof::Whir { .. } => bail!(
+                "proof at {} is a WHIR proof, not a Groth16 proof — re-prove with `--backend \
+                 groth16`",
+                self.proof_path.display(),
+            ),
+        };
+
+        let g16: Groth16Proof = Groth16Proof::deserialize_compressed(proof_bytes.as_slice())
+            .context("deserializing compressed Groth16 proof")?;
+        if g16.commitments.len() != 1 {
+            bail!(
+                "this exporter only supports single-commitment proofs (got {} commitments)",
+                g16.commitments.len()
+            );
+        }
+
+        let mut evm = Vec::with_capacity(256 + 64 * (g16.commitments.len() + 1));
+        push_g1_be(&mut evm, &g16.ar, "Ar")?;
+        push_g2_be(&mut evm, &g16.bs, "Bs")?;
+        push_g1_be(&mut evm, &g16.krs, "Krs")?;
+        for (i, c) in g16.commitments.iter().enumerate() {
+            push_g1_be(&mut evm, c, &format!("commitments[{i}]"))?;
+        }
+        push_g1_be(&mut evm, &g16.commitment_pok, "commitment_pok")?;
+
+        let inputs: &[Fr] = &public_inputs.0;
+        info!(
+            evm_bytes = evm.len(),
+            n_inputs = inputs.len(),
+            "ready to write EVM calldata",
+        );
+
+        fs::create_dir_all(&self.out_dir)
+            .with_context(|| format!("creating {}", self.out_dir.display()))?;
+
+        let mut proof_hex = String::with_capacity(2 + evm.len() * 2);
+        proof_hex.push_str("0x");
+        for b in &evm {
+            write!(&mut proof_hex, "{:02x}", b).unwrap();
+        }
+        let proof_hex_path = self.out_dir.join("proof.hex");
+        fs::write(&proof_hex_path, &proof_hex)
+            .with_context(|| format!("writing {}", proof_hex_path.display()))?;
+
+        let mut inputs_txt = String::new();
+        for (i, fr) in inputs.iter().enumerate() {
+            // Emit as decimal — `cast` / `forge` parse uint256 args in decimal
+            // (and hex too, but decimal needs no `0x` and trims fewer characters).
+            // Use the raw bigint representation (canonical, not Montgomery).
+            let big = fr.into_bigint();
+            writeln!(&mut inputs_txt, "{big}")
+                .with_context(|| format!("formatting public input {i}"))?;
+        }
+        let inputs_path = self.out_dir.join("inputs.txt");
+        fs::write(&inputs_path, inputs_txt)
+            .with_context(|| format!("writing {}", inputs_path.display()))?;
+
+        info!(
+            proof = %proof_hex_path.display(),
+            inputs = %inputs_path.display(),
+            "wrote EVM calldata",
+        );
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EVM-BE serialization helpers
+// ---------------------------------------------------------------------------
+
+/// Append a base-field element as 32 big-endian bytes.
+fn push_fq_be(out: &mut Vec<u8>, f: &Fq) {
+    let bytes = f.into_bigint().to_bytes_be();
+    if bytes.len() < 32 {
+        out.extend(std::iter::repeat(0).take(32 - bytes.len()));
+    }
+    out.extend_from_slice(&bytes[bytes.len().saturating_sub(32)..]);
+}
+
+/// Append a G1 point as 64 bytes: X (BE) || Y (BE).
+/// Errors on the point at infinity — the on-chain verifier rejects it.
+fn push_g1_be(out: &mut Vec<u8>, p: &G1Affine, name: &str) -> Result<()> {
+    let (x, y) = p
+        .xy()
+        .with_context(|| format!("{name} is the point at infinity"))?;
+    push_fq_be(out, &x);
+    push_fq_be(out, &y);
+    Ok(())
+}
+
+/// Append a G2 point in EIP-197 ordering: X.c1, X.c0, Y.c1, Y.c0 — each 32
+/// bytes BE. Mirrors gnark's `MarshalSolidity` for Bs / commitments-in-G2.
+fn push_g2_be(out: &mut Vec<u8>, p: &G2Affine, name: &str) -> Result<()> {
+    let (x, y) = p
+        .xy()
+        .with_context(|| format!("{name} is the point at infinity"))?;
+    push_fq_be(out, &x.c1);
+    push_fq_be(out, &x.c0);
+    push_fq_be(out, &y.c1);
+    push_fq_be(out, &y.c0);
+    Ok(())
+}

--- a/tooling/cli/src/cmd/export_solidity.rs
+++ b/tooling/cli/src/cmd/export_solidity.rs
@@ -1,0 +1,525 @@
+//! `export-solidity` — turn a `provekit_groth16::VerifyingKey` (carried inside
+//! a `.pkv`) into a concrete `ProvekitGroth16Verifier.sol` by substituting all
+//! `CODEGEN` markers in the contract template with real BN254 constants.
+//!
+//! Outputs a contract that's directly compilable with `solc 0.8.20+` and
+//! `forge build`. See `provekit/groth16/contracts/README.md` for the round-trip
+//! test recipe (prove off-chain → dump bytes → `verifyProof` from forge).
+//!
+//! The Rust verifier (`provekit_groth16::verifier::verify`) is the
+//! authoritative spec; the on-chain verifier must produce the same Pedersen
+//! check, the same BSB22 challenge, and the same Groth16 pairing equation.
+//! This tool exists so we never substitute constants by hand.
+
+use {
+    super::{util::resolve_key_path, Command},
+    anyhow::{bail, ensure, Context, Result},
+    argh::FromArgs,
+    ark_bn254::{Fq, G1Affine, G2Affine, G2Projective},
+    ark_ec::{AffineRepr, CurveGroup},
+    ark_ff::{BigInteger, PrimeField},
+    provekit_common::{file::read, Verifier},
+    provekit_groth16::{VerifierGroth16Ext, VerifyingKey},
+    std::{fmt::Write as _, fs, path::PathBuf},
+    tracing::{info, instrument},
+};
+
+/// Generate a circuit-specific Solidity verifier from a `.pkv` file.
+///
+/// Reads the Groth16 verifying key embedded in `--pkv`, computes the
+/// gnark-style negations (`-β`, `-γ`, `-δ`, `-σ·G`), and substitutes every
+/// `CODEGEN` placeholder in the template at `--template`. Writes the result
+/// to `--out`.
+#[derive(FromArgs, PartialEq, Eq, Debug)]
+#[argh(subcommand, name = "export-solidity")]
+pub struct Args {
+    /// path to the ProveKit Verifier (PKV) file containing the Groth16
+    /// verifying key (default: `<circuit>.pkv` in the current directory)
+    #[argh(option, long = "pkv", short = 'v')]
+    pkv_path: Option<PathBuf>,
+
+    /// path to the Solidity template (typically
+    /// `provekit/groth16/contracts/ProvekitGroth16Verifier.sol`)
+    #[argh(option, long = "template", short = 't')]
+    template_path: PathBuf,
+
+    /// output path for the generated Solidity file
+    #[argh(option, long = "out", short = 'o')]
+    output_path: PathBuf,
+}
+
+impl Command for Args {
+    #[instrument(skip_all)]
+    fn run(&self) -> Result<()> {
+        let pkv_path = resolve_key_path(self.pkv_path.as_deref(), "pkv")?;
+        let verifier: Verifier =
+            read(&pkv_path).with_context(|| format!("reading {}", pkv_path.display()))?;
+
+        // `groth16_vk_typed` runs `deserialize_uncompressed` which in turn
+        // runs `precompute()` inline, so `g2_delta_neg`, `g2_gamma_neg`,
+        // `e_alpha_beta` are filled in.
+        let vk = verifier.groth16_vk_typed()?.context(
+            "PKV does not contain a Groth16 verifying key (this PKV was built for the WHIR \
+             backend, not Groth16)",
+        )?;
+
+        let params = CircuitParams::from_vk(&vk)?;
+        info!(
+            n_pub = params.n_pub,
+            n_commit = params.n_commit,
+            n_challenge_per_commit = params.n_challenge_per_commit,
+            n_pub_extended = params.n_pub_extended,
+            n_committed = params.n_committed,
+            "loaded VK",
+        );
+
+        let template = fs::read_to_string(&self.template_path)
+            .with_context(|| format!("reading template {}", self.template_path.display()))?;
+        let rendered = render(&template, &vk, &params)?;
+
+        if let Some(parent) = self.output_path.parent() {
+            fs::create_dir_all(parent).ok();
+        }
+        fs::write(&self.output_path, rendered)
+            .with_context(|| format!("writing {}", self.output_path.display()))?;
+
+        info!(out = %self.output_path.display(), "wrote Solidity verifier");
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Circuit dimensions
+// ---------------------------------------------------------------------------
+
+/// Compile-time-constant dimensions extracted from the VK.
+///
+/// Mirrors the constants at the top of `ProvekitGroth16Verifier.sol`. We
+/// derive them here rather than asking the user to pass them on the command
+/// line so the contract and prover can never disagree on shape.
+struct CircuitParams {
+    /// Number of explicit public inputs the circuit takes (excluding ONE_WIRE
+    /// and derived BSB22 challenge wires).
+    n_pub:                    usize,
+    /// Number of BSB22 Pedersen commitments. Template only supports 1.
+    n_commit:                 usize,
+    /// Number of derived challenges per commitment. Template only supports 1.
+    n_challenge_per_commit:   usize,
+    /// `N_PUB + N_COMMIT * N_CHALLENGE`.
+    n_pub_extended:           usize,
+    /// Number of `input[]` entries hashed into the BSB22 challenge — the
+    /// length of `vk.public_and_commitment_committed[0]`.
+    n_committed:              usize,
+    /// 0-indexed `input[]` indices in the order the prover hashes them.
+    committed_idx_zero_based: Vec<usize>,
+}
+
+impl CircuitParams {
+    fn from_vk(vk: &VerifyingKey) -> Result<Self> {
+        let n_commit = vk.commitment_keys.len();
+        ensure!(
+            n_commit == 1,
+            "this codegen template only supports single-commitment circuits (got N_COMMIT = \
+             {n_commit}); multi-commitment support is listed as future work in the contract footer",
+        );
+        let n_challenge_per_commit = vk.num_challenges_per_commitment[0];
+        ensure!(
+            n_challenge_per_commit >= 1,
+            "VK declares zero challenges for commitment 0 — single-commitment BSB22 needs at \
+             least one",
+        );
+
+        let total_challenges: usize = vk.num_challenges_per_commitment.iter().sum();
+        ensure!(
+            vk.g1_k.len() >= total_challenges + 1,
+            "invalid VK: g1_k has {} entries but {} challenges + ONE_WIRE declared",
+            vk.g1_k.len(),
+            total_challenges,
+        );
+        let n_pub = vk
+            .g1_k
+            .len()
+            .checked_sub(total_challenges + 1)
+            .context("g1_k smaller than ONE_WIRE + challenge wires")?;
+        let n_pub_extended = n_pub + n_commit * n_challenge_per_commit;
+
+        // `public_and_commitment_committed[i]` indices are 1-based offsets
+        // into `extended_public` — see `verifier.rs:81-92`. By commitment i's
+        // turn `extended_public` has length
+        //   n_pub + Σ_{j<i} num_challenges_per_commitment[j]
+        // and the loop body reads `extended_public[idx - 1]`. Under the
+        // single-commitment guard above (i == 0), `extended_public` is just
+        // `public_witness`, so the valid range collapses to 1..=n_pub and
+        // each `idx - 1` is the 0-based offset into Solidity's `input[]`.
+        //
+        // If the n_commit==1 guard is ever lifted, this conversion must
+        // also handle i>0 — where committed indices may reference earlier
+        // commitments' derived challenges and the upper bound rises to
+        // n_pub_extended.
+        let raw = &vk.public_and_commitment_committed[0];
+        let mut committed_idx_zero_based = Vec::with_capacity(raw.len());
+        for &abs in raw {
+            ensure!(
+                abs >= 1 && abs <= n_pub,
+                "commitment-committed index {abs} out of range (expected 1..={n_pub} for N_PUB = \
+                 {n_pub})",
+            );
+            committed_idx_zero_based.push(abs - 1);
+        }
+
+        Ok(Self {
+            n_pub,
+            n_commit,
+            n_challenge_per_commit,
+            n_pub_extended,
+            n_committed: raw.len(),
+            committed_idx_zero_based,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hex / coordinate helpers
+// ---------------------------------------------------------------------------
+
+/// Format a BN254 base-field element as a 32-byte big-endian `0xHEX` string,
+/// matching how the Solidity contract reads coordinates from calldata.
+fn fp_hex(f: &Fq) -> String {
+    let mut bytes = f.into_bigint().to_bytes_be();
+    // `into_bigint().to_bytes_be()` returns a full-limb-width buffer (32B for
+    // BN254 Fq), but be defensive in case arkworks tweaks the layout.
+    if bytes.len() < 32 {
+        let mut padded = vec![0u8; 32];
+        padded[32 - bytes.len()..].copy_from_slice(&bytes);
+        bytes = padded;
+    }
+    let mut s = String::with_capacity(2 + 64);
+    s.push_str("0x");
+    for b in &bytes[bytes.len() - 32..] {
+        write!(&mut s, "{:02x}", b).unwrap();
+    }
+    s
+}
+
+/// Solidity-compatible representation of a G1 point: just `(x_hex, y_hex)`.
+/// Panics if called on the point at infinity — the VK shouldn't contain any.
+fn g1_coords(p: &G1Affine, name: &str) -> Result<(String, String)> {
+    let (x, y) = p
+        .xy()
+        .with_context(|| format!("{name} is the point at infinity in the VK"))?;
+    Ok((fp_hex(&x), fp_hex(&y)))
+}
+
+/// Solidity-compatible representation of a G2 point in EIP-197 ordering:
+/// `(x.c0, x.c1, y.c0, y.c1)`. Note: the on-chain pairing precompile expects
+/// the c1 component before c0 — that ordering is applied in the contract
+/// itself (`pairings[2] = bsX1; pairings[3] = bsX0; …`), so we emit the
+/// natural (c0, c1, c0, c1) here.
+fn g2_coords(p: &G2Affine, name: &str) -> Result<(String, String, String, String)> {
+    let (x, y) = p
+        .xy()
+        .with_context(|| format!("{name} is the point at infinity in the VK"))?;
+    Ok((fp_hex(&x.c0), fp_hex(&x.c1), fp_hex(&y.c0), fp_hex(&y.c1)))
+}
+
+/// Negate a G2 point in projective space, returning the affine form.
+fn g2_neg(p: &G2Affine) -> G2Affine {
+    (-G2Projective::from(*p)).into_affine()
+}
+
+// ---------------------------------------------------------------------------
+// Template substitution
+// ---------------------------------------------------------------------------
+
+fn render(template: &str, vk: &VerifyingKey, params: &CircuitParams) -> Result<String> {
+    let mut out = template.to_string();
+
+    // ---------- scalar constants ----------
+    // Mapping of `uint256 internal constant NAME` → value (decimal or 0x hex).
+    let (alpha_x, alpha_y) = g1_coords(&vk.g1_alpha, "vk.g1_alpha")?;
+    let g2_beta_neg = g2_neg(&vk.g2_beta);
+    let (beta_x0, beta_x1, beta_y0, beta_y1) = g2_coords(&g2_beta_neg, "-vk.g2_beta")?;
+    let (gamma_x0, gamma_x1, gamma_y0, gamma_y1) = g2_coords(&vk.g2_gamma_neg, "vk.g2_gamma_neg")?;
+    let (delta_x0, delta_x1, delta_y0, delta_y1) = g2_coords(&vk.g2_delta_neg, "vk.g2_delta_neg")?;
+    let (k0_x, k0_y) = g1_coords(&vk.g1_k[0], "vk.g1_k[0]")?;
+
+    let ck = &vk.commitment_keys[0];
+    let (pg_x0, pg_x1, pg_y0, pg_y1) = g2_coords(&ck.g, "vk.commitment_keys[0].g")?;
+    let (psn_x0, psn_x1, psn_y0, psn_y1) =
+        g2_coords(&ck.g_sigma_neg, "vk.commitment_keys[0].g_sigma_neg")?;
+
+    let scalar_subs: Vec<(&str, String)> = vec![
+        // circuit dimensions
+        ("N_PUB", params.n_pub.to_string()),
+        ("N_COMMIT", params.n_commit.to_string()),
+        ("N_CHALLENGE", params.n_challenge_per_commit.to_string()),
+        ("N_PUB_EXTENDED", params.n_pub_extended.to_string()),
+        ("N_COMMITTED", params.n_committed.to_string()),
+        // VK constants (G1 + G2 + Pedersen)
+        ("ALPHA_X", alpha_x),
+        ("ALPHA_Y", alpha_y),
+        ("BETA_NEG_X_0", beta_x0),
+        ("BETA_NEG_X_1", beta_x1),
+        ("BETA_NEG_Y_0", beta_y0),
+        ("BETA_NEG_Y_1", beta_y1),
+        ("GAMMA_NEG_X_0", gamma_x0),
+        ("GAMMA_NEG_X_1", gamma_x1),
+        ("GAMMA_NEG_Y_0", gamma_y0),
+        ("GAMMA_NEG_Y_1", gamma_y1),
+        ("DELTA_NEG_X_0", delta_x0),
+        ("DELTA_NEG_X_1", delta_x1),
+        ("DELTA_NEG_Y_0", delta_y0),
+        ("DELTA_NEG_Y_1", delta_y1),
+        ("K0_X", k0_x),
+        ("K0_Y", k0_y),
+        ("PEDERSEN_G_X_0", pg_x0),
+        ("PEDERSEN_G_X_1", pg_x1),
+        ("PEDERSEN_G_Y_0", pg_y0),
+        ("PEDERSEN_G_Y_1", pg_y1),
+        ("PEDERSEN_GSIGMA_NEG_X_0", psn_x0),
+        ("PEDERSEN_GSIGMA_NEG_X_1", psn_x1),
+        ("PEDERSEN_GSIGMA_NEG_Y_0", psn_y0),
+        ("PEDERSEN_GSIGMA_NEG_Y_1", psn_y1),
+    ];
+    for (name, value) in &scalar_subs {
+        out = replace_constant(&out, name, value)
+            .with_context(|| format!("substituting constant {name}"))?;
+    }
+
+    // ---------- block replacements ----------
+    out = replace_block(&out, "PUB_BASES", &render_pub_bases(vk, params)?)?;
+    out = replace_block(&out, "MSM_STEPS", &render_msm_steps(params))?;
+    out = replace_block(&out, "COMMITTED_INDICES", &render_committed_indices(params))?;
+
+    // Any leftover `// CODEGEN` markers mean the template grew a new slot
+    // this tool doesn't know about. Fail loud rather than ship a half-baked
+    // verifier.
+    if let Some(line) = out
+        .lines()
+        .find(|l| l.contains("CODEGEN") && !l.trim_start().starts_with("//"))
+    {
+        bail!("template still contains an unsubstituted CODEGEN marker: {line:?}");
+    }
+
+    Ok(out)
+}
+
+/// Replace the right-hand side of `uint256 internal constant NAME = ...;`
+/// with `new_value`. Errors if the constant declaration is missing or
+/// appears more than once.
+fn replace_constant(src: &str, name: &str, new_value: &str) -> Result<String> {
+    // We match the declaration line robustly across whitespace variations:
+    //
+    //     uint256 internal constant <NAME>[whitespace]=[whitespace]<old>;
+    //
+    // and rewrite it as
+    //
+    //     uint256 internal constant <NAME> = <new>;
+    //
+    // preserving the original indentation. Anything after the semicolon
+    // (e.g. `// CODEGEN`) is preserved.
+    let mut found = false;
+    let mut output = String::with_capacity(src.len());
+    for line in src.split_inclusive('\n') {
+        if !found {
+            if let Some(rewritten) = try_rewrite_constant_line(line, name, new_value) {
+                output.push_str(&rewritten);
+                found = true;
+                continue;
+            }
+        }
+        output.push_str(line);
+    }
+    ensure!(found, "no declaration of `{name}` found in template");
+    // Defensive: refuse to substitute when the same constant appears twice.
+    let occurrences = src.matches(&format!("constant {name} ")).count()
+        + src.matches(&format!("constant {name}=")).count();
+    ensure!(
+        occurrences <= 1,
+        "constant `{name}` appears {occurrences} times in template; codegen requires exactly one \
+         declaration",
+    );
+    Ok(output)
+}
+
+fn try_rewrite_constant_line(line: &str, name: &str, new_value: &str) -> Option<String> {
+    // Quick reject: the constant name must appear in the line surrounded by
+    // word boundaries that match the `constant NAME` pattern.
+    let needle = format!("constant {name}");
+    let idx = line.find(&needle)?;
+    // The next non-space char after the name must be `=` (allows `NAME=` or
+    // `NAME =` etc.). Without this we'd happily rewrite `NAME_X` when asked
+    // for `NAME`.
+    let after_name = &line[idx + needle.len()..];
+    let mut chars = after_name.chars();
+    let next_significant = chars.by_ref().find(|c| !c.is_whitespace())?;
+    if next_significant != '=' {
+        return None;
+    }
+
+    // Split the line at the `=` and replace everything up to the next `;`.
+    let eq_idx = line[idx + needle.len()..].find('=')? + idx + needle.len();
+    let semi_idx = line[eq_idx..].find(';')? + eq_idx;
+    // `let prefix = line[..eq_idx];  // includes "constant NAME"` part and the `=`.
+    let prefix = &line[..eq_idx + 1]; // include '='
+
+    // Build a clean suffix: `;` plus the line terminator, dropping any trailing
+    // `// CODEGEN…` placeholder comment. Without this, the leftover-CODEGEN
+    // detector in `render()` would fire on every successfully-substituted
+    // line — `uint256 … = 0x…; // CODEGEN` contains "CODEGEN" but doesn't
+    // start with "//" after `trim_start`. Dropping the comment also keeps the
+    // detector useful as a tripwire for *unknown* CODEGEN slots a future
+    // template grows.
+    let raw_suffix = &line[semi_idx..]; // starts with ';'
+    let suffix: String = match raw_suffix.find('\n') {
+        Some(nl) => {
+            let between = &raw_suffix[1..nl];
+            if between.trim_start().starts_with("//") && between.contains("CODEGEN") {
+                format!(";{}", &raw_suffix[nl..])
+            } else {
+                raw_suffix.to_string()
+            }
+        }
+        None => {
+            // No trailing newline (file's last line); same rule applied to the tail.
+            let between = &raw_suffix[1..];
+            if between.trim_start().starts_with("//") && between.contains("CODEGEN") {
+                ";".to_string()
+            } else {
+                raw_suffix.to_string()
+            }
+        }
+    };
+
+    let mut rewritten = String::with_capacity(line.len() + new_value.len());
+    rewritten.push_str(prefix.trim_end_matches('='));
+    rewritten.push_str("= ");
+    rewritten.push_str(new_value);
+    rewritten.push_str(&suffix);
+    Some(rewritten)
+}
+
+/// Replace the content between `//<BEGIN_CODEGEN:TAG>` and
+/// `//<END_CODEGEN:TAG>` (exclusive of the markers themselves) with
+/// `replacement`. Each replacement line is re-indented to match the
+/// END marker line; the template always aligns BEGIN/END so this is
+/// equivalent to "preserve the block's indent".
+fn replace_block(src: &str, tag: &str, replacement: &str) -> Result<String> {
+    let begin_marker = format!("//<BEGIN_CODEGEN:{tag}>");
+    let end_marker = format!("//<END_CODEGEN:{tag}>");
+
+    let begin = src
+        .find(&begin_marker)
+        .with_context(|| format!("missing `{begin_marker}` in template"))?;
+    let after_begin_line_end = src[begin..]
+        .find('\n')
+        .map(|n| begin + n + 1)
+        .with_context(|| format!("`{begin_marker}` not followed by a newline"))?;
+    let end = src
+        .find(&end_marker)
+        .with_context(|| format!("missing `{end_marker}` in template"))?;
+    ensure!(
+        end > begin,
+        "block markers for `{tag}` are in the wrong order"
+    );
+    // `end_line_start` points at the first byte of the END marker's line.
+    // The slice `src[end_line_start..end]` is then just the leading
+    // whitespace before `//<END_CODEGEN:…>`, which we reuse as the indent
+    // for each generated line below.
+    let end_line_start = src[..end].rfind('\n').map(|n| n + 1).unwrap_or(0);
+
+    let indent = leading_whitespace(&src[end_line_start..end]);
+    let mut indented = String::new();
+    for body_line in replacement.lines() {
+        if body_line.is_empty() {
+            indented.push('\n');
+        } else {
+            indented.push_str(indent);
+            indented.push_str(body_line);
+            indented.push('\n');
+        }
+    }
+
+    let mut out = String::with_capacity(src.len() + indented.len());
+    out.push_str(&src[..after_begin_line_end]);
+    out.push_str(&indented);
+    out.push_str(&src[end_line_start..]);
+    Ok(out)
+}
+
+fn leading_whitespace(s: &str) -> &str {
+    let end = s
+        .char_indices()
+        .find(|(_, c)| !c.is_whitespace() || *c == '\n')
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    &s[..end]
+}
+
+// ---------------------------------------------------------------------------
+// Block renderers
+// ---------------------------------------------------------------------------
+
+fn render_pub_bases(vk: &VerifyingKey, params: &CircuitParams) -> Result<String> {
+    ensure!(
+        vk.g1_k.len() == params.n_pub_extended + 1,
+        "VK g1_k length {} doesn't match N_PUB_EXTENDED + 1 = {}",
+        vk.g1_k.len(),
+        params.n_pub_extended + 1,
+    );
+    let mut s = String::new();
+    for i in 0..params.n_pub_extended {
+        let (x, y) = g1_coords(&vk.g1_k[i + 1], &format!("vk.g1_k[{}]", i + 1))?;
+        let role = if i < params.n_pub {
+            format!("public input #{i}")
+        } else {
+            format!("challenge #{}", i - params.n_pub)
+        };
+        writeln!(
+            &mut s,
+            "uint256 internal constant PUB_{i}_X = {x}; // K[{}] — {role}",
+            i + 1
+        )
+        .unwrap();
+        writeln!(
+            &mut s,
+            "uint256 internal constant PUB_{i}_Y = {y}; // K[{}] — {role}",
+            i + 1
+        )
+        .unwrap();
+    }
+    Ok(s)
+}
+
+fn render_msm_steps(params: &CircuitParams) -> String {
+    let mut s = String::new();
+    // First N_PUB entries are public inputs from calldata.
+    for i in 0..params.n_pub {
+        writeln!(&mut s, "_msmStep(buf, PUB_{i}_X, PUB_{i}_Y, input[{i}]);").unwrap();
+    }
+    // Then the derived BSB22 challenges. The contract now always passes a
+    // `uint256[N_CHALLENGE] memory challenges` array (size 1 when there's a
+    // single challenge), so we always index it.
+    for j in 0..(params.n_commit * params.n_challenge_per_commit) {
+        let pub_idx = params.n_pub + j;
+        writeln!(
+            &mut s,
+            "_msmStep(buf, PUB_{pub_idx}_X, PUB_{pub_idx}_Y, challenges[{j}]);"
+        )
+        .unwrap();
+    }
+    s
+}
+
+fn render_committed_indices(params: &CircuitParams) -> String {
+    let mut s = String::new();
+    for (slot, src_idx) in params.committed_idx_zero_based.iter().enumerate() {
+        writeln!(
+            &mut s,
+            "_writeReversedAt(msgBuf, 64 + 32 * {slot}, input[{src_idx}]); // committed[{slot}] = \
+             input[{src_idx}]"
+        )
+        .unwrap();
+    }
+    s
+}

--- a/tooling/cli/src/cmd/mod.rs
+++ b/tooling/cli/src/cmd/mod.rs
@@ -1,5 +1,7 @@
 mod analyze_pkp;
 mod circuit_stats;
+mod export_evm_proof;
+mod export_solidity;
 mod generate_gnark_inputs;
 mod prepare;
 mod prove;
@@ -46,6 +48,8 @@ enum Commands {
     Verify(verify::Args),
     GenerateGnarkInputs(generate_gnark_inputs::Args),
     ShowInputs(show_inputs::Args),
+    ExportSolidity(export_solidity::Args),
+    ExportEvmProof(export_evm_proof::Args),
 }
 
 impl Command for Args {
@@ -64,6 +68,8 @@ impl Command for Commands {
             Self::Verify(args) => args.run(),
             Self::GenerateGnarkInputs(args) => args.run(),
             Self::ShowInputs(args) => args.run(),
+            Self::ExportSolidity(args) => args.run(),
+            Self::ExportEvmProof(args) => args.run(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- `export-solidity`: render `ProvekitGroth16Verifier.sol` from a PKV
- `export-evm-proof`: convert `proof.np` to EVM `proof.hex` + `inputs.txt`
- Template implements RFC 9380 `expand_message_xmd-SHA256` for BSB22 on-chain
