### PR TITLE
Add wasm tooling crate to v1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,15 @@ rustflags = ["-C", "target-feature=+simd128,+relaxed-simd"]
 [target.wasm32-wasip1]
 runner = "wasmtime run --dir . "
 rustflags = ["-C", "target-feature=+simd128,+relaxed-simd"]
+
+[target.wasm32-unknown-unknown]
+rustflags = [
+    "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128,+relaxed-simd,-reference-types",
+    "-C", "link-arg=--shared-memory",
+    "-C", "link-arg=--import-memory",
+    "-C", "link-arg=--max-memory=4294967296",
+    "-C", "link-arg=--export=__wasm_init_tls",
+    "-C", "link-arg=--export=__tls_size",
+    "-C", "link-arg=--export=__tls_align",
+    "-C", "link-arg=--export=__tls_base",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # NOTE: build, clippy, and doc each run on a dedicated runner. They share no
+  # disk, so the `--all-targets --all-features` target dir is not accumulated
+  # across steps. A single combined job runs out of disk on the ARM runner now
+  # that the workspace includes `provekit-wasm` and its dependency tree.
   build_and_test:
     name: Build and test
     runs-on: ubuntu-24.04-arm
@@ -27,14 +31,48 @@ jobs:
         with:
           channel: nightly-2026-03-04
           cache-base: main
-          components: rustfmt, clippy
-      - run: cargo fmt --all --check
-      - run: cargo clippy --all-targets --all-features --verbose
       - run: cargo build --all-targets --all-features --verbose
       - run: cargo test --no-fail-fast --all-features --verbose --lib --tests --bins -- --nocapture
         env:
           RUST_BACKTRACE: 1
       - run: cargo test --doc --all-features --verbose
+
+  cargo_clippy:
+    name: Clippy
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup rust toolchain, cache and bins
+        uses: moonrepo/setup-rust@v1
+        with:
+          channel: nightly-2026-03-04
+          cache-base: main
+          components: clippy
+      - run: cargo clippy --all-targets --all-features --verbose
+
+  cargo_fmt:
+    name: Cargo fmt
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup rust toolchain, cache and bins
+        uses: moonrepo/setup-rust@v1
+        with:
+          channel: nightly-2026-03-04
+          cache-base: main
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  cargo_doc:
+    name: Documentation
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup rust toolchain, cache and bins
+        uses: moonrepo/setup-rust@v1
+        with:
+          channel: nightly-2026-03-04
+          cache-base: main
       - run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: "--cfg doc_cfg -D warnings"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1101,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1851,9 +1876,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1863,10 +1890,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2748,6 +2777,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3614,7 +3653,7 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "provekit-bench"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "divan",
@@ -3633,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-cli"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "argh",
@@ -3662,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-common"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3695,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-ffi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -3710,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-gnark"
-version = "0.1.2"
+version = "1.0.0"
 dependencies = [
  "ark-poly",
  "provekit-common",
@@ -3722,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-prover"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "ark-ff 0.5.0",
@@ -3741,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-r1cs-compiler"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3792,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "provekit-verifier"
-version = "0.1.4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "ark-std 0.5.0",
@@ -3800,6 +3839,31 @@ dependencies = [
  "provekit-whir",
  "rayon",
  "tracing",
+]
+
+[[package]]
+name = "provekit-wasm"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "console_error_panic_hook",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "getrandom 0.4.2",
+ "hex",
+ "js-sys",
+ "lzma-rs",
+ "postcard",
+ "provekit-common",
+ "provekit-prover",
+ "provekit-verifier",
+ "provekit_acir",
+ "ruzstd",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-rayon",
 ]
 
 [[package]]
@@ -4517,6 +4581,7 @@ checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -4527,6 +4592,7 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+ "wasm_sync",
 ]
 
 [[package]]
@@ -4966,6 +5032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5150,6 +5225,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6157,6 +6243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6282,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "verifier-server"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -6431,6 +6523,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a16c60a56c81e4dc3b9c43d76ba5633e1c0278211d59a9cb07d61b6cd1c6583"
+dependencies = [
+ "crossbeam-channel",
+ "js-sys",
+ "rayon",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6459,6 +6563,17 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm_sync"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff360cade7fec41ff0e9d2cda57fe58258c5f16def0e21302394659e6bbb0ea"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "tooling/provekit-bench",
   "tooling/provekit-ffi",
   "tooling/provekit-gnark",
+  "tooling/provekit-wasm",
   "tooling/verifier-server",
   # "ntt",
 ]
@@ -105,6 +106,7 @@ provekit-prover = { path = "provekit/prover", version = "1.0.0" }
 provekit-r1cs-compiler = { path = "provekit/r1cs-compiler", version = "1.0.0" }
 provekit-verifier = { path = "provekit/verifier", version = "1.0.0" }
 provekit-verifier-server = { path = "tooling/verifier-server" }
+provekit-wasm = { path = "tooling/provekit-wasm" }
 
 # 3rd party
 anyhow = "1.0.93"
@@ -153,9 +155,18 @@ zerocopy = "0.8.25"
 zeroize = "1.8.1"
 zstd = "0.13"
 
-# WASM feature unification: direct dep on getrandom v0.2 activates `js`
-# backend for transitive rand_core 0.6 (via k256 -> provekit_acvm_blackbox_solver).
+# WASM-specific dependencies
+console_error_panic_hook = "0.1"
 getrandom = { version = "0.2", features = ["js"] }
+getrandom03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+# Required by transitive deps (e.g. rand_core 0.10) when building wasm32-unknown-unknown.
+getrandom04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+js-sys = "0.3"
+lzma-rs = "0.3"
+ruzstd = "0.8"
+serde-wasm-bindgen = "0.6"
+wasm-bindgen = "0.2"
+wasm-bindgen-rayon = "1.2"
 
 # Noir language dependencies
 acir = { package = "provekit_acir", version = "1.0.0-beta.11-alpha.1" }

--- a/tooling/provekit-wasm/Cargo.toml
+++ b/tooling/provekit-wasm/Cargo.toml
@@ -1,0 +1,59 @@
+# WASM build:
+#   cargo build --release --target wasm32-unknown-unknown -p provekit-wasm -Z build-std=panic_abort,std
+#   wasm-bindgen --target web --out-dir tooling/provekit-wasm/pkg target/wasm32-unknown-unknown/release/provekit_wasm.wasm
+#   wasm-opt -O3 --enable-simd --enable-threads --enable-bulk-memory --enable-mutable-globals --enable-nontrapping-float-to-int --enable-sign-ext --fast-math --low-memory-unused -o pkg/provekit_wasm_bg.wasm pkg/provekit_wasm_bg.wasm
+#
+# RUSTFLAGS and linker args are in .cargo/config.toml under [target.wasm32-unknown-unknown].
+# The browser must serve with Cross-Origin-Opener-Policy: same-origin and
+# Cross-Origin-Embedder-Policy: require-corp headers for SharedArrayBuffer.
+
+[package]
+name = "provekit-wasm"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Workspace crates - enable parallel features with wasm-bindgen-rayon
+provekit-common.workspace = true
+provekit-prover = { path = "../../provekit/prover", version = "1.0.0", default-features = false, features = [
+  "parallel",
+] }
+provekit-verifier.workspace = true
+
+# Noir language
+acir.workspace = true
+
+
+# 3rd party
+anyhow.workspace = true
+base64.workspace = true
+console_error_panic_hook.workspace = true
+getrandom.workspace = true   # Enable js feature for WASM via feature unification (v0.2)
+getrandom03.workspace = true  # Enable wasm_js feature for WASM via feature unification (v0.3)
+# Enable wasm_js feature for getrandom v0.4 used transitively by rand_core 0.10.
+getrandom04.workspace = true
+hex.workspace = true
+js-sys.workspace = true
+lzma-rs.workspace = true
+postcard.workspace = true
+ruzstd.workspace = true  # Pure-Rust Zstd decompressor (native crate zstd uses C bindings, incompatible with WASM)
+serde_json.workspace = true
+serde-wasm-bindgen.workspace = true
+wasm-bindgen.workspace = true
+
+# WASM parallelism via Web Workers
+wasm-bindgen-rayon.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["getrandom", "getrandom03", "getrandom04"]
+
+[lints]
+workspace = true

--- a/tooling/provekit-wasm/src/format.rs
+++ b/tooling/provekit-wasm/src/format.rs
@@ -1,0 +1,209 @@
+use {
+    provekit_common::{Prover, Verifier},
+    wasm_bindgen::prelude::*,
+};
+
+pub(crate) const HEADER_SIZE: usize = 20;
+pub(crate) const MAGIC_BYTES: &[u8] = b"\xDC\xDFOZkp\x01\x00";
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xb5, 0x2f, 0xfd];
+const XZ_MAGIC: [u8; 6] = [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00];
+
+const PROVER_FORMAT: [u8; 8] = *b"PrvKitPr";
+const PROVER_VERSION: (u16, u16) = (1, 1);
+
+const VERIFIER_FORMAT: [u8; 8] = *b"PrvKitVr";
+const VERIFIER_VERSION: (u16, u16) = (1, 2);
+
+pub(crate) fn parse_binary_header<'a>(
+    data: &'a [u8],
+    expected_format: &[u8; 8],
+    (expected_major, min_minor): (u16, u16),
+    label: &str,
+) -> Result<&'a [u8], JsError> {
+    parse_binary_header_impl(data, expected_format, (expected_major, min_minor), label)
+        .map_err(|msg| JsError::new(&msg))
+}
+
+fn parse_binary_header_impl<'a>(
+    data: &'a [u8],
+    expected_format: &[u8; 8],
+    (expected_major, min_minor): (u16, u16),
+    label: &str,
+) -> Result<&'a [u8], String> {
+    if data.len() < HEADER_SIZE {
+        return Err(format!("{label} data too short for binary format"));
+    }
+    if &data[..8] != MAGIC_BYTES {
+        return Err(format!("Invalid magic bytes in {label} data"));
+    }
+    if &data[8..16] != expected_format {
+        return Err(format!("Invalid format identifier in {label} data"));
+    }
+
+    let major = u16::from_le_bytes([data[16], data[17]]);
+    let minor = u16::from_le_bytes([data[18], data[19]]);
+    if major != expected_major {
+        return Err(format!(
+            "Incompatible {label} format: major version {major}, expected {expected_major}"
+        ));
+    }
+    if minor < min_minor {
+        return Err(format!(
+            "Incompatible {label} format: minor version {minor}, expected >= {min_minor}"
+        ));
+    }
+
+    Ok(&data[HEADER_SIZE..])
+}
+
+pub(crate) fn decompress(data: &[u8]) -> Result<Vec<u8>, JsError> {
+    decompress_impl(data).map_err(|msg| JsError::new(&msg))
+}
+
+fn decompress_impl(data: &[u8]) -> Result<Vec<u8>, String> {
+    if data.len() >= 4 && data[..4] == ZSTD_MAGIC {
+        let mut decoder = ruzstd::decoding::StreamingDecoder::new(std::io::Cursor::new(data))
+            .map_err(|e| format!("Failed to init Zstd decoder: {e}"))?;
+        let hint = usize::try_from(decoder.decoder.content_size()).unwrap_or(0);
+        let mut out = Vec::with_capacity(hint);
+        std::io::Read::read_to_end(&mut decoder, &mut out)
+            .map_err(|e| format!("Failed to decompress Zstd data: {e}"))?;
+        Ok(out)
+    } else if data.len() >= 6 && data[..6] == XZ_MAGIC {
+        let mut out = Vec::new();
+        lzma_rs::xz_decompress(&mut std::io::Cursor::new(data), &mut out)
+            .map_err(|e| format!("Failed to decompress XZ data: {e}"))?;
+        Ok(out)
+    } else {
+        Err(format!(
+            "Unknown compression format (first bytes: {:02X?})",
+            &data[..data.len().min(6)]
+        ))
+    }
+}
+
+/// Parses a binary prover artifact (.pkp format).
+pub fn parse_binary_prover(data: &[u8]) -> Result<Prover, JsError> {
+    let payload = parse_binary_header(data, &PROVER_FORMAT, PROVER_VERSION, "prover")?;
+    let decompressed = decompress(payload)?;
+    postcard::from_bytes(&decompressed)
+        .map_err(|err| JsError::new(&format!("Failed to deserialize prover data: {err}")))
+}
+
+/// Parses a binary verifier artifact (.pkv format).
+pub fn parse_binary_verifier(data: &[u8]) -> Result<Verifier, JsError> {
+    let payload = parse_binary_header(data, &VERIFIER_FORMAT, VERIFIER_VERSION, "verifier")?;
+    let decompressed = decompress(payload)?;
+    postcard::from_bytes(&decompressed)
+        .map_err(|err| JsError::new(&format!("Failed to deserialize verifier data: {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        ruzstd::encoding::{compress_to_vec, CompressionLevel},
+    };
+
+    fn build_header(format: [u8; 8], version: (u16, u16), payload: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(HEADER_SIZE + payload.len());
+        data.extend_from_slice(MAGIC_BYTES);
+        data.extend_from_slice(&format);
+        data.extend_from_slice(&version.0.to_le_bytes());
+        data.extend_from_slice(&version.1.to_le_bytes());
+        data.extend_from_slice(payload);
+        data
+    }
+
+    #[test]
+    fn parse_binary_header_accepts_valid_header() {
+        let payload = b"payload-bytes";
+        let data = build_header(PROVER_FORMAT, PROVER_VERSION, payload);
+
+        let parsed = parse_binary_header(&data, &PROVER_FORMAT, PROVER_VERSION, "prover").unwrap();
+
+        assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn parse_binary_header_rejects_magic_mismatch() {
+        let mut data = build_header(PROVER_FORMAT, PROVER_VERSION, b"x");
+        data[0] ^= 0x01;
+
+        let err =
+            parse_binary_header_impl(&data, &PROVER_FORMAT, PROVER_VERSION, "prover").unwrap_err();
+        assert!(err.contains("Invalid magic bytes in prover data"));
+    }
+
+    #[test]
+    fn parse_binary_header_rejects_format_mismatch() {
+        let data = build_header(VERIFIER_FORMAT, PROVER_VERSION, b"x");
+
+        let err =
+            parse_binary_header_impl(&data, &PROVER_FORMAT, PROVER_VERSION, "prover").unwrap_err();
+        assert!(err.contains("Invalid format identifier in prover data"));
+    }
+
+    #[test]
+    fn parse_binary_header_rejects_major_version_mismatch() {
+        let bad_major = (PROVER_VERSION.0 + 1, PROVER_VERSION.1);
+        let data = build_header(PROVER_FORMAT, bad_major, b"x");
+
+        let err =
+            parse_binary_header_impl(&data, &PROVER_FORMAT, PROVER_VERSION, "prover").unwrap_err();
+        assert!(err.contains("Incompatible prover format: major version"));
+    }
+
+    #[test]
+    fn parse_binary_header_rejects_minor_version_too_low() {
+        let min_minor = PROVER_VERSION.1 + 1;
+        let data = build_header(PROVER_FORMAT, PROVER_VERSION, b"x");
+
+        let err = parse_binary_header_impl(
+            &data,
+            &PROVER_FORMAT,
+            (PROVER_VERSION.0, min_minor),
+            "prover",
+        )
+        .unwrap_err();
+        assert!(err.contains("Incompatible prover format: minor version"));
+    }
+
+    #[test]
+    fn parse_binary_header_rejects_data_too_short() {
+        let too_short = vec![0_u8; HEADER_SIZE - 1];
+
+        let err = parse_binary_header_impl(&too_short, &PROVER_FORMAT, PROVER_VERSION, "prover")
+            .unwrap_err();
+        assert!(err.contains("prover data too short for binary format"));
+    }
+
+    #[test]
+    fn decompress_rejects_unknown_magic() {
+        let err = decompress_impl(b"\x01\x02\x03\x04").unwrap_err();
+        assert!(err.contains("Unknown compression format"));
+    }
+
+    #[test]
+    fn decompress_roundtrips_zstd_data() {
+        let payload = b"provekit-zstd-roundtrip";
+        let compressed = compress_to_vec(payload.as_slice(), CompressionLevel::Fastest);
+
+        assert_eq!(&compressed[..4], ZSTD_MAGIC.as_slice());
+
+        let decompressed = decompress_impl(&compressed).unwrap();
+        assert_eq!(decompressed, payload);
+    }
+
+    #[test]
+    fn decompress_roundtrips_xz_data() {
+        let payload = b"provekit-xz-roundtrip";
+        let mut compressed = Vec::new();
+        lzma_rs::xz_compress(&mut std::io::Cursor::new(payload), &mut compressed).unwrap();
+
+        assert_eq!(&compressed[..6], XZ_MAGIC.as_slice());
+
+        let decompressed = decompress_impl(&compressed).unwrap();
+        assert_eq!(decompressed, payload);
+    }
+}

--- a/tooling/provekit-wasm/src/lib.rs
+++ b/tooling/provekit-wasm/src/lib.rs
@@ -1,0 +1,32 @@
+//! WebAssembly bindings for ProveKit.
+//!
+//! # Example
+//!
+//! ```javascript
+//! import { initPanicHook, initThreadPool, Prover } from "./pkg/provekit_wasm.js";
+//!
+//! // Initialize panic hook and thread pool
+//! initPanicHook();
+//! await initThreadPool(navigator.hardwareConcurrency);
+//!
+//! // Load prover artifact (.pkp file — same as native CLI uses)
+//! const proverBin = new Uint8Array(await (await fetch("/prover.pkp")).arrayBuffer());
+//! const prover = new Prover(proverBin);
+//!
+//! // Extract circuit for noir_js witness generation
+//! const circuitJson = JSON.parse(new TextDecoder().decode(prover.getCircuit()));
+//! const noir = new Noir(circuitJson);
+//! const { witness } = await noir.execute(inputs);
+//! const proof = prover.proveBytes(decompressWitness(witness)[0].witness);
+//! ```
+
+mod format;
+mod prover;
+mod verifier;
+
+pub use wasm_bindgen_rayon::init_thread_pool;
+
+#[wasm_bindgen::prelude::wasm_bindgen(js_name = initPanicHook)]
+pub fn init_panic_hook() {
+    console_error_panic_hook::set_once();
+}

--- a/tooling/provekit-wasm/src/prover.rs
+++ b/tooling/provekit-wasm/src/prover.rs
@@ -1,0 +1,277 @@
+use {
+    crate::format::parse_binary_prover,
+    acir::{
+        circuit::Program,
+        native_types::{Witness, WitnessMap},
+        AcirField, FieldElement,
+    },
+    anyhow::Context,
+    base64::{engine::general_purpose::STANDARD as BASE64, Engine as _},
+    provekit_common::{NoirElement, NoirProof, Prover as ProverCore},
+    provekit_prover::Prove,
+    std::{cell::RefCell, collections::BTreeMap},
+    wasm_bindgen::prelude::*,
+};
+
+/// WASM bindings for proof generation. Consumed after `proveBytes`/`proveJs`.
+#[wasm_bindgen]
+pub struct Prover {
+    inner: Option<ProverCore>,
+}
+
+#[wasm_bindgen]
+impl Prover {
+    #[wasm_bindgen(constructor)]
+    pub fn new(prover_data: &[u8]) -> Result<Prover, JsError> {
+        let is_binary = prover_data.len() >= crate::format::HEADER_SIZE
+            && &prover_data[..8] == crate::format::MAGIC_BYTES;
+
+        let inner = if is_binary {
+            parse_binary_prover(prover_data)?
+        } else {
+            serde_json::from_slice(prover_data).map_err(|err| {
+                JsError::new(&format!(
+                    "Failed to parse prover JSON: {err}. Data length: {}, first bytes: {:02X?}",
+                    prover_data.len(),
+                    &prover_data[..prover_data.len().min(20)]
+                ))
+            })?
+        };
+        Ok(Self { inner: Some(inner) })
+    }
+
+    /// `witness_map`: JS `Map<number, string>` or plain object `{ "0": "0xhex…"
+    /// }`.
+    #[wasm_bindgen(js_name = proveBytes)]
+    pub fn prove_bytes(&mut self, witness_map: JsValue) -> Result<Box<[u8]>, JsError> {
+        let proof = self.prove_inner(witness_map)?;
+        serde_json::to_vec(&proof)
+            .map(|bytes| bytes.into_boxed_slice())
+            .map_err(|err| JsError::new(&format!("Failed to serialize proof to JSON: {err}")))
+    }
+
+    #[wasm_bindgen(js_name = proveJs)]
+    pub fn prove_js(&mut self, witness_map: JsValue) -> Result<JsValue, JsError> {
+        let proof = self.prove_inner(witness_map)?;
+        serde_wasm_bindgen::to_value(&proof)
+            .map_err(|err| JsError::new(&format!("Failed to convert proof to JsValue: {err}")))
+    }
+
+    /// Returns circuit JSON for `@noir-lang/noir_js`.
+    ///
+    /// ```js
+    /// const prover = new Prover(pkpBytes);
+    /// const circuitJson = JSON.parse(new TextDecoder().decode(prover.getCircuit()));
+    /// const noir = new Noir(circuitJson);
+    /// ```
+    #[wasm_bindgen(js_name = getCircuit)]
+    pub fn get_circuit(&self) -> Result<Box<[u8]>, JsError> {
+        let prover = self.inner_ref()?;
+        let program_bytes = Program::<NoirElement>::serialize_program(&prover.program);
+        let bytecode_b64 = BASE64.encode(&program_bytes);
+
+        let abi_json = serde_json::to_value(&prover.witness_generator.abi)
+            .map_err(|e| JsError::new(&format!("Failed to serialize ABI: {e}")))?;
+
+        let circuit = serde_json::json!({
+            "abi": abi_json,
+            "bytecode": bytecode_b64,
+        });
+
+        serde_json::to_vec(&circuit)
+            .map(|b| b.into_boxed_slice())
+            .map_err(|e| JsError::new(&format!("Failed to serialize circuit JSON: {e}")))
+    }
+
+    #[wasm_bindgen(js_name = getNumConstraints)]
+    pub fn get_num_constraints(&self) -> Result<usize, JsError> {
+        Ok(self.inner_ref()?.size().0)
+    }
+
+    #[wasm_bindgen(js_name = getNumWitnesses)]
+    pub fn get_num_witnesses(&self) -> Result<usize, JsError> {
+        Ok(self.inner_ref()?.size().1)
+    }
+}
+
+impl Prover {
+    fn inner_ref(&self) -> Result<&ProverCore, JsError> {
+        self.inner
+            .as_ref()
+            .ok_or_else(|| JsError::new("Prover has been consumed by a previous prove() call"))
+    }
+
+    fn prove_inner(&mut self, witness_map: JsValue) -> Result<NoirProof, JsError> {
+        let witness = parse_witness_map(witness_map)?;
+        let inner = self
+            .inner
+            .take()
+            .ok_or_else(|| JsError::new("Prover has been consumed by a previous prove() call"))?;
+        inner
+            .prove_with_witness(witness)
+            .context("Failed to generate proof")
+            .map_err(|err| JsError::new(&format!("{err:#}")))
+    }
+}
+
+/// Max byte length for a BN254 field element (32 bytes = 64 hex chars).
+pub(crate) const MAX_FIELD_ELEMENT_BYTES: usize = 32;
+
+/// Accepts a JS `Map<number|string, string>` or a plain object `{ "idx":
+/// "0xhex…" }`.
+pub(crate) fn parse_witness_map(js_value: JsValue) -> Result<WitnessMap<FieldElement>, JsError> {
+    let map: BTreeMap<String, String> = if js_value.is_instance_of::<js_sys::Map>() {
+        js_map_to_btree(&js_sys::Map::from(js_value))?
+    } else {
+        serde_wasm_bindgen::from_value(js_value).map_err(|err| {
+            JsError::new(&format!(
+                "Expected a Map or plain object mapping witness indices to hex strings: {err}"
+            ))
+        })?
+    };
+
+    parse_witness_map_entries(map)
+}
+
+fn parse_witness_map_entries(
+    map: BTreeMap<String, String>,
+) -> Result<WitnessMap<FieldElement>, JsError> {
+    parse_witness_map_entries_impl(map).map_err(|msg| JsError::new(&msg))
+}
+
+fn parse_witness_map_entries_impl(
+    map: BTreeMap<String, String>,
+) -> Result<WitnessMap<FieldElement>, String> {
+    if map.is_empty() {
+        return Err("Witness map is empty".to_owned());
+    }
+
+    let mut witness_map = WitnessMap::new();
+
+    for (index_str, hex_value) in map {
+        let index: u32 = index_str
+            .parse()
+            .map_err(|err| format!("Failed to parse witness index '{index_str}': {err}"))?;
+
+        let hex_str = hex_value.trim_start_matches("0x");
+
+        let bytes = hex::decode(hex_str)
+            .map_err(|err| format!("Failed to parse hex string at index {index}: {err}"))?;
+
+        if bytes.len() > MAX_FIELD_ELEMENT_BYTES {
+            return Err(format!(
+                "Hex value at index {index} is {} bytes, exceeds BN254 field element size (32 \
+                 bytes)",
+                bytes.len()
+            ));
+        }
+
+        let field_element = FieldElement::from_be_bytes_reduce(&bytes);
+        witness_map.insert(Witness(index), field_element);
+    }
+
+    Ok(witness_map)
+}
+
+/// Converts a JS `Map` to `BTreeMap<String, String>`, handling numeric and
+/// string keys and Witness objects with an `inner` property.
+fn js_map_to_btree(map: &js_sys::Map) -> Result<BTreeMap<String, String>, JsError> {
+    let mut result = BTreeMap::new();
+    let err: RefCell<Option<String>> = RefCell::new(None);
+
+    map.for_each(&mut |value: JsValue, key: JsValue| {
+        if err.borrow().is_some() {
+            return;
+        }
+
+        let key_str = if let Some(n) = key.as_f64() {
+            (n as u32).to_string()
+        } else if let Some(s) = key.as_string() {
+            s
+        } else if let Ok(inner) = js_sys::Reflect::get(&key, &"inner".into()) {
+            if let Some(n) = inner.as_f64() {
+                (n as u32).to_string()
+            } else {
+                *err.borrow_mut() = Some(format!("Map key has non-numeric .inner property"));
+                return;
+            }
+        } else {
+            *err.borrow_mut() = Some(format!("Unsupported Map key type"));
+            return;
+        };
+
+        let val_str = match value.as_string() {
+            Some(s) => s,
+            None => {
+                *err.borrow_mut() = Some(format!("Map value at key {key_str} is not a string"));
+                return;
+            }
+        };
+
+        result.insert(key_str, val_str);
+    });
+
+    if let Some(msg) = err.into_inner() {
+        return Err(JsError::new(&msg));
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn witness_map_from_pairs(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn max_field_element_bytes_is_32() {
+        assert_eq!(MAX_FIELD_ELEMENT_BYTES, 32);
+    }
+
+    #[test]
+    fn parse_witness_map_entries_parses_valid_hex_values() {
+        let input = witness_map_from_pairs(&[("1", "0x01"), ("2", "ff")]);
+
+        let parsed = parse_witness_map_entries(input).unwrap();
+
+        assert_eq!(parsed.get(&Witness(1)), Some(&FieldElement::from(1_u128)));
+        assert_eq!(parsed.get(&Witness(2)), Some(&FieldElement::from(255_u128)));
+    }
+
+    #[test]
+    fn parse_witness_map_entries_rejects_empty_map() {
+        let err = parse_witness_map_entries_impl(BTreeMap::new()).unwrap_err();
+        assert!(err.contains("Witness map is empty"));
+    }
+
+    #[test]
+    fn parse_witness_map_entries_rejects_invalid_index() {
+        let input = witness_map_from_pairs(&[("abc", "0x01")]);
+
+        let err = parse_witness_map_entries_impl(input).unwrap_err();
+        assert!(err.contains("Failed to parse witness index 'abc'"));
+    }
+
+    #[test]
+    fn parse_witness_map_entries_rejects_invalid_hex() {
+        let input = witness_map_from_pairs(&[("1", "0xzz")]);
+
+        let err = parse_witness_map_entries_impl(input).unwrap_err();
+        assert!(err.contains("Failed to parse hex string at index 1"));
+    }
+
+    #[test]
+    fn parse_witness_map_entries_rejects_too_many_bytes() {
+        let too_long_hex = format!("0x{}", "11".repeat(MAX_FIELD_ELEMENT_BYTES + 1));
+        let mut input = BTreeMap::new();
+        input.insert("5".to_owned(), too_long_hex);
+
+        let err = parse_witness_map_entries_impl(input).unwrap_err();
+        assert!(err.contains("exceeds BN254 field element size (32 bytes)"));
+    }
+}

--- a/tooling/provekit-wasm/src/verifier.rs
+++ b/tooling/provekit-wasm/src/verifier.rs
@@ -1,0 +1,58 @@
+use {
+    crate::format::parse_binary_verifier,
+    provekit_common::{NoirProof, Verifier as VerifierCore},
+    provekit_verifier::Verify,
+    wasm_bindgen::prelude::*,
+};
+
+/// WASM bindings for proof verification. Reusable across multiple proofs.
+#[wasm_bindgen]
+pub struct Verifier {
+    inner: VerifierCore,
+}
+
+#[wasm_bindgen]
+impl Verifier {
+    /// Creates a new verifier from a `.pkv` verifier artifact.
+    #[wasm_bindgen(constructor)]
+    pub fn new(verifier_data: &[u8]) -> Result<Verifier, JsError> {
+        let is_binary = verifier_data.len() >= crate::format::HEADER_SIZE
+            && &verifier_data[..8] == crate::format::MAGIC_BYTES;
+
+        let inner = if is_binary {
+            parse_binary_verifier(verifier_data)?
+        } else {
+            serde_json::from_slice(verifier_data)
+                .map_err(|err| JsError::new(&format!("Failed to parse verifier JSON: {err}")))?
+        };
+        Ok(Self { inner })
+    }
+
+    /// Verifies a proof provided as JSON bytes. The verifier is **not**
+    /// consumed.
+    #[wasm_bindgen(js_name = verifyBytes)]
+    pub fn verify_bytes(&self, proof_json: &[u8]) -> Result<(), JsError> {
+        let proof: NoirProof = serde_json::from_slice(proof_json)
+            .map_err(|err| JsError::new(&format!("Failed to parse proof JSON: {err}")))?;
+        self.verify_proof(&proof)
+    }
+
+    /// Verifies a proof provided as a JavaScript object. The verifier is
+    /// **not** consumed.
+    #[wasm_bindgen(js_name = verifyJs)]
+    pub fn verify_js(&self, proof: JsValue) -> Result<(), JsError> {
+        let proof: NoirProof = serde_wasm_bindgen::from_value(proof)
+            .map_err(|err| JsError::new(&format!("Failed to parse proof: {err}")))?;
+        self.verify_proof(&proof)
+    }
+}
+
+impl Verifier {
+    fn verify_proof(&self, proof: &NoirProof) -> Result<(), JsError> {
+        // Clone so the core verifier's .take() consumption doesn't prevent reuse.
+        let mut verifier = self.inner.clone();
+        verifier
+            .verify(proof)
+            .map_err(|err| JsError::new(&format!("{err:#}")))
+    }
+}


### PR DESCRIPTION
## What changed

- Added the `tooling/provekit-wasm` crate from `main` to the `v1` workspace.
- Wired the wasm crate into the workspace manifest and lockfile.
- Added the `wasm32-unknown-unknown` rustflags required by `wasm-bindgen-rayon`.
- Adapted the copied wasm bindings for `v1` artifacts: `v1` uses a 20-byte binary header and has `Prover` as a struct rather than the newer `main` enum shape.

## Why

This brings the wasm tooling crate onto the `v1` branch while keeping the implementation scoped to the wasm package and the build configuration it needs.

## Validation

- `cargo fmt --all --check`
- `cargo check -p provekit-wasm --target wasm32-unknown-unknown -Z build-std=panic_abort,std`
- `cargo test -p provekit-wasm --lib` (15 passed)

The focused checks pass. The build still reports existing warnings from the v1 verifier `FinalClaim` handling and the expected unstable wasm atomics target-feature warning.