### PR TITLE
perf(prover): run the first sumcheck round in the base field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -2518,6 +2519,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90807d610575744524d9bdc69f3885d96f0e6c3354565b0828354a7ff2a262b8"
+dependencies = [
+ "ahash",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,6 +3710,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4506,11 +4533,15 @@ dependencies = [
  "anyhow",
  "ark-ff",
  "ark-std",
+ "inferno",
  "provekit-backend-bn254",
  "provekit-backend-goldilocks",
  "provekit-common",
  "provekit-prover",
  "provekit-verifier",
+ "tracing",
+ "tracing-flame",
+ "tracing-subscriber",
  "whir",
 ]
 
@@ -4604,6 +4635,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quickcheck"
@@ -4988,6 +5028,15 @@ checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
 dependencies = [
  "ctutils",
  "hmac",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -5902,6 +5951,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6472,6 +6527,17 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ chrono = "0.4.41"
 # This is a workaround because different package selection based on target does not mix well with workspace dependencies.
 divan = "0.1.21"
 hex = "0.4.3"
+inferno = { version = "0.12", default-features = false }
 itertools = "0.14.0"
 num-bigint = "0.4"
 paste = "1.0.15"
@@ -153,6 +154,7 @@ tokio-util = "0.7.13"
 tower = "0.5.2"
 tower-http = { version = "0.6.6", features = ["cors", "timeout", "trace"] }
 tracing = "0.1.41"
+tracing-flame = "0.2"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "ansi"] }
 tracing-tracy = "=0.11.4"
 tracy-client = "=0.18.0"

--- a/provekit/backend/bn254/src/mavros_prove.rs
+++ b/provekit/backend/bn254/src/mavros_prove.rs
@@ -18,7 +18,7 @@ use {
     },
     provekit_prover::{prove_from_alphas, run_zk_sumcheck_prover, WhirR1CSCommitment},
     tracing::instrument,
-    whir::transcript::ProverState,
+    whir::{algebra::embedding::Identity, transcript::ProverState},
 };
 
 pub trait MavrosR1CSProver {
@@ -53,13 +53,11 @@ impl MavrosR1CSProver for WhirR1CSScheme<Bn254Field> {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("c1 must carry blinding state"))?;
 
-        let [a, b, c] = [witgen.out_a, witgen.out_b, witgen.out_c];
         // `g` is committed separately in the extension field; open `blinding_eval`
         // against the blinding vector (g flattened at offset 0).
         let (alpha, blinding_eval) = run_zk_sumcheck_prover(
-            a,
-            b,
-            c,
+            &Identity::new(),
+            [witgen.out_a, witgen.out_b, witgen.out_c],
             &mut merlin,
             self.m_0,
             &blinding.polynomial,

--- a/provekit/common/src/utils/sumcheck.rs
+++ b/provekit/common/src/utils/sumcheck.rs
@@ -5,6 +5,7 @@ use {
         R1CS,
     },
     ark_ff::Field,
+    rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     std::array,
     tracing::instrument,
     whir::algebra::embedding::Embedding,
@@ -100,6 +101,73 @@ fn sumcheck_fold_map_reduce_inner<const N: usize, const M: usize, F: Field>(
         }
         result
     }
+}
+
+/// Compute the sum of a vector valued function over the boolean hypercube in
+/// the leading variable, with base-field `mles` against an extension-field
+/// `ext_mle`.
+pub fn mixed_sumcheck_map_reduce<const N: usize, const M: usize, F: Field, G: Field>(
+    mles: [&[F]; N],
+    ext_mle: &[G],
+    map: impl Fn([(F, F); N], (G, G)) -> [G; M] + Send + Sync + Copy,
+) -> [G; M] {
+    let size = ext_mle.len();
+    assert!(size.is_power_of_two());
+    assert!(size >= 2);
+    assert!(mles.iter().all(|mle| mle.len() == size));
+
+    let mles = mles.map(|mle| mle.split_at(size / 2));
+    mixed_map_reduce_inner::<N, M, F, G>(mles, ext_mle.split_at(size / 2), map)
+}
+
+fn mixed_map_reduce_inner<const N: usize, const M: usize, F: Field, G: Field>(
+    mles: [(&[F], &[F]); N],
+    ext_mle: (&[G], &[G]),
+    map: impl Fn([(F, F); N], (G, G)) -> [G; M] + Send + Sync + Copy,
+) -> [G; M] {
+    let size = ext_mle.0.len();
+    if size * (N + 1) * 2 > workload_size::<G>() {
+        // Split slices
+        let pairs = mles.map(|(p0, p1)| (p0.split_at(size / 2), p1.split_at(size / 2)));
+        let left = pairs.map(|((l0, _), (l1, _))| (l0, l1));
+        let right = pairs.map(|((_, r0), (_, r1))| (r0, r1));
+        let (ext_p0, ext_p1) = (ext_mle.0.split_at(size / 2), ext_mle.1.split_at(size / 2));
+
+        // Parallel recurse
+        let (l, r) = rayon::join(
+            || mixed_map_reduce_inner(left, (ext_p0.0, ext_p1.0), map),
+            || mixed_map_reduce_inner(right, (ext_p0.1, ext_p1.1), map),
+        );
+
+        // Combine results
+        array::from_fn(|i| l[i] + r[i])
+    } else {
+        let mut result = [G::zero(); M];
+        for i in 0..size {
+            let e = mles.map(|(p0, p1)| (p0[i], p1[i]));
+            let local = map(e, (ext_mle.0[i], ext_mle.1[i]));
+            result.iter_mut().zip(local).for_each(|(r, l)| *r += l);
+        }
+        result
+    }
+}
+
+/// Fold the leading variable of a base-field mle at an extension-field point,
+/// lifting it into the extension: `out[i] = mle[i] + point * (mle[i + n/2] -
+/// mle[i])`.
+pub fn mixed_fold<M: Embedding>(
+    embedding: &M,
+    mle: &[M::Source],
+    point: M::Target,
+) -> Vec<M::Target> {
+    assert!(mle.len().is_power_of_two());
+    assert!(mle.len() >= 2);
+    let (p0, p1) = mle.split_at(mle.len() / 2);
+    p0.par_iter()
+        .zip(p1.par_iter())
+        .with_min_len(workload_size::<M::Target>())
+        .map(|(&e0, &e1)| embedding.mixed_add(embedding.mixed_mul(point, e1 - e0), e0))
+        .collect()
 }
 
 /// List of evaluations for eq(r, x) over the boolean hypercube, truncated to
@@ -230,7 +298,10 @@ mod tests {
     use {
         super::*,
         ark_std::{One, Zero},
-        whir::algebra::fields::Field64 as FieldElement,
+        whir::algebra::{
+            embedding::{Basefield, Identity},
+            fields::{Field64 as FieldElement, Field64_3},
+        },
     };
 
     fn fe(v: i64) -> FieldElement {
@@ -239,6 +310,10 @@ mod tests {
         } else {
             FieldElement::from(0u64) - FieldElement::from((-v) as u64)
         }
+    }
+
+    fn fe3(a: i64, b: i64, c: i64) -> Field64_3 {
+        Field64_3::from_base_prime_field_elems(vec![fe(a), fe(b), fe(c)]).unwrap()
     }
 
     /// Build a small 3×4 R1CS for matrix tests.
@@ -358,6 +433,131 @@ mod tests {
         let r = [fe(2), fe(3)];
         let result = calculate_evaluations_over_boolean_hypercube_for_eq(&r, 1);
         assert_eq!(result, vec![calculate_eq(&r, &[fe(0), fe(0)])]);
+    }
+
+    // mixed_sumcheck_map_reduce / mixed_fold
+
+    /// The cubic sumcheck round evaluations, base mles against ext eq.
+    fn mixed_round_map(
+        embedding: &Basefield<Field64_3>,
+        [a, b, c]: [(FieldElement, FieldElement); 3],
+        eq: (Field64_3, Field64_3),
+    ) -> [Field64_3; 3] {
+        let f0 = embedding.mixed_mul(eq.0, a.0 * b.0 - c.0);
+        let f_em1 = embedding.mixed_mul(
+            eq.0 + eq.0 - eq.1,
+            (a.0 + a.0 - a.1) * (b.0 + b.0 - b.1) - (c.0 + c.0 - c.1),
+        );
+        let f_inf = embedding.mixed_mul(eq.1 - eq.0, (a.1 - a.0) * (b.1 - b.0));
+        [f0, f_em1, f_inf]
+    }
+
+    /// The same round evaluations, everything lifted to the extension.
+    fn ext_round_map([a, b, c, eq]: [(Field64_3, Field64_3); 4]) -> [Field64_3; 3] {
+        let f0 = eq.0 * (a.0 * b.0 - c.0);
+        let f_em1 =
+            (eq.0 + eq.0 - eq.1) * ((a.0 + a.0 - a.1) * (b.0 + b.0 - b.1) - (c.0 + c.0 - c.1));
+        let f_inf = (eq.1 - eq.0) * (a.1 - a.0) * (b.1 - b.0);
+        [f0, f_em1, f_inf]
+    }
+
+    fn mixed_test_mles(n: usize) -> ([Vec<FieldElement>; 3], Vec<Field64_3>) {
+        let a = (0..n).map(|i| fe(i as i64 + 1)).collect();
+        let b = (0..n).map(|i| fe(2 * i as i64 + 3)).collect();
+        let c = (0..n).map(|i| fe(7 * i as i64 + 5)).collect();
+        let eq = (0..n)
+            .map(|i| fe3(i as i64 + 2, 3 * i as i64 + 1, i as i64))
+            .collect();
+        ([a, b, c], eq)
+    }
+
+    #[test]
+    fn test_mixed_map_reduce_matches_lifted() {
+        let embedding = Basefield::<Field64_3>::new();
+        let ([a, b, c], eq) = mixed_test_mles(16);
+
+        let mixed = mixed_sumcheck_map_reduce([&a[..], &b[..], &c[..]], &eq, |mles, eq| {
+            mixed_round_map(&embedding, mles, eq)
+        });
+
+        let (mut la, mut lb, mut lc, mut leq) = (
+            embedding.map_vec(a),
+            embedding.map_vec(b),
+            embedding.map_vec(c),
+            eq,
+        );
+        let lifted =
+            sumcheck_fold_map_reduce([&mut la, &mut lb, &mut lc, &mut leq], None, ext_round_map);
+
+        assert_eq!(mixed, lifted);
+    }
+
+    #[test]
+    fn test_mixed_fold_matches_lifted() {
+        let embedding = Basefield::<Field64_3>::new();
+        let n = 8;
+        let mle: Vec<FieldElement> = (0..n).map(|i| fe(3 * i as i64 + 2)).collect();
+        let point = fe3(5, 7, 11);
+
+        let folded = mixed_fold(&embedding, &mle, point);
+
+        let lifted = embedding.map_vec(mle);
+        let (p0, p1) = lifted.split_at(n / 2);
+        let expected: Vec<Field64_3> = p0
+            .iter()
+            .zip(p1)
+            .map(|(&l, &h)| l + point * (h - l))
+            .collect();
+        assert_eq!(folded, expected);
+    }
+
+    #[test]
+    fn test_mixed_fold_identity() {
+        let n = 4;
+        let mle: Vec<Field64_3> = (0..n)
+            .map(|i| fe3(i as i64 + 1, i as i64, 2 * i as i64))
+            .collect();
+        let point = fe3(9, 4, 6);
+
+        let folded = mixed_fold(&Identity::new(), &mle, point);
+
+        let expected: Vec<Field64_3> = (0..n / 2)
+            .map(|i| mle[i] + point * (mle[i + n / 2] - mle[i]))
+            .collect();
+        assert_eq!(folded, expected);
+    }
+
+    /// Explicit `mixed_fold` + fold-free round must match the fused in-place
+    /// fold inside `sumcheck_fold_map_reduce` — the parity the prover's
+    /// base-field first round relies on.
+    #[test]
+    fn test_explicit_mixed_fold_matches_fused_fold() {
+        let embedding = Basefield::<Field64_3>::new();
+        let ([a, b, c], eq) = mixed_test_mles(8);
+        let alpha = fe3(3, 8, 2);
+
+        let (mut la, mut lb, mut lc, mut leq) = (
+            embedding.map_vec(a.clone()),
+            embedding.map_vec(b.clone()),
+            embedding.map_vec(c.clone()),
+            eq.clone(),
+        );
+        let fused = sumcheck_fold_map_reduce(
+            [&mut la, &mut lb, &mut lc, &mut leq],
+            Some(alpha),
+            ext_round_map,
+        );
+
+        let (mut fa, mut fb, mut fc, mut feq) = (
+            mixed_fold(&embedding, &a, alpha),
+            mixed_fold(&embedding, &b, alpha),
+            mixed_fold(&embedding, &c, alpha),
+            mixed_fold(&Identity::new(), &eq, alpha),
+        );
+        let explicit =
+            sumcheck_fold_map_reduce([&mut fa, &mut fb, &mut fc, &mut feq], None, ext_round_map);
+
+        assert_eq!(fused, explicit);
     }
 
     /// transpose_r1cs_matrices

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -1,7 +1,7 @@
 use {
     ::tracing::instrument,
     anyhow::{ensure, Result},
-    ark_ff::Field,
+    ark_ff::{Field, One},
     ark_std::{
         rand::distributions::{Distribution, Standard},
         Zero,
@@ -525,6 +525,10 @@ where
     // Prove that sum of F + ρ·G over the boolean hypercube equals ρ·Σ(G).
     let mut saved_val_for_sumcheck_equality_assertion = rho * sum_g_reduce;
 
+    // 2 is invertible in any field of odd characteristic; precompute 1/2 once
+    // and reuse it for each round's cubic-coefficient solve.
+    let half = M::Target::one() / (M::Target::one() + M::Target::one());
+
     // First round: a, b, c are base-field, so the constraint products stay in
     // the base field with one mixed mul per point against the ext eq.
     let hhat = mixed_sumcheck_map_reduce([&a[..], &b[..], &c[..]], &eq, |[a, b, c], eq| {
@@ -543,6 +547,7 @@ where
         hhat,
         g_poly,
         rho,
+        half,
         saved_val_for_sumcheck_equality_assertion,
     );
     saved_val_for_sumcheck_equality_assertion = saved_val;
@@ -582,6 +587,7 @@ where
             hhat,
             g_poly,
             rho,
+            half,
             saved_val_for_sumcheck_equality_assertion,
         );
         saved_val_for_sumcheck_equality_assertion = saved_val;
@@ -606,6 +612,7 @@ fn combined_round_message<F: Field + Codec, S: DuplexSpongeInterface<U = u8>>(
     hhat: [F; 3],
     g_poly: [F; 4],
     rho: F,
+    half: F,
     saved_val_for_sumcheck_equality_assertion: F,
 ) -> (F, F) {
     let [hhat_i_at_0, hhat_i_at_em1, hhat_i_at_inf_over_x_cube] = hhat;
@@ -617,12 +624,11 @@ fn combined_round_message<F: Field + Codec, S: DuplexSpongeInterface<U = u8>>(
     let g_at_minus_one = g_poly[0] - g_poly[1] + g_poly[2] - g_poly[3];
     let combined_at_em1 = hhat_i_at_em1 + rho * g_at_minus_one;
 
-    let two = F::one() + F::one();
     combined_hhat_i_coeffs[2] = (saved_val_for_sumcheck_equality_assertion + combined_at_em1
         - combined_hhat_i_coeffs[0]
         - combined_hhat_i_coeffs[0]
         - combined_hhat_i_coeffs[0])
-        / two;
+        * half;
 
     combined_hhat_i_coeffs[3] = hhat_i_at_inf_over_x_cube + rho * g_poly[3];
 

--- a/provekit/prover/src/whir_r1cs.rs
+++ b/provekit/prover/src/whir_r1cs.rs
@@ -16,8 +16,8 @@ use {
             pad_to_power_of_two,
             sumcheck::{
                 calculate_evaluations_over_boolean_hypercube_for_eq, calculate_witness_bounds,
-                eval_cubic_poly, multiply_transposed_by_eq_alpha, sumcheck_fold_map_reduce,
-                transpose_r1cs_matrices,
+                eval_cubic_poly, mixed_fold, mixed_sumcheck_map_reduce,
+                multiply_transposed_by_eq_alpha, sumcheck_fold_map_reduce, transpose_r1cs_matrices,
             },
         },
         Base, Ext, FieldHash, PrefixCovector, ProofField, PublicInputs, WhirR1CSProof,
@@ -156,28 +156,21 @@ where
         let (a, b, c) = calculate_witness_bounds(&r1cs, &full_witness);
         drop(full_witness);
 
-        // Witness bounds are computed in the base field; lift them to the
-        // extension for the sumcheck (a no-op under the `Identity` embedding,
-        // where base == ext).
         let embedding = <P::Embedding>::default();
-        let (a, b, c) = (
-            embedding.map_vec(a),
-            embedding.map_vec(b),
-            embedding.map_vec(c),
-        );
 
         let blinding = commitments[0]
             .blinding
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("c1 must carry blinding state"))?;
 
-        // The Spartan sumcheck runs entirely in the extension field; `g` is
-        // native ext, committed separately. `blinding_eval` opens the ext
-        // blinding vector (which holds `g` flattened at offset 0).
+        // The witness bounds stay in the base field for the first sumcheck
+        // round; the fold at the first challenge lifts them into the
+        // extension. `g` is native ext, committed separately; `blinding_eval`
+        // opens the ext blinding vector (which holds `g` flattened at
+        // offset 0).
         let (alpha, blinding_eval) = run_zk_sumcheck_prover(
-            a,
-            b,
-            c,
+            &embedding,
+            [a, b, c],
             &mut merlin,
             self.m_0,
             &blinding.polynomial,
@@ -495,17 +488,25 @@ pub fn pad_to_pow2_len_min2<F: Field>(v: &mut Vec<F>) {
     }
 }
 
+/// Run the blinded Spartan sumcheck. The first round consumes the base-field
+/// mles directly; the fold at the first challenge lifts them into the
+/// extension, where the remaining rounds run.
 #[instrument(skip_all)]
-pub fn run_zk_sumcheck_prover<F: Field + Codec, S: DuplexSpongeInterface<U = u8>>(
-    mut a: Vec<F>,
-    mut b: Vec<F>,
-    mut c: Vec<F>,
+pub fn run_zk_sumcheck_prover<M, S>(
+    embedding: &M,
+    mles: [Vec<M::Source>; 3],
     merlin: &mut ProverState<S>,
     m_0: usize,
-    blinding_polynomial: &[[F; 4]],
-    blinding_vector: &[F],
-) -> (Vec<F>, F) {
-    let r: Vec<F> = merlin.verifier_message_vec(m_0);
+    blinding_polynomial: &[[M::Target; 4]],
+    blinding_vector: &[M::Target],
+) -> (Vec<M::Target>, M::Target)
+where
+    M: Embedding,
+    M::Target: Codec,
+    S: DuplexSpongeInterface<U = u8>,
+{
+    let [mut a, mut b, mut c] = mles;
+    let r: Vec<M::Target> = merlin.verifier_message_vec(m_0);
     let mut eq = calculate_evaluations_over_boolean_hypercube_for_eq(&r, 1 << r.len());
 
     pad_to_pow2_len_min2(&mut a);
@@ -513,26 +514,52 @@ pub fn run_zk_sumcheck_prover<F: Field + Codec, S: DuplexSpongeInterface<U = u8>
     pad_to_pow2_len_min2(&mut c);
     pad_to_pow2_len_min2(&mut eq);
 
-    let mut alpha = Vec::<F>::with_capacity(m_0);
+    let mut alpha = Vec::<M::Target>::with_capacity(m_0);
 
     let sum_g_reduce = sum_over_hypercube(blinding_polynomial);
 
     merlin.prover_message(&sum_g_reduce);
 
-    let rho: F = merlin.verifier_message();
+    let rho: M::Target = merlin.verifier_message();
 
     // Prove that sum of F + ρ·G over the boolean hypercube equals ρ·Σ(G).
     let mut saved_val_for_sumcheck_equality_assertion = rho * sum_g_reduce;
 
+    // First round: a, b, c are base-field, so the constraint products stay in
+    // the base field with one mixed mul per point against the ext eq.
+    let hhat = mixed_sumcheck_map_reduce([&a[..], &b[..], &c[..]], &eq, |[a, b, c], eq| {
+        let f0 = embedding.mixed_mul(eq.0, a.0 * b.0 - c.0);
+        let f_em1 = embedding.mixed_mul(
+            eq.0 + eq.0 - eq.1,
+            (a.0 + a.0 - a.1) * (b.0 + b.0 - b.1) - (c.0 + c.0 - c.1),
+        );
+        let f_inf = embedding.mixed_mul(eq.1 - eq.0, (a.1 - a.0) * (b.1 - b.0));
+
+        [f0, f_em1, f_inf]
+    });
+    let g_poly = compute_blinding_coefficients_for_round(blinding_polynomial, 0, &[]);
+    let (alpha_0, saved_val) = combined_round_message(
+        merlin,
+        hhat,
+        g_poly,
+        rho,
+        saved_val_for_sumcheck_equality_assertion,
+    );
+    saved_val_for_sumcheck_equality_assertion = saved_val;
+    alpha.push(alpha_0);
+
+    // Fold at the first challenge, lifting the mles into the extension.
+    let folded_a = mixed_fold(embedding, &a, alpha_0);
+    let folded_b = mixed_fold(embedding, &b, alpha_0);
+    let folded_c = mixed_fold(embedding, &c, alpha_0);
+    let folded_eq = mixed_fold(&Identity::new(), &eq, alpha_0);
+    drop((a, b, c, eq));
+    let (mut a, mut b, mut c, mut eq) = (folded_a, folded_b, folded_c, folded_eq);
+
     let mut fold = None;
 
-    // 2 is invertible in any field of odd characteristic.
-    let half = (F::one() + F::one())
-        .inverse()
-        .expect("field characteristic is not 2");
-
-    for idx in 0..m_0 {
-        let [hhat_i_at_0, hhat_i_at_em1, hhat_i_at_inf_over_x_cube] =
+    for idx in 1..m_0 {
+        let hhat =
             sumcheck_fold_map_reduce([&mut a, &mut b, &mut c, &mut eq], fold, |[a, b, c, eq]| {
                 let f0 = eq.0 * (a.0 * b.0 - c.0);
                 let f_em1 = (eq.0 + eq.0 - eq.1)
@@ -550,47 +577,17 @@ pub fn run_zk_sumcheck_prover<F: Field + Codec, S: DuplexSpongeInterface<U = u8>
 
         let g_poly =
             compute_blinding_coefficients_for_round(blinding_polynomial, idx, alpha.as_slice());
-
-        let mut combined_hhat_i_coeffs = [F::zero(); 4];
-
-        combined_hhat_i_coeffs[0] = hhat_i_at_0 + rho * g_poly[0];
-
-        let g_at_minus_one = g_poly[0] - g_poly[1] + g_poly[2] - g_poly[3];
-        let combined_at_em1 = hhat_i_at_em1 + rho * g_at_minus_one;
-
-        combined_hhat_i_coeffs[2] = (saved_val_for_sumcheck_equality_assertion + combined_at_em1
-            - combined_hhat_i_coeffs[0]
-            - combined_hhat_i_coeffs[0]
-            - combined_hhat_i_coeffs[0])
-            * half;
-
-        combined_hhat_i_coeffs[3] = hhat_i_at_inf_over_x_cube + rho * g_poly[3];
-
-        combined_hhat_i_coeffs[1] = saved_val_for_sumcheck_equality_assertion
-            - combined_hhat_i_coeffs[0]
-            - combined_hhat_i_coeffs[0]
-            - combined_hhat_i_coeffs[3]
-            - combined_hhat_i_coeffs[2];
-
-        assert_eq!(
+        let (alpha_i, saved_val) = combined_round_message(
+            merlin,
+            hhat,
+            g_poly,
+            rho,
             saved_val_for_sumcheck_equality_assertion,
-            combined_hhat_i_coeffs[0]
-                + combined_hhat_i_coeffs[0]
-                + combined_hhat_i_coeffs[1]
-                + combined_hhat_i_coeffs[2]
-                + combined_hhat_i_coeffs[3]
         );
-
-        for coeff in &combined_hhat_i_coeffs {
-            merlin.prover_message(coeff);
-        }
-        let alpha_i: F = merlin.verifier_message();
+        saved_val_for_sumcheck_equality_assertion = saved_val;
         alpha.push(alpha_i);
 
         fold = Some(alpha_i);
-
-        saved_val_for_sumcheck_equality_assertion =
-            eval_cubic_poly(combined_hhat_i_coeffs, alpha_i);
     }
     drop((a, b, c, eq));
 
@@ -599,6 +596,57 @@ pub fn run_zk_sumcheck_prover<F: Field + Codec, S: DuplexSpongeInterface<U = u8>
     merlin.prover_message(&blinding_eval);
 
     (alpha, blinding_eval)
+}
+
+/// Absorb the combined round polynomial `hhat_i + ρ·g_i` into the transcript
+/// and draw the round challenge; returns it with the sumcheck equality value
+/// for the next round.
+fn combined_round_message<F: Field + Codec, S: DuplexSpongeInterface<U = u8>>(
+    merlin: &mut ProverState<S>,
+    hhat: [F; 3],
+    g_poly: [F; 4],
+    rho: F,
+    saved_val_for_sumcheck_equality_assertion: F,
+) -> (F, F) {
+    let [hhat_i_at_0, hhat_i_at_em1, hhat_i_at_inf_over_x_cube] = hhat;
+
+    let mut combined_hhat_i_coeffs = [F::zero(); 4];
+
+    combined_hhat_i_coeffs[0] = hhat_i_at_0 + rho * g_poly[0];
+
+    let g_at_minus_one = g_poly[0] - g_poly[1] + g_poly[2] - g_poly[3];
+    let combined_at_em1 = hhat_i_at_em1 + rho * g_at_minus_one;
+
+    let two = F::one() + F::one();
+    combined_hhat_i_coeffs[2] = (saved_val_for_sumcheck_equality_assertion + combined_at_em1
+        - combined_hhat_i_coeffs[0]
+        - combined_hhat_i_coeffs[0]
+        - combined_hhat_i_coeffs[0])
+        / two;
+
+    combined_hhat_i_coeffs[3] = hhat_i_at_inf_over_x_cube + rho * g_poly[3];
+
+    combined_hhat_i_coeffs[1] = saved_val_for_sumcheck_equality_assertion
+        - combined_hhat_i_coeffs[0]
+        - combined_hhat_i_coeffs[0]
+        - combined_hhat_i_coeffs[3]
+        - combined_hhat_i_coeffs[2];
+
+    assert_eq!(
+        saved_val_for_sumcheck_equality_assertion,
+        combined_hhat_i_coeffs[0]
+            + combined_hhat_i_coeffs[0]
+            + combined_hhat_i_coeffs[1]
+            + combined_hhat_i_coeffs[2]
+            + combined_hhat_i_coeffs[3]
+    );
+
+    for coeff in &combined_hhat_i_coeffs {
+        merlin.prover_message(coeff);
+    }
+    let alpha_i: F = merlin.verifier_message();
+
+    (alpha_i, eval_cubic_poly(combined_hhat_i_coeffs, alpha_i))
 }
 
 fn create_weights_and_evaluations<const N: usize, M: Embedding>(

--- a/tooling/provekit-fixtures/Cargo.toml
+++ b/tooling/provekit-fixtures/Cargo.toml
@@ -24,9 +24,9 @@ whir.workspace = true
 # Concrete proof fields to instantiate the generic harness.
 provekit-backend-bn254.workspace = true
 provekit-backend-goldilocks.workspace = true
-inferno = { version = "0.12", default-features = false }
+inferno.workspace = true
 tracing.workspace = true
-tracing-flame = "0.2"
+tracing-flame.workspace = true
 tracing-subscriber.workspace = true
 
 [lints]

--- a/tooling/provekit-fixtures/Cargo.toml
+++ b/tooling/provekit-fixtures/Cargo.toml
@@ -24,6 +24,10 @@ whir.workspace = true
 # Concrete proof fields to instantiate the generic harness.
 provekit-backend-bn254.workspace = true
 provekit-backend-goldilocks.workspace = true
+inferno = { version = "0.12", default-features = false }
+tracing.workspace = true
+tracing-flame = "0.2"
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/tooling/provekit-fixtures/src/harness.rs
+++ b/tooling/provekit-fixtures/src/harness.rs
@@ -287,3 +287,67 @@ where
     scheme.prove_noir(merlin, r1cs_owned, vec![c1, c2], full_witness, &public)?;
     Ok(start.elapsed())
 }
+
+/// Pre-built inputs for a timed single-commit prove, constructed outside the
+/// timer/flamegraph so scheme construction and the witness clones are not
+/// measured. Opaque: build with [`prove_setup`], consume with
+/// [`time_prove_core`].
+pub struct ProveInputs<P: FieldHash> {
+    scheme:         WhirR1CSScheme<P>,
+    r1cs:           R1CS<Base<P>>,
+    witness_commit: Vec<Base<P>>,
+    witness_prove:  Vec<Base<P>>,
+}
+
+/// Build the scheme and owned witness copies for a single-commit prove. Kept
+/// separate from [`time_prove_core`] so a profiler can install its subscriber
+/// between setup and the timed region (only the latter is captured).
+pub fn prove_setup<P>(r1cs: &R1CS<Base<P>>, witness: &[Base<P>]) -> ProveInputs<P>
+where
+    P: FieldHash,
+    Standard: Distribution<Ext<P>> + Distribution<Base<P>>,
+{
+    let scheme = WhirR1CSScheme::<P>::new_for_r1cs(r1cs, witness.len(), 0, Vec::new(), true, HASH);
+    ProveInputs {
+        scheme,
+        r1cs: r1cs.clone(),
+        witness_commit: witness.to_vec(),
+        witness_prove: witness.to_vec(),
+    }
+}
+
+/// Time the single-commit proving core — `commit` + `prove_noir` — from
+/// pre-built inputs, returning the elapsed time alongside the proof and scheme.
+pub fn time_prove_core<P>(
+    inp: ProveInputs<P>,
+    public_inputs: &PublicInputs<Base<P>>,
+) -> Result<(Duration, WhirR1CSProof, WhirR1CSScheme<P>)>
+where
+    P: FieldHash,
+    Standard: Distribution<Ext<P>> + Distribution<Base<P>>,
+{
+    let ProveInputs {
+        scheme,
+        r1cs,
+        witness_commit,
+        witness_prove,
+    } = inp;
+
+    // Transcript binding derives from the scheme; built before the timer starts.
+    let instance = public_inputs.hash_bytes::<P>(HASH);
+    let ds = scheme.create_domain_separator().instance(&instance);
+    let num_witnesses = r1cs.num_witnesses();
+    let num_constraints = r1cs.num_constraints();
+
+    let start = Instant::now();
+    let mut merlin = ProverState::new(&ds, P::transcript_sponge(HASH));
+    let commitment = scheme.commit(
+        &mut merlin,
+        num_witnesses,
+        num_constraints,
+        witness_commit,
+        true,
+    )?;
+    let proof = scheme.prove_noir(merlin, r1cs, vec![commitment], witness_prove, public_inputs)?;
+    Ok((start.elapsed(), proof, scheme))
+}

--- a/tooling/provekit-fixtures/tests/profile.rs
+++ b/tooling/provekit-fixtures/tests/profile.rs
@@ -12,100 +12,21 @@
 
 use {
     ark_std::rand::distributions::{Distribution, Standard},
-    provekit_common::{
-        Base, Ext, FieldHash, HashConfig, PublicInputs, PublicInputsHash, WhirR1CSProof,
-        WhirR1CSScheme, R1CS,
+    provekit_common::{Base, Ext, FieldHash, PublicInputs},
+    provekit_fixtures::{
+        builders::squaring_chain,
+        harness::{prove_setup, time_prove_core},
     },
-    provekit_fixtures::builders::squaring_chain,
-    provekit_prover::WhirR1CSProver,
     provekit_verifier::WhirR1CSVerifier,
     std::{
         collections::HashMap,
         path::PathBuf,
         time::{Duration, Instant},
     },
-    whir::transcript::ProverState,
 };
 
 /// Log2 witness sizes to sweep.
 const SIZES: [u32; 4] = [14, 16, 18, 20];
-
-/// Instance-binding hash for the probes (matches the harness default).
-const HASH: HashConfig = HashConfig::Sha256;
-
-/// Inputs for a single-commit prove, built outside the timer so scheme
-/// construction and the `commit`/`prove_noir` ownership copies aren't measured.
-struct ProveInputs<P: FieldHash> {
-    scheme:          WhirR1CSScheme<P>,
-    r1cs_owned:      R1CS<Base<P>>,
-    witness_commit:  Vec<Base<P>>,
-    witness_prove:   Vec<Base<P>>,
-    num_witnesses:   usize,
-    num_constraints: usize,
-}
-
-/// Build the scheme + ownership copies (excluded from the timer and
-/// flamegraph).
-fn prove_setup<P>(r1cs: &R1CS<Base<P>>, witness: &[Base<P>]) -> ProveInputs<P>
-where
-    P: FieldHash,
-    Standard: Distribution<Ext<P>> + Distribution<Base<P>>,
-{
-    let scheme = WhirR1CSScheme::<P>::new_for_r1cs(r1cs, witness.len(), 0, Vec::new(), true, HASH);
-    ProveInputs {
-        scheme,
-        r1cs_owned: r1cs.clone(),
-        witness_commit: witness.to_vec(),
-        witness_prove: witness.to_vec(),
-        num_witnesses: r1cs.num_witnesses(),
-        num_constraints: r1cs.num_constraints(),
-    }
-}
-
-/// Time the proving core — `commit` + `prove_noir` — from pre-built inputs.
-fn time_prove_core<P>(
-    inp: ProveInputs<P>,
-    public_inputs: &PublicInputs<Base<P>>,
-) -> (Duration, WhirR1CSProof, WhirR1CSScheme<P>)
-where
-    P: FieldHash,
-    Standard: Distribution<Ext<P>> + Distribution<Base<P>>,
-{
-    let ProveInputs {
-        scheme,
-        r1cs_owned,
-        witness_commit,
-        witness_prove,
-        num_witnesses,
-        num_constraints,
-    } = inp;
-
-    // Transcript binding derives from the scheme; built before the timer starts.
-    let instance = public_inputs.hash_bytes::<P>(HASH);
-    let ds = scheme.create_domain_separator().instance(&instance);
-
-    let start = Instant::now();
-    let mut merlin = ProverState::new(&ds, P::transcript_sponge(HASH));
-    let commitment = scheme
-        .commit(
-            &mut merlin,
-            num_witnesses,
-            num_constraints,
-            witness_commit,
-            true,
-        )
-        .expect("commit");
-    let proof = scheme
-        .prove_noir(
-            merlin,
-            r1cs_owned,
-            vec![commitment],
-            witness_prove,
-            public_inputs,
-        )
-        .expect("prove_noir");
-    (start.elapsed(), proof, scheme)
-}
 
 /// Build a `2^log_size`-witness squaring chain, prove, verify, and return
 /// `(prove, verify, narg_bytes, hints_bytes)`.
@@ -120,7 +41,7 @@ where
 
     // Only commit + prove_noir are timed (setup excluded above).
     let inp = prove_setup::<P>(&r1cs, &w);
-    let (prove_t, proof, scheme) = time_prove_core::<P>(inp, &public_inputs);
+    let (prove_t, proof, scheme) = time_prove_core::<P>(inp, &public_inputs).expect("prove");
 
     let t = Instant::now();
     scheme
@@ -187,13 +108,14 @@ fn size_sweep() {
     println!();
 }
 
-/// Repo `provekit/.claude/profile/` directory (created if absent).
+/// Workspace `target/profile/` directory (created if absent). Lives under the
+/// gitignored build dir so the artifacts are not committed and the probe is
+/// portable across machines.
 fn profile_dir() -> PathBuf {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
-        .join("provekit")
-        .join(".claude")
+        .join("target")
         .join("profile");
     std::fs::create_dir_all(&dir).expect("create profile dir");
     dir
@@ -230,7 +152,8 @@ fn flamegraph_2pow20_bf() {
 
     // Timed + captured: the true prove core only (setup/clones already done).
     let (prove_t, proof, _scheme) =
-        time_prove_core::<provekit_backend_goldilocks::GoldilocksField>(inp, &public_inputs);
+        time_prove_core::<provekit_backend_goldilocks::GoldilocksField>(inp, &public_inputs)
+            .expect("prove");
     println!(
         "\n[flamegraph] 2^20 goldilocks-BF prove={prove_t:.3?} narg={} hints={}",
         proof.narg_string.len(),

--- a/tooling/provekit-fixtures/tests/profile.rs
+++ b/tooling/provekit-fixtures/tests/profile.rs
@@ -1,0 +1,302 @@
+//! `#[ignore]` prover profiling harness.
+//!
+//! Two probes (run with `--release`):
+//!
+//! ```text
+//! # Size sweep: BF vs EF vs bn254 at 2^14..2^20
+//! cargo test -p provekit-fixtures --release --test profile size_sweep -- --ignored --nocapture
+//!
+//! # Flamegraph + stage breakdown for one 2^20 goldilocks-BF prove
+//! cargo test -p provekit-fixtures --release --test profile flamegraph_2pow20_bf -- --ignored --nocapture
+//! ```
+
+use {
+    ark_std::rand::distributions::{Distribution, Standard},
+    provekit_common::{
+        Base, Ext, FieldHash, HashConfig, PublicInputs, PublicInputsHash, WhirR1CSProof,
+        WhirR1CSScheme, R1CS,
+    },
+    provekit_fixtures::builders::squaring_chain,
+    provekit_prover::WhirR1CSProver,
+    provekit_verifier::WhirR1CSVerifier,
+    std::{
+        collections::HashMap,
+        path::PathBuf,
+        time::{Duration, Instant},
+    },
+    whir::transcript::ProverState,
+};
+
+/// Log2 witness sizes to sweep.
+const SIZES: [u32; 4] = [14, 16, 18, 20];
+
+/// Instance-binding hash for the probes (matches the harness default).
+const HASH: HashConfig = HashConfig::Sha256;
+
+/// Inputs for a single-commit prove, built outside the timer so scheme
+/// construction and the `commit`/`prove_noir` ownership copies aren't measured.
+struct ProveInputs<P: FieldHash> {
+    scheme:          WhirR1CSScheme<P>,
+    r1cs_owned:      R1CS<Base<P>>,
+    witness_commit:  Vec<Base<P>>,
+    witness_prove:   Vec<Base<P>>,
+    num_witnesses:   usize,
+    num_constraints: usize,
+}
+
+/// Build the scheme + ownership copies (excluded from the timer and flamegraph).
+fn prove_setup<P>(r1cs: &R1CS<Base<P>>, witness: &[Base<P>]) -> ProveInputs<P>
+where
+    P: FieldHash,
+    Standard: Distribution<Ext<P>> + Distribution<Base<P>>,
+{
+    let scheme = WhirR1CSScheme::<P>::new_for_r1cs(r1cs, witness.len(), 0, Vec::new(), true, HASH);
+    ProveInputs {
+        scheme,
+        r1cs_owned: r1cs.clone(),
+        witness_commit: witness.to_vec(),
+        witness_prove: witness.to_vec(),
+        num_witnesses: r1cs.num_witnesses(),
+        num_constraints: r1cs.num_constraints(),
+    }
+}
+
+/// Time the proving core — `commit` + `prove_noir` — from pre-built inputs.
+fn time_prove_core<P>(
+    inp: ProveInputs<P>,
+    public_inputs: &PublicInputs<Base<P>>,
+) -> (Duration, WhirR1CSProof, WhirR1CSScheme<P>)
+where
+    P: FieldHash,
+    Standard: Distribution<Ext<P>> + Distribution<Base<P>>,
+{
+    let ProveInputs {
+        scheme,
+        r1cs_owned,
+        witness_commit,
+        witness_prove,
+        num_witnesses,
+        num_constraints,
+    } = inp;
+
+    // Transcript binding derives from the scheme; built before the timer starts.
+    let instance = public_inputs.hash_bytes::<P>(HASH);
+    let ds = scheme.create_domain_separator().instance(&instance);
+
+    let start = Instant::now();
+    let mut merlin = ProverState::new(&ds, P::transcript_sponge(HASH));
+    let commitment = scheme
+        .commit(
+            &mut merlin,
+            num_witnesses,
+            num_constraints,
+            witness_commit,
+            true,
+        )
+        .expect("commit");
+    let proof = scheme
+        .prove_noir(
+            merlin,
+            r1cs_owned,
+            vec![commitment],
+            witness_prove,
+            public_inputs,
+        )
+        .expect("prove_noir");
+    (start.elapsed(), proof, scheme)
+}
+
+/// Build a `2^log_size`-witness squaring chain, prove, verify, and return
+/// `(prove, verify, narg_bytes, hints_bytes)`.
+fn run_one<P>(log_size: u32) -> (Duration, Duration, usize, usize)
+where
+    P: FieldHash,
+    Standard: Distribution<Ext<P>> + Distribution<Base<P>>,
+{
+    let depth = (1usize << log_size) - 2; // num_witnesses = depth + 2 = 2^log_size
+    let (r1cs, w) = squaring_chain::<Base<P>>(2, depth);
+    let public_inputs = PublicInputs::from_vec(vec![w[1]]);
+
+    // Only commit + prove_noir are timed (setup excluded above).
+    let inp = prove_setup::<P>(&r1cs, &w);
+    let (prove_t, proof, scheme) = time_prove_core::<P>(inp, &public_inputs);
+
+    let t = Instant::now();
+    scheme
+        .verify(&proof, &public_inputs, &r1cs)
+        .expect("verify");
+    let verify_t = t.elapsed();
+
+    (
+        prove_t,
+        verify_t,
+        proof.narg_string.len(),
+        proof.hints.len(),
+    )
+}
+
+/// Run one (field, size) cell and print its row immediately (so partial results
+/// survive a later OOM). Wrapped in `catch_unwind` so a panic in one cell does
+/// not abort the rest of the sweep.
+fn row<P>(label: &str, log_size: u32)
+where
+    P: FieldHash,
+    Standard: Distribution<Ext<P>> + Distribution<Base<P>>,
+{
+    let res = std::panic::catch_unwind(|| run_one::<P>(log_size));
+    match res {
+        Ok((p, v, narg, hints)) => println!(
+            "{:>5} | {:<13} | {:>10.3?} | {:>9.3?} | {:>8} | {:>9}",
+            format!("2^{log_size}"),
+            label,
+            p,
+            v,
+            narg,
+            hints
+        ),
+        Err(_) => println!(
+            "{:>5} | {:<13} | {:>10} | {:>9} | {:>8} | {:>9}",
+            format!("2^{log_size}"),
+            label,
+            "FAILED",
+            "-",
+            "-",
+            "-"
+        ),
+    }
+}
+
+#[test]
+#[ignore = "profiling probe; run --release -- --ignored --nocapture"]
+fn size_sweep() {
+    provekit_backend_goldilocks::register();
+    provekit_backend_bn254::register();
+
+    println!("\n size | field         |      prove |    verify |     narg |     hints");
+    println!("------+---------------+------------+-----------+----------+----------");
+    for &s in &SIZES {
+        row::<provekit_backend_goldilocks::GoldilocksField>("goldilocks-BF", s);
+    }
+    for &s in &SIZES {
+        row::<provekit_backend_goldilocks::GoldilocksEfField>("goldilocks-EF", s);
+    }
+    for &s in &SIZES {
+        row::<provekit_backend_bn254::Bn254Field>("bn254", s);
+    }
+    println!();
+}
+
+/// Repo `provekit/.claude/profile/` directory (created if absent).
+fn profile_dir() -> PathBuf {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("provekit")
+        .join(".claude")
+        .join("profile");
+    std::fs::create_dir_all(&dir).expect("create profile dir");
+    dir
+}
+
+#[test]
+#[ignore = "profiling probe; run --release -- --ignored --nocapture"]
+fn flamegraph_2pow20_bf() {
+    use {
+        tracing_flame::FlameLayer,
+        tracing_subscriber::{prelude::*, registry::Registry},
+    };
+
+    provekit_backend_goldilocks::register();
+
+    let dir = profile_dir();
+    let folded_path = dir.join("goldilocks_bf_2pow20.folded");
+    let svg_path = dir.join("goldilocks_bf_2pow20.svg");
+
+    // Fixture-gen + prove setup happen BEFORE the flame layer installs, so only
+    // the prove core (commit + prove_noir) is captured.
+    let log_size = 20u32;
+    let depth = (1usize << log_size) - 2;
+    let (r1cs, w) = squaring_chain::<Base<provekit_backend_goldilocks::GoldilocksField>>(2, depth);
+    let public_inputs = PublicInputs::from_vec(vec![w[1]]);
+    let inp = prove_setup::<provekit_backend_goldilocks::GoldilocksField>(&r1cs, &w);
+
+    // Global subscriber required: prove() uses rayon, and only the global
+    // default captures spans created on rayon worker threads.
+    let (flame_layer, guard) =
+        FlameLayer::with_file(&folded_path).expect("create flame layer file");
+    let subscriber = Registry::default().with(flame_layer);
+    tracing::subscriber::set_global_default(subscriber).expect("set global subscriber");
+
+    // Timed + captured: the true prove core only (setup/clones already done).
+    let (prove_t, proof, _scheme) =
+        time_prove_core::<provekit_backend_goldilocks::GoldilocksField>(inp, &public_inputs);
+    println!(
+        "\n[flamegraph] 2^20 goldilocks-BF prove={prove_t:.3?} narg={} hints={}",
+        proof.narg_string.len(),
+        proof.hints.len()
+    );
+
+    // Flush folded stacks.
+    drop(guard);
+
+    // Render SVG via inferno.
+    let folded = std::fs::read_to_string(&folded_path).expect("read folded");
+    {
+        let svg = std::fs::File::create(&svg_path).expect("create svg");
+        let mut opts = inferno::flamegraph::Options::default();
+        opts.title = "provekit 2^20 goldilocks-BF prove".to_string();
+        inferno::flamegraph::from_reader(&mut opts, folded.as_bytes(), svg)
+            .expect("render flamegraph");
+    }
+
+    println!("[flamegraph] folded: {}", folded_path.display());
+    println!("[flamegraph] svg:    {}", svg_path.display());
+
+    analyze_folded(&folded);
+}
+
+/// Parse tracing-flame folded stacks and print (1) per-leaf self-time table and
+/// (2) the top folded stacks by total weight.
+fn analyze_folded(folded: &str) {
+    // Each line: `frame1;frame2;...;leaf weight`. In folded format the weight is
+    // the self-time of that exact stack, so summing by leaf gives per-span self
+    // time, and aggregating identical stacks gives total stack time.
+    let mut leaf_self: HashMap<&str, u64> = HashMap::new();
+    let mut stack_total: HashMap<&str, u64> = HashMap::new();
+    let mut total: u64 = 0;
+
+    for line in folded.lines() {
+        let Some((stack, weight_str)) = line.rsplit_once(' ') else {
+            continue;
+        };
+        let Ok(weight) = weight_str.trim().parse::<u64>() else {
+            continue;
+        };
+        total += weight;
+        *stack_total.entry(stack).or_default() += weight;
+        let leaf = stack.rsplit(';').next().unwrap_or(stack);
+        *leaf_self.entry(leaf).or_default() += weight;
+    }
+
+    if total == 0 {
+        println!("[flamegraph] no folded samples captured");
+        return;
+    }
+    let pct = |w: u64| 100.0 * (w as f64) / (total as f64);
+
+    let mut leaves: Vec<(&str, u64)> = leaf_self.into_iter().collect();
+    leaves.sort_by_key(|leaf| std::cmp::Reverse(leaf.1));
+    println!("\n=== 2^20 goldilocks-BF: per-span SELF time (top 25) ===");
+    println!("   self% |       weight | span");
+    for (leaf, w) in leaves.iter().take(25) {
+        println!("  {:>5.1}% | {:>12} | {}", pct(*w), w, leaf);
+    }
+
+    let mut stacks: Vec<(&str, u64)> = stack_total.into_iter().collect();
+    stacks.sort_by_key(|stack| std::cmp::Reverse(stack.1));
+    println!("\n=== 2^20 goldilocks-BF: top 20 folded stacks by total time ===");
+    for (stack, w) in stacks.iter().take(20) {
+        println!("  {:>5.1}% | {:>12} | {}", pct(*w), w, stack);
+    }
+    println!("\n[flamegraph] total folded weight = {total}");
+}

--- a/tooling/provekit-fixtures/tests/profile.rs
+++ b/tooling/provekit-fixtures/tests/profile.rs
@@ -44,7 +44,8 @@ struct ProveInputs<P: FieldHash> {
     num_constraints: usize,
 }
 
-/// Build the scheme + ownership copies (excluded from the timer and flamegraph).
+/// Build the scheme + ownership copies (excluded from the timer and
+/// flamegraph).
 fn prove_setup<P>(r1cs: &R1CS<Base<P>>, witness: &[Base<P>]) -> ProveInputs<P>
 where
     P: FieldHash,


### PR DESCRIPTION
## Summary

Runs the **first Spartan sumcheck round over the base field**. After the witness became base-committed (#470), the opening round still lifted the `a, b, c` mles into the extension *before* folding. This computes round 0's cubic evaluations directly on the base-field mles (one mixed base×ext multiply per point against the extension `eq`), then lifts into the extension only at the round-0 challenge. It also extracts the per-round message construction into a shared `combined_round_message` helper and adds the base-field sumcheck primitives it needs. A pair of `#[ignore]`d profiling probes are included so the win is reproducible in-tree.

Stacks on **#470** (base-field witness commitment). Independent of the CI guard (#469).

## Why

On the Goldilocks base-field path the witness mles are 64-bit `Field64`, but the sumcheck `eq` and challenges live in the degree-3 extension `Field64_3`. Lifting `a, b, c` to the extension before the first fold pays extension-width multiplies for data that is still base-valued. Doing round 0 in the base field removes one round's worth of extension multiplies — ~5% prove-time at 2^20 on the goldilocks base-field path. bn254 rides the identity embedding, so its path is a no-op (base == ext) and its proofs are unchanged.

## What changed

- **`provekit-common`** — `common/src/utils/sumcheck.rs` gains `mixed_sumcheck_map_reduce` and `mixed_fold`: reduce/fold the leading variable of base-field mles against an extension-field `eq`/challenge. Because the base→ext embedding `map` is a ring homomorphism, fold-then-lift is bit-identical to the old lift-then-fold — pinned by `test_mixed_map_reduce_matches_lifted` and `test_explicit_mixed_fold_matches_fused_fold`.
- **`provekit-prover`** — `prover/src/whir_r1cs.rs`: round 0 is hoisted out of the sumcheck loop and computed on the base-field mles (the loop now runs `1..m_0`); the per-round coefficient combination (`hhat + rho·g_poly`, saved-value equality) is extracted verbatim into `combined_round_message` and shared by round 0 and the loop.
- **`provekit-backend-bn254`** — `mavros_prove.rs` passes the embedding (`&Identity::new()`) and the base-field mles into the prover; identity embedding ⇒ no-op, transcript unchanged.
- **Profiling (`#[ignore]d`)** — `tooling/provekit-fixtures/tests/profile.rs`: a size sweep (BF vs EF vs bn254, 2^14..2^20) and a 2^20 goldilocks-BF flamegraph + stage breakdown. Timing excludes scheme construction and harness clones. Dev-deps `inferno` / `tracing-flame` are scoped to `provekit-fixtures` only.

## Transcript / soundness

The prover round messages, challenge draw order, and the separate ext blinding commitment are unchanged from #470 — the verifier is untouched and replays the identical Fiat-Shamir transcript. Round 0's base-field evaluations equal the old extension-lifted ones because `map` is a ring homomorphism (`map(a·b − c) = map(a)·map(b) − map(c)`, `map(0) = 0` for zero-padding). Both bn254 and goldilocks fixtures still prove→verify.

## Out of scope (tracked separately)

Same as #470: this does not touch the Go `recursive-verifier/` or the `provekit-gnark` bridge. The reported ~5% is from the local flamegraph probe, not a CI-enforced benchmark.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features`, `cargo build --all-targets --all-features` — all green, no new warnings.
- `cargo build --locked -p provekit-fixtures` — merged `Cargo.lock` self-consistent with the new `inferno`/`tracing-flame` pins.
- `provekit-common` 87 (incl. the base/ext parity tests), `provekit-r1cs-compiler` 41.
- Fixtures over **both** fields: bn254 7 roundtrip + 6 soundness, goldilocks 7 + 6 — all pass. Profiling probes are `#[ignore]d`.

## Commits

5 commits: profiling probes (ignored) · doc-comment rewrap · base-field sumcheck round helpers (`common`) · first sumcheck round in the base field (`prover` + bn254 call-site) · review follow-ups (hoist `1/2` inverse out of the per-round loop, move the profiling dev-deps to `[workspace.dependencies]`, dedup the single-commit timed prove into the fixtures harness).
