### PR TITLE
chore(ci): add Kani workflow

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,0 +1,20 @@
+name: Kani model checking
+
+on:
+  push:
+    paths:
+      - "cm31/**"
+  pull_request:
+    paths:
+      - "cm31/**"
+
+jobs:
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Kani
+        uses: model-checking/kani-github-action@v1
+        with:
+          # Whitelist directories that use Kani this prevents the entire project from being built.
+          working-directory: "cm31"


### PR DESCRIPTION
Adds the Kani GitHub Actions workflow based on the final workflow from closed PR #244. It runs on changes under cm31/ and uses actions/checkout@v4 plus model-checking/kani-github-action@v1.

Prompted by: dcbuilder.eth