### PR TITLE
Build whitepaper PDF with GitHub Actions

### DIFF
--- a/.github/workflows/whitepaper.yml
+++ b/.github/workflows/whitepaper.yml
@@ -1,0 +1,41 @@
+name: Build whitepaper
+
+on:
+  push:
+    branches:
+      - feature/whitepaper
+    paths:
+      - "whitepaper/**"
+      - ".github/workflows/whitepaper.yml"
+  pull_request:
+    branches:
+      - feature/whitepaper
+    paths:
+      - "whitepaper/**"
+      - ".github/workflows/whitepaper.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Compile whitepaper
+        uses: xu-cheng/latex-action@v4
+        with:
+          root_file: main.tex
+          working_directory: whitepaper
+
+      - name: Upload PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: provekit-whitepaper
+          path: whitepaper/main.pdf
+          if-no-files-found: error

--- a/whitepaper/Correlated agreement.tex
+++ b/whitepaper/Correlated agreement.tex
@@ -33,5 +33,5 @@ is of size
 then there exist polynomials $q_0(X)$, $q_1(X)\in\mathscr P_k$ with $d((q_0,q_1),(f_0,f_1))\leq \theta$, and $\Gamma(q_0,0)= \Gamma(q_1,1) = 0$. 
 \end{thm}
 
-The theorem is direct consequence of line decodability \cite{}, also called collinearity of proximates property in \cite{Basefold:LDR}.
-Given a of proximates of the random linear combinations, one for each, then a notable fraction of it lies on a line. 
+The theorem is direct consequence of line decodability, also called collinearity of proximates property in \cite{Basefold:LDR}.
+Given a of proximates of the random linear combinations, one for each, then a notable fraction of it lies on a line.

--- a/whitepaper/SNARKs.bib
+++ b/whitepaper/SNARKs.bib
@@ -951,7 +951,7 @@ Code-Based {SNARKs}},
       title = {Greyhound: Fast Polynomial Commitments from Lattices},
       howpublished = {IACR preprint archive 2024/1293},
       year = {2024},
-      note = {\url{https://eprint.iacr.org/2024/1293}
+      note = {\url{https://eprint.iacr.org/2024/1293}}
 }
 
 %%
@@ -1854,6 +1854,5 @@ Code-Based {SNARKs}},
 	year = {2023},
 	note = {\url{https://people.cs.georgetown.edu/jthaler/ProofsArgsAndZK.html}}
 }
-
 
 

--- a/whitepaper/main.tex
+++ b/whitepaper/main.tex
@@ -324,7 +324,7 @@ There is a split-witness builder for stepwise computation of the complete witnes
 
 Although the entire construction described in the writeup applies to arbitrary prime fields, we confine ourselve to the the following choices.
 %
-Let $\mathbb F_q$ be the Goldilocks prime field \cite{}, with the Solinas prime
+Let $\mathbb F_q$ be the Goldilocks prime field, with the Solinas prime
 \[
 q = 2^{64} - 2^{32} + 1
 \]

--- a/whitepaper/main.tex
+++ b/whitepaper/main.tex
@@ -993,7 +993,7 @@ After the last round of the sumcheck, the prover sends
 v_A = w_A(\vec\alpha),  \quad v_B = w_B(\vec\alpha), \quad v_C = w_C(\vec\alpha),
 \end{equation*}
 where $\vec\alpha \in F^m$ are the verifier challenges drawn in the course of the sumcheck, and the verifier checks if 
-$q_m(\alpha_m) = (v_A\cdot v_B - v_C) \cdot eq(\alpha,\rho).
+$q_m(\alpha_m) = (v_A\cdot v_B - v_C) \cdot eq(\alpha,\rho)$.
 %These claims are announced by the prover in the last round. 
 
 \item 


### PR DESCRIPTION
Adds a GitHub Actions workflow that compiles whitepaper/main.tex with BibTeX support and uploads the generated PDF as an artifact.

The workflow runs for pushes to feature/whitepaper, pull requests targeting feature/whitepaper, and manual dispatches.

Prompted by: ulrich.haboeck